### PR TITLE
fix: validate and avoid setting duplicate page routes / titles in an app

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,7 @@
 			</keep-alive>
 		</router-view>
 
-		<Toaster :visible-toasts="2" position="bottom-right" richColors />
+		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
 		<Dialogs></Dialogs>
 	</div>
 </template>

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -141,7 +141,6 @@ async function setPage() {
 	if (route.params.pageID === "new") {
 		await studioPages.insert
 			.submit({
-				page_title: "My Page",
 				draft_blocks: [getRootBlock()],
 				studio_app: route.params.appID as string,
 			})

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -176,10 +176,26 @@ const useStudioStore = defineStore("store", () => {
 	async function publishPage() {
 		if (!selectedPage.value) return
 		return studioPages.runDocMethod
-			.submit({
+			.submit(
+				{
 				name: selectedPage.value,
 				method: "publish",
-			})
+				},
+				{
+					onError(error: any) {
+						toast.error("Failed to publish the page", {
+							description: error.messages.join(", "),
+							duration: Infinity,
+							action: {
+								label: "Edit Pages",
+								onClick: () => {
+									studioLayout.leftPanelActiveTab = "Pages"
+								}
+							}
+						})
+					},
+				}
+			)
 			.then(async () => {
 				activePage.value = await fetchPage(selectedPage.value!)
 				if (activeApp.value && activePage.value) {

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -70,4 +70,6 @@ class StudioApp(WebsiteGenerator):
 			self.route = f"{camel_case_to_kebab_case(self.app_title, True)}-{frappe.generate_hash(length=4)}"
 
 	def get_studio_pages(self):
-		return frappe.get_all("Studio Page", dict(studio_app=self.name), ["name", "page_title", "route"])
+		return frappe.get_all(
+			"Studio Page", dict(studio_app=self.name, published=1), ["name", "page_title", "route"]
+		)

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -3,6 +3,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.naming import append_number_if_name_exists
 
 from studio.utils import camel_case_to_kebab_case
 
@@ -49,6 +50,14 @@ class StudioPage(Document):
 			self.blocks = "[]"
 		if not self.page_title:
 			self.page_title = "My Page"
+			self.page_title = append_number_if_name_exists(
+				"Studio Page",
+				self.page_title,
+				fieldname="page_title",
+				filters={
+					"studio_app": self.studio_app,
+				},
+			)
 		if not self.route:
 			self.route = f"{camel_case_to_kebab_case(self.page_title, True)}-{frappe.generate_hash(length=4)}"
 


### PR DESCRIPTION
## Problem

Vue Router needs unique route names along with route paths. If pages were added using the New Page button in Pages panel, it would add pages with the same "My Page" title. If you don't edit these titles before publishing, adding dynamic routes fails and your rendered app crashes. Ref: https://github.com/frappe/studio/issues/40#issuecomment-2808874107

## Fix

- Avoid setting duplicate page title on new page creation. This was already handled in "Duplicate Page" action by appending a "Copy" suffix to the page title. Now on new page insertion, it checks and appends a number to the title if the same title already exists in the current app -> My Page, My Page 1, My Page 2
-  On hitting Publish, validate title and route conflicts in the current app scope and nudge the user to edit page options. Clicking on Edit Pages will open the "Pages" Panel

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/022df2fa-4a3d-4381-8e46-c7987e2c3319" />

PS: The styling for default toasts could be better. Merging for now
