### PR TITLE
feat: Session in editor + basic app search

### DIFF
--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -1,9 +1,19 @@
 <template>
 	<div class="toolbar flex h-14 items-center justify-center bg-white p-2 shadow-sm">
 		<div class="absolute left-3 flex items-center justify-center gap-5">
-			<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
-				<StudioLogo class="h-7 w-7"></StudioLogo>
-			</router-link>
+			<Dropdown
+				:options="[
+					{ label: 'Back to Dashboard', icon: 'arrow-left', onClick: () => $router.push({ name: 'Home' }) },
+					{ label: 'Logout', icon: 'log-out', onClick: () => session.logout() },
+				]"
+			>
+				<template v-slot="{ open }">
+					<div class="flex cursor-pointer items-center gap-1">
+						<StudioLogo class="h-7 w-7"></StudioLogo>
+						<FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="h-4 w-4 text-gray-700" />
+					</div>
+				</template>
+			</Dropdown>
 
 			<div class="flex gap-2">
 				<Tooltip
@@ -94,6 +104,7 @@ import PageOptions from "@/components/PageOptions.vue"
 import StudioLogo from "@/components/Icons/StudioLogo.vue"
 
 import type { StudioMode } from "@/types"
+import session from "@/utils/session"
 
 const store = useStudioStore()
 const canvasStore = useCanvasStore()

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,23 +1,41 @@
 <template>
 	<div class="h-screen flex-col overflow-hidden bg-white">
-		<div class="toolbar sticky top-0 z-10 flex h-14 items-center justify-center bg-white p-2 shadow-sm">
-			<div class="absolute left-3 flex items-center justify-center gap-2">
-				<StudioLogo class="h-7 w-7"></StudioLogo>
-				<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
-					<h1 class="text-md mt-[2px] font-semibold leading-5 text-gray-800">Studio</h1>
-				</router-link>
-			</div>
+		<div class="toolbar sticky top-0 z-10 flex h-14 items-center justify-between bg-white p-2 shadow-sm">
+			<Dropdown :options="[{ label: 'Logout', icon: 'log-out', onClick: () => session.logout() }]">
+				<template v-slot="{ open }">
+					<div class="flex cursor-pointer items-center gap-2">
+						<StudioLogo class="h-7 w-7"></StudioLogo>
+						<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
+							<h1 class="text-md mt-[2px] font-semibold leading-5 text-gray-800">Studio</h1>
+						</router-link>
+						<FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="h-4 w-4 text-gray-700" />
+					</div>
+				</template>
+			</Dropdown>
+
+			<Button variant="solid" icon-left="plus" @click="showDialog = true">New App</Button>
 		</div>
 
 		<div class="flex h-full flex-col items-center px-20 py-10">
 			<div class="flex w-full flex-row justify-between">
 				<div class="text-lg font-semibold text-gray-800">All Apps</div>
-				<Button variant="solid" icon-left="plus" @click="showDialog = true">New App</Button>
+				<TextInput
+					class="w-48"
+					placeholder="Search"
+					type="text"
+					variant="outline"
+					autofocus
+					@input="(e: Event) => (searchFilter = (e.target as HTMLInputElement).value)"
+				>
+					<template #prefix>
+						<FeatherIcon name="search" class="h-4 w-4 text-gray-500" />
+					</template>
+				</TextInput>
 			</div>
 			<div class="mt-5 grid w-full grid-cols-5 items-start gap-5">
 				<router-link
 					class="flex flex-col justify-center gap-1 rounded-lg border-2 p-5"
-					v-for="app in studioApps.data"
+					v-for="app in appList"
 					:to="{ name: 'StudioApp', params: { appID: app.name } }"
 					:key="app.name"
 				>
@@ -60,6 +78,8 @@ import { studioApps } from "@/data/studioApps"
 import { UseTimeAgo } from "@vueuse/components"
 import StudioLogo from "@/components/Icons/StudioLogo.vue"
 import { NewStudioApp, StudioApp } from "@/types/Studio/StudioApp"
