### PR TITLE
refactor: Infer prop info from TS -> JSON schema as a fallback in editor

### DIFF
--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -302,10 +302,10 @@ watch(
 		if (!componentRef.value) return
 		// set data-component-id on update since some frappeui components have inheritAttrs: false
 		target.value = getComponentRoot(componentRef)
-		if (target.value) {
+		if (target.value && target.value instanceof Element) {
 			target.value?.setAttribute("data-component-id", props.block.componentId)
-			isComponentReady.value = true
 		}
+		isComponentReady.value = true
 	},
 	{ immediate: true },
 )

--- a/frontend/src/json_types/frappeui/Alert.json
+++ b/frontend/src/json_types/frappeui/Alert.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/AlertProps",
+  "definitions": {
+    "AlertProps": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "const": "warning"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Avatar.json
+++ b/frontend/src/json_types/frappeui/Avatar.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/AvatarProps",
+  "definitions": {
+    "AvatarProps": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl",
+            "3xl"
+          ]
+        },
+        "shape": {
+          "type": "string",
+          "enum": [
+            "circle",
+            "square"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Badge.json
+++ b/frontend/src/json_types/frappeui/Badge.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BadgeProps",
+  "definitions": {
+    "BadgeProps": {
+      "type": "object",
+      "properties": {
+        "theme": {
+          "type": "string",
+          "enum": [
+            "gray",
+            "blue",
+            "green",
+            "orange",
+            "red"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg"
+          ]
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "subtle",
+            "outline",
+            "ghost"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "number"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Breadcrumbs.json
+++ b/frontend/src/json_types/frappeui/Breadcrumbs.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BreadcrumbsProps",
+  "definitions": {
+    "BreadcrumbsProps": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "route": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ],
+                "description": "Route Location the link should navigate to when clicked on."
+              },
+              "onClick": {
+                "$comment": "() => void"
+              }
+            },
+            "required": [
+              "label"
+            ]
+          }
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Button.json
+++ b/frontend/src/json_types/frappeui/Button.json
@@ -37,34 +37,13 @@
           "type": "string"
         },
         "icon": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ]
+          "type": "string"
         },
         "iconLeft": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ]
+          "type": "string"
         },
         "iconRight": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ]
+          "type": "string"
         },
         "loading": {
           "type": "boolean"

--- a/frontend/src/json_types/frappeui/Checkbox.json
+++ b/frontend/src/json_types/frappeui/Checkbox.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/CheckboxProps",
+  "definitions": {
+    "CheckboxProps": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "checked": {
+          "type": "boolean"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "padding": {
+          "type": "boolean"
+        },
+        "modelValue": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number",
+              "const": 1
+            },
+            {
+              "type": "number",
+              "const": 0
+            }
+          ]
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/CircularProgressBar.json
+++ b/frontend/src/json_types/frappeui/CircularProgressBar.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline"
+      ]
+    },
+    "Theme": {
+      "type": "string",
+      "enum": [
+        "black",
+        "red",
+        "green",
+        "blue",
+        "orange"
+      ]
+    },
+    "ThemeProps": {
+      "type": "object",
+      "properties": {
+        "primary": {
+          "type": "string"
+        },
+        "secondary": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary",
+        "secondary"
+      ],
+      "additionalProperties": false
+    },
+    "Size": {
+      "type": "string",
+      "enum": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ]
+    },
+    "SizeProps": {
+      "type": "object",
+      "properties": {
+        "ringSize": {
+          "type": "string"
+        },
+        "ringBarWidth": {
+          "type": "string"
+        },
+        "innerTextFontSize": {
+          "type": "string"
+        },
+        "checkIconSize": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "ringSize",
+        "ringBarWidth",
+        "innerTextFontSize",
+        "checkIconSize"
+      ],
+      "additionalProperties": false
+    },
+    "CircularProgressBarProps": {
+      "type": "object",
+      "properties": {
+        "step": {
+          "type": "number"
+        },
+        "totalSteps": {
+          "type": "number"
+        },
+        "showPercentage": {
+          "type": "boolean"
+        },
+        "variant": {
+          "$ref": "#/definitions/Variant"
+        },
+        "theme": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Theme"
+            },
+            {
+              "$ref": "#/definitions/ThemeProps"
+            }
+          ]
+        },
+        "size": {
+          "$ref": "#/definitions/Size"
+        },
+        "themeComplete": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "step",
+        "totalSteps"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Dialog.json
+++ b/frontend/src/json_types/frappeui/Dialog.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DialogIcon": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "appearance": {
+          "type": "string",
+          "enum": [
+            "warning",
+            "info",
+            "danger",
+            "success"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "DialogOptions": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl",
+            "3xl",
+            "4xl",
+            "5xl",
+            "6xl",
+            "7xl"
+          ]
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DialogIcon"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DialogAction"
+          }
+        },
+        "position": {
+          "type": "string",
+          "enum": [
+            "top",
+            "center"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DialogAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "onClick": {
+          "$comment": "(context: DialogActionContext) => void | Promise<void>",
+          "type": "object",
+          "properties": {
+            "namedArgs": {
+              "type": "object",
+              "properties": {
+                "context": {
+                  "$ref": "#/definitions/DialogActionContext"
+                }
+              },
+              "required": [
+                "context"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "theme": {
+          "type": "string",
+          "enum": [
+            "gray",
+            "blue",
+            "green",
+            "red"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl"
+          ]
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "subtle",
+            "outline",
+            "ghost"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "icon": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconLeft": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconRight": {
+          "type": [
+            "string"
+          ]
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "loadingText": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "route": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
+    "ButtonProps": {
+      "type": "object",
+      "properties": {
+        "theme": {
+          "type": "string",
+          "enum": [
+            "gray",
+            "blue",
+            "green",
+            "red"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl"
+          ]
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "subtle",
+            "outline",
+            "ghost"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "icon": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconLeft": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconRight": {
+          "type": [
+            "string"
+          ]
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "loadingText": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "route": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "link": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DialogActionContext": {
+      "type": "object",
+      "properties": {
+        "close": {
+          "$comment": "() => void"
+        }
+      },
+      "required": [
+        "close"
+      ],
+      "additionalProperties": false
+    },
+    "DialogProps": {
+      "type": "object",
+      "properties": {
+        "modelValue": {
+          "type": "boolean"
+        },
+        "options": {
+          "$ref": "#/definitions/DialogOptions"
+        },
+        "disableOutsideClickToClose": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "modelValue"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Divider.json
+++ b/frontend/src/json_types/frappeui/Divider.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DividerAction": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "handler": {
+          "$comment": "() => any"
+        },
+        "loading": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "label",
+        "handler"
+      ],
+      "additionalProperties": false
+    },
+    "DividerProps": {
+      "type": "object",
+      "properties": {
+        "orientation": {
+          "type": "string",
+          "enum": [
+            "horizontal",
+            "vertical"
+          ]
+        },
+        "position": {
+          "type": "string",
+          "enum": [
+            "start",
+            "center",
+            "end"
+          ]
+        },
+        "flexItem": {
+          "type": "boolean"
+        },
+        "action": {
+          "$ref": "#/definitions/DividerAction"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Dropdown.json
+++ b/frontend/src/json_types/frappeui/Dropdown.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DropdownOption": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "component": {},
+        "onClick": {
+          "$comment": "() => void"
+        },
+        "route": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "Route Location the link should navigate to when clicked on."
+        },
+        "condition": {
+          "$comment": "() => boolean"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "additionalProperties": false
+    },
+    "DropdownGroupOption": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "number"
+        },
+        "group": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DropdownOption"
+          }
+        },
+        "hideLabel": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "group",
+        "items"
+      ],
+      "additionalProperties": false
+    },
+    "DropdownOptions": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/DropdownOption"
+          },
+          {
+            "$ref": "#/definitions/DropdownGroupOption"
+          }
+        ]
+      }
+    },
+    "DropdownProps": {
+      "type": "object",
+      "properties": {
+        "button": {
+          "$ref": "#/definitions/ButtonProps"
+        },
+        "options": {
+          "$ref": "#/definitions/DropdownOptions"
+        },
+        "placement": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ButtonProps": {
+      "type": "object",
+      "properties": {
+        "theme": {
+          "type": "string",
+          "enum": [
+            "gray",
+            "blue",
+            "green",
+            "red"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl"
+          ]
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "solid",
+            "subtle",
+            "outline",
+            "ghost"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "icon": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconLeft": {
+          "type": [
+            "string"
+          ]
+        },
+        "iconRight": {
+          "type": [
+            "string"
+          ]
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "loadingText": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "route": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "link": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Progress.json
+++ b/frontend/src/json_types/frappeui/Progress.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ProgressProps",
+  "definitions": {
+    "ProgressProps": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "hint": {
+          "type": "boolean"
+        },
+        "intervals": {
+          "type": "boolean"
+        },
+        "intervalCount": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Rating.json
+++ b/frontend/src/json_types/frappeui/Rating.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/RatingProps",
+  "definitions": {
+    "RatingProps": {
+      "type": "object",
+      "properties": {
+        "modelValue": {
+          "type": "number"
+        },
+        "rating_from": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Select.json
+++ b/frontend/src/json_types/frappeui/Select.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SelectOption": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "disabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "label",
+            "value"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SelectProps": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md",
+            "lg"
+          ]
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "subtle",
+            "outline",
+            "ghost"
+          ]
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "modelValue": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SelectOption"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Switch.json
+++ b/frontend/src/json_types/frappeui/Switch.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SwitchProps",
+  "definitions": {
+    "SwitchProps": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "enum": [
+            "sm",
+            "md"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "modelValue": {
+          "type": [
+            "boolean",
+            "number",
+            "string"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/TextInput.json
+++ b/frontend/src/json_types/frappeui/TextInput.json
@@ -1,28 +1,30 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/TextInputProps",
   "definitions": {
+    "TextInputTypes": {
+      "type": "string",
+      "enum": [
+        "date",
+        "datetime-local",
+        "email",
+        "file",
+        "month",
+        "number",
+        "password",
+        "search",
+        "tel",
+        "text",
+        "time",
+        "url",
+        "week",
+        "range"
+      ]
+    },
     "TextInputProps": {
       "type": "object",
       "properties": {
         "type": {
-          "type": "string",
-          "enum": [
-            "date",
-            "datetime-local",
-            "email",
-            "file",
-            "month",
-            "number",
-            "password",
-            "search",
-            "tel",
-            "text",
-            "time",
-            "url",
-            "week",
-            "range"
-          ]
+          "$ref": "#/definitions/TextInputTypes"
         },
         "size": {
           "type": "string",

--- a/frontend/src/json_types/frappeui/Textarea.json
+++ b/frontend/src/json_types/frappeui/Textarea.json
@@ -1,29 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/TextInputProps",
+  "$ref": "#/definitions/TextareaProps",
   "definitions": {
-    "TextInputProps": {
+    "TextareaProps": {
       "type": "object",
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "date",
-            "datetime-local",
-            "email",
-            "file",
-            "month",
-            "number",
-            "password",
-            "search",
-            "tel",
-            "text",
-            "time",
-            "url",
-            "week",
-            "range"
-          ]
-        },
         "size": {
           "type": "string",
           "enum": [
@@ -50,16 +31,16 @@
           "type": "string"
         },
         "modelValue": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": "string"
         },
         "debounce": {
           "type": "number"
         },
-        "required": {
-          "type": "boolean"
+        "rows": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/frontend/src/json_types/frappeui/Tooltip.json
+++ b/frontend/src/json_types/frappeui/Tooltip.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/TooltipProps",
+  "definitions": {
+    "TooltipProps": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "hoverDelay": {
+          "type": "number"
+        },
+        "placement": {
+          "$ref": "#/definitions/Side",
+          "description": "The preferred side of the trigger to render against when open. Will be reversed when collisions occur and avoidCollisions is enabled."
+        },
+        "arrowClass": {},
+        "disabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Side": {
+      "type": "string",
+      "enum": [
+        "top",
+        "right",
+        "bottom",
+        "left"
+      ]
+    }
+  }
+}

--- a/frontend/src/json_types/frappeui/Tree.json
+++ b/frontend/src/json_types/frappeui/Tree.json
@@ -49,6 +49,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "TreeProps": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/TreeNode"
+        },
+        "nodeKey": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/TreeOptions"
+        }
+      },
+      "required": [
+        "node",
+        "nodeKey"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/frontend/src/json_types/index.ts
+++ b/frontend/src/json_types/index.ts
@@ -1,4 +1,5 @@
 // frappeui components
+export { default as Alert } from "./frappeui/Alert.json"
 export { default as Button } from "./frappeui/Button.json"
 export { default as DatePicker } from "./frappeui/DatePicker.json"
 export { default as FormControl } from "./frappeui/FormControl.json"

--- a/frontend/src/json_types/index.ts
+++ b/frontend/src/json_types/index.ts
@@ -17,6 +17,7 @@ export { default as Select } from "./frappeui/Select.json"
 export { default as Switch } from "./frappeui/Switch.json"
 export { default as TextInput } from "./frappeui/TextInput.json"
 export { default as Textarea } from "./frappeui/Textarea.json"
+export { default as Tooltip } from "./frappeui/Tooltip.json"
 export { default as Tree } from "./frappeui/Tree.json"
 // end of frappeui components
 

--- a/frontend/src/json_types/index.ts
+++ b/frontend/src/json_types/index.ts
@@ -1,9 +1,22 @@
 // frappeui components
 export { default as Alert } from "./frappeui/Alert.json"
+export { default as Avatar } from "./frappeui/Avatar.json"
+export { default as Badge } from "./frappeui/Badge.json"
+export { default as Breadcrumbs } from "./frappeui/Breadcrumbs.json"
 export { default as Button } from "./frappeui/Button.json"
+export { default as Checkbox } from "./frappeui/Checkbox.json"
+export { default as CircularProgressBar } from "./frappeui/CircularProgressBar.json"
 export { default as DatePicker } from "./frappeui/DatePicker.json"
+export { default as Dialog } from "./frappeui/Dialog.json"
+export { default as Divider } from "./frappeui/Divider.json"
+export { default as Dropdown } from "./frappeui/Dropdown.json"
 export { default as FormControl } from "./frappeui/FormControl.json"
+export { default as Progress } from "./frappeui/Progress.json"
+export { default as Rating } from "./frappeui/Rating.json"
+export { default as Select } from "./frappeui/Select.json"
+export { default as Switch } from "./frappeui/Switch.json"
 export { default as TextInput } from "./frappeui/TextInput.json"
+export { default as Textarea } from "./frappeui/Textarea.json"
 export { default as Tree } from "./frappeui/Tree.json"
 // end of frappeui components
 

--- a/frontend/src/json_types/studio/Sidebar.json
+++ b/frontend/src/json_types/studio/Sidebar.json
@@ -10,9 +10,6 @@
         "route_to": {
           "type": "string"
         },
-        "selected": {
-          "type": "boolean"
-        },
         "featherIcon": {
           "type": "string"
         }

--- a/frontend/src/utils/components.ts
+++ b/frontend/src/utils/components.ts
@@ -2,7 +2,14 @@ import components from "@/data/components"
 import { ComponentProp, ComponentProps } from "@/types"
 import { VueProp, VuePropType } from "@/types/vue"
 
-import * as componentTypes from "@/json_types"
+import * as jsonTypes from "@/json_types"
+
+interface ComponentTypes {
+	[componentName: string]: {
+		definitions: Record<string, any>
+	}
+}
+const componentTypes = jsonTypes as ComponentTypes
 
 function getComponentProps(componentName: string) {
 	const props = components.getProps(componentName)
@@ -32,7 +39,7 @@ function getComponentProps(componentName: string) {
 
 				if ("anyOf" in propertySchema) {
 					// prop has multiple types
-					const propTypes = propertySchema?.anyOf.map((prop) => prop?.type)
+					const propTypes = propertySchema?.anyOf.map((prop: Record<string, any>) => prop?.type)
 					propType = getSinglePropType(propTypes)
 				} else {
 					propType = propertySchema?.type

--- a/frontend/src/utils/components.ts
+++ b/frontend/src/utils/components.ts
@@ -34,6 +34,10 @@ function getComponentProps(componentName: string) {
 					propType = getSinglePropType(propTypes)
 				} else {
 					propType = properties?.[propName]?.type
+					if (!propType && properties?.[propName]?.$ref) {
+						// no explicit type defined, but a reference to another type
+						propType = "object"
+					}
 				}
 			}
 			const config: ComponentProp = {

--- a/frontend/src/utils/components.ts
+++ b/frontend/src/utils/components.ts
@@ -40,6 +40,11 @@ function getComponentProps(componentName: string) {
 					}
 				}
 			}
+
+			if (typeof propType === "string") {
+				propType = propType?.toLowerCase()
+			}
+
 			const config: ComponentProp = {
 				type: propType,
 				default: prop.default,
@@ -47,7 +52,7 @@ function getComponentProps(componentName: string) {
 				required: isRequired,
 			}
 
-			if (propType === "String") {
+			if (propType === "string") {
 				const enums = getPropEnums(properties, propName)
 				if (enums) {
 					// prop has predefined options
@@ -59,6 +64,7 @@ function getComponentProps(componentName: string) {
 			propsConfig[propName] = config
 		})
 	}
+
 	return propsConfig
 }
 
@@ -71,9 +77,6 @@ function getPropType(propType: VuePropType | VuePropType[]) {
 }
 
 function getPropInputType(propType: string) {
-	if (typeof propType === "string") {
-		propType = propType?.toLowerCase()
-	}
 	switch (propType) {
 		case "string":
 			return "text"

--- a/frontend/src/utils/components.ts
+++ b/frontend/src/utils/components.ts
@@ -19,21 +19,25 @@ function getComponentProps(componentName: string) {
 		})
 		return propsConfig
 	} else {
-		const propTypes = getComponentPropsFromTypescript(componentName)
+		const componentSchema = getComponentSchema(componentName)
+		const { required, properties } = componentSchema || {}
+
 		Object.entries(props as Record<string, VueProp>).forEach(([propName, prop]) => {
 			let propType = getPropType(prop.type)
+			let isRequired = prop.required
 			if (!propType) {
-				propType = propTypes?.[propName]?.type
+				propType = properties?.[propName]?.type
+				isRequired = required?.includes(propName)
 			}
 			const config: ComponentProp = {
 				type: propType,
 				default: prop.default,
 				inputType: getPropInputType(propType),
-				required: prop.required,
+				required: isRequired,
 			}
 
 			if (propType === "String") {
-				const enums = getPropEnums(propTypes, propName)
+				const enums = getPropEnums(properties, propName)
 				if (enums) {
 					// prop has predefined options
 					config.inputType = "select"
@@ -77,15 +81,15 @@ function getPropInputType(propType: string) {
 	}
 }
 
-function getPropEnums(propTypes: object, propName: string): string[] | undefined {
+function getPropEnums(properties: object, propName: string): string[] | undefined {
 	// fetches prop enums like Button.json > definitions > ButtonProps > properties > variant > enum - ["solid", "subtle", "outline", "ghost"]
-	return propTypes?.[propName]?.enum
+	return properties?.[propName]?.enum
 }
 
-function getComponentPropsFromTypescript(componentName: string) {
+function getComponentSchema(componentName: string) {
 	// fetches component properties object from JSON types (converted from TS)
 	// e.g.: Button.json > definitions > ButtonProps > properties
-	return componentTypes?.[componentName]?.definitions?.[`${componentName}Props`]?.properties
+	return componentTypes?.[componentName]?.definitions?.[`${componentName}Props`]
 }
 
 // events

--- a/frontend/src/utils/tsToJSON/customParser.ts
+++ b/frontend/src/utils/tsToJSON/customParser.ts
@@ -36,8 +36,8 @@ export class VueComponentParser implements SubNodeParser {
 	}
 
 	createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType {
-		// treat Component and ComponentPublicInstance as a plain object
-		return new ObjectType("VueComponent", [], [], true)
+		// treat Component and ComponentPublicInstance as String
+		return new StringType()
 	}
 }
 
@@ -56,9 +56,6 @@ export class RouteLocationParser implements SubNodeParser {
 
 	createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType {
 		// treat RouteLocation, RouteLocationNormalized and RouteLocationRaw as a string or an object
-		return new UnionType([
-			new StringType(),
-			new ObjectType("RouteLocation", [], [], true)
-		])
+		return new UnionType([new StringType(), new ObjectType("RouteLocation", [], [], true)])
 	}
 }


### PR DESCRIPTION
## Problem

If Vue components do not use a "runtime declaration" for props and only rely on typescript, the vue compiler doesn't retain an exact runtime props object in production in case of type-based props, as opposed to what's mentioned in the docs

<img width="630" alt="image" src="https://github.com/user-attachments/assets/26b06e19-6ecc-49f4-8df8-f6b30aaeb105" />

**Dev**:

<img width="1440" alt="props-dev" src="https://github.com/user-attachments/assets/5b6460a5-851a-4fe8-90d8-18b85a979b14" />

**Prod**:

Only defaults are retained, everything else is wiped out  

<img width="1440" alt="props-prod" src="https://github.com/user-attachments/assets/c8ed085f-c01e-419e-aebe-043d902d7c39" />

## Solution

Currently the JSON schema generated from component typescript definitions is only being used to populate select field options (enums) like theme for Buttons - subtle/solid, etc

Make use of this schema for all prop type inference if runtime prop definition is not found:

- [x] Fallback to TS JSON schema for inferring prop types for prop inputs in studio editor
- [x] Handle union types
- [x] Infer "required" props from JSON schema
- [x] Handle prop types which reference another type. Eg: Tree's node prop is of type `TreeNode` which should to be considered as 'object', simply
- [x] Handle inferring types and enums from another type: Tooltip's placement prop is derived from Side type of radix ui, Tree's node is derived from TreeNode type, TextInputProps type prop is derived from type TextInputTypes
- [x] Generate missing schema for other components

## After

![image](https://github.com/user-attachments/assets/373fdc7b-bede-4acf-bf43-ca3d1581893c)

Closes https://github.com/frappe/studio/issues/38
