### PR TITLE
fix: navigation to broken app URL on publishing

### DIFF
--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -205,8 +205,19 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	function openPageInBrowser(app: StudioApp, page: StudioPage) {
-		let route = `${window.site_url}/${app.route}${page.route}`
-		window.open(route, "studio-preview")
+		let route = `/${app.route}${page.route}`
+		if (import.meta.env.DEV) {
+			route = `${window.site_url}/${app.route}${page.route}`
+		}
+
+		const targetWindow = window.open(route, "studio-preview")
+		if (targetWindow?.location.pathname === route) {
+			targetWindow?.location.reload()
+		} else {
+			setTimeout(() => {
+				targetWindow?.location.reload()
+			}, 50)
+		}
 	}
 
 	// styles


### PR DESCRIPTION
Closes https://github.com/frappe/studio/issues/43

**Problem**: The publish button used to open the route `${window.site_url}/${app.route}${page.route}`
Framework's [get_site_url](https://github.com/frappe/frappe/blob/095f44baf85eb41d052cf24ad30c8fe6ad632026/frappe/utils/__init__.py#L539) is not very reliable. It will append `webserver_port` if it doesn't find the `host_name` key in site config. But this is not set on all prod sites, especially self-hosted. Only FC sites set this key.

**Fix**: Open relative URL by default and only rely on site and port in development mode. While developing studio I need to go from
`http://studio:8080/studio/app/app-cf0a134d/page-83e8b518` -> `http://studio:8006/test/` because the renderer and vite dev server are running on different ports