+import session from "@/utils/session"
+import { watchDebounced } from "@vueuse/core"
 
 const showDialog = ref(false)
 const emptyAppState = {
@@ -68,6 +88,21 @@ const emptyAppState = {
 }
 const newApp = ref({ ...emptyAppState })
 const router = useRouter()
+
+const searchFilter = ref("")
+const appList = ref<StudioApp[]>([])
+
+const fetchApps = () => {
+	appList.value = studioApps.data
+	console.log(searchFilter.value)
+	if (searchFilter.value) {
+		appList.value = studioApps.data?.filter((app: StudioApp) =>
+			app.app_title.toLowerCase().includes(searchFilter.value?.toLowerCase()),
+		)
+	}
+}
+
+watchDebounced(searchFilter, fetchApps, { debounce: 300, immediate: true })
 
 const createStudioApp = (app: NewStudioApp) => {
 	studioApps.insert

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -94,7 +94,6 @@ const appList = ref<StudioApp[]>([])
 
 const fetchApps = () => {
 	appList.value = studioApps.data
-	console.log(searchFilter.value)
 	if (searchFilter.value) {
 		appList.value = studioApps.data?.filter((app: StudioApp) =>
 			app.app_title.toLowerCase().includes(searchFilter.value?.toLowerCase()),

--- a/frontend/src/pages/NotPermitted.vue
+++ b/frontend/src/pages/NotPermitted.vue
@@ -1,0 +1,11 @@
+<template>
+	<div class="flex h-screen w-full items-center justify-center bg-gray-50">
+		<div class="flex flex-col items-center justify-center">
+			<h1 class="mt-1 text-2xl font-semibold text-gray-600">403: Permission Denied</h1>
+			<div class="mt-2 text-base text-gray-500">
+				You don't have permission to access this page. Make sure you have the right roles & permissions.
+			</div>
+			<a href="/app" class="mt-4 text-base text-gray-600 underline"> Back to Home </a>
+		</div>
+	</div>
+</template>

--- a/frontend/src/router/studio_router.ts
+++ b/frontend/src/router/studio_router.ts
@@ -1,4 +1,6 @@
-import { createRouter, createWebHistory } from "vue-router"
+import { ref } from "vue"
+import { createRouter, createWebHistory, NavigationGuardNext } from "vue-router"
+import { createResource } from "frappe-ui"
 
 const routes = [
 	{
@@ -26,5 +28,52 @@ let router = createRouter({
 	history: createWebHistory("/studio"),
 	routes,
 })
+
+let hasPermission: null | boolean = null
+let sessionUser = ref("Guest")
+
+router.beforeEach(async (to, _, next) => {
+	if (isUserLoggedIn()) {
+		sessionUser.value = getSessionUser()
+		if (hasPermission === null) {
+			try {
+				const response = await createResource({
+					url: "frappe.client.has_permission",
+				}).submit({
+					doctype: "Studio Page",
+					docname: null,
+					perm_type: "write",
+				})
+				hasPermission = response.has_permission
+				return validatePermission(next)
+			} catch (e) {
+				hasPermission = false
+				return validatePermission(next)
+			}
+		}
+	}
+	return validatePermission(next)
+})
+
+function validatePermission(next: NavigationGuardNext) {
+	if (hasPermission) {
+		next()
+	} else {
+		alert("You do not have permission to access this page")
+		if (isUserLoggedIn()) {
+			window.location.href = "/app"
+		} else {
+			window.location.href = "/login?redirect-to=/studio"
+		}
+	}
+}
+
+function isUserLoggedIn() {
+	return document.cookie.includes("user_id") && !document.cookie.includes("user_id=Guest")
+}
+
+function getSessionUser() {
+	return decodeURIComponent(document.cookie.split("user_id=")[1].split(";")[0]) || "Guest"
+}
 
 export default router

--- a/frontend/src/router/studio_router.ts
+++ b/frontend/src/router/studio_router.ts
@@ -21,6 +21,11 @@ const routes = [
 		name: "StudioPage",
 		component: () => import("@/pages/StudioPage.vue"),
 	},
+	{
+		path: "/not-permitted",
+		name: "NotPermitted",
+		component: () => import("@/pages/NotPermitted.vue"),
+	}
 ]
 
 let router = createRouter({
@@ -35,6 +40,9 @@ router.beforeEach(async (to, _, next) => {
 	if (!session.isLoggedIn) {
 		window.location.href = "/login?redirect-to=/studio"
 		return next(false)
+	}
+	if (!session.hasPermission && to.path !== "/not-permitted") {
+		return next("/not-permitted")
 	}
 	return next()
 })

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -19,6 +19,7 @@ const session = reactive({
 	user: { ...emptyUser },
 	//@ts-ignore
 	isLoggedIn: computed(() => session.user.email && session.user.email !== "Guest"),
+	hasPermission: false,
 	initialize,
 	logout,
 })
@@ -26,6 +27,7 @@ const session = reactive({
 async function initialize() {
 	if (session.initialized) return
 	Object.assign(session.user, getSessionFromCookie())
+	await fetchPermissions()
 	session.initialized = true
 }
 
@@ -38,6 +40,12 @@ function getSessionFromCookie() {
 			acc[key] = decodeURIComponent(value)
 			return acc
 		}, {} as any)
+}
+
+async function fetchPermissions() {
+	if (!session.isLoggedIn) return
+	const has_permission = await call("studio.api.has_permission")
+	session.hasPermission = Boolean(has_permission)
 }
 
 async function logout() {

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -1,0 +1,53 @@
+import { computed, reactive } from "vue"
+import { call } from "frappe-ui"
+
+type SessionUser = {
+	email: string
+	full_name: string
+	user_image: string
+}
+
+const emptyUser: SessionUser = {
+	email: "",
+	full_name: "",
+	user_image: "",
+}
+
+//@ts-ignore
+const session = reactive({
+	initialized: false,
+	user: { ...emptyUser },
+	//@ts-ignore
+	isLoggedIn: computed(() => session.user.email && session.user.email !== "Guest"),
+	initialize,
+	logout,
+})
+
+async function initialize() {
+	if (session.initialized) return
+	Object.assign(session.user, getSessionFromCookie())
+	session.initialized = true
+}
+
+function getSessionFromCookie() {
+	return document.cookie
+		.split("; ")
+		.map((c) => c.split("="))
+		.reduce((acc, [key, value]) => {
+			key = key === "user_id" ? "email" : key
+			acc[key] = decodeURIComponent(value)
+			return acc
+		}, {} as any)
+}
+
+async function logout() {
+	resetSession()
+	await call("logout")
+	window.location.reload()
+}
+
+function resetSession() {
+	Object.assign(session.user, { ...emptyUser })
+}
+
+export default session

--- a/studio/api.py
+++ b/studio/api.py
@@ -42,3 +42,18 @@ def get_whitelisted_methods(doctype: str) -> list[str]:
 				continue
 
 	return whitelisted_methods
+
+
+@frappe.whitelist()
+def has_permission() -> bool:
+	if frappe.session.user == "Administrator":
+		return True
+
+	if all(
+		[
+			frappe.has_permission("Studio App", ptype="write"),
+			frappe.has_permission("Studio Page", ptype="write"),
+		]
+	):
+		return True
+	return False

--- a/studio/studio/doctype/studio_app/studio_app.json
+++ b/studio/studio/doctype/studio_app/studio_app.json
@@ -58,7 +58,7 @@
    "link_fieldname": "studio_app"
   }
  ],
- "modified": "2025-03-05 16:54:27.699139",
+ "modified": "2025-04-16 18:53:40.047892",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio App",
@@ -76,8 +76,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Studio User",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/studio/studio/doctype/studio_client_script/studio_client_script.json
+++ b/studio/studio/doctype/studio_client_script/studio_client_script.json
@@ -20,7 +20,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-31 14:02:02.257570",
+ "modified": "2025-04-16 18:54:49.138966",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Client Script",
@@ -36,6 +36,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Studio User",
    "share": 1,
    "write": 1
   }

--- a/studio/studio/doctype/studio_page/studio_page.json
+++ b/studio/studio/doctype/studio_page/studio_page.json
@@ -120,7 +120,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-01 09:33:28.358540",
+ "modified": "2025-04-16 18:53:26.580465",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page",
@@ -136,6 +136,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Studio User",
    "share": 1,
    "write": 1
   }

--- a/studio/studio/doctype/studio_resource/studio_resource.json
+++ b/studio/studio/doctype/studio_resource/studio_resource.json
@@ -131,9 +131,10 @@
    "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-18 15:19:24.623558",
+ "modified": "2025-04-16 18:53:58.772413",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Resource",
@@ -151,8 +152,21 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Studio User",
+   "share": 1,
+   "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",


### PR DESCRIPTION
**Added basic session & validations in editor**

![image](https://github.com/user-attachments/assets/c5e93d85-7a48-4fbf-8b55-808cabc9f738)

**Basic App Search**

![image](https://github.com/user-attachments/assets/dc98170f-fd70-4367-bba1-8819e2726ff0)

**Redirect to Not Permitted page if user is logged in but doesn't have permission to access Studio App/Studio Page doctypes**

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/dbac54ec-47ce-4184-b13b-8134b4e0654b" />

Closes: https://github.com/frappe/studio/issues/36
PS: This still doesn't implement sessions for the rendered app. Will add a feature to set up authentication in built app soon. 