### PR TITLE
feat(ui): add clear icon to search inputs and clean up redundant input handlers

### DIFF
--- a/frontend/src/components/ComponentPanel.vue
+++ b/frontend/src/components/ComponentPanel.vue
@@ -9,8 +9,19 @@
 				variant="outline"
 				placeholder="Search component"
 				v-model="componentFilter"
-				@input="(e: Event) => (componentFilter = (e.target as HTMLInputElement).value)"
-			/>
+			>
+				<template #prefix>
+					<FeatherIcon name="search" class="h-4 w-4 text-gray-500" />
+				</template>
+
+				<template #suffix v-if="componentFilter">
+					<FeatherIcon
+						name="x"
+						class="h-4 w-4 cursor-pointer text-gray-500 hover:text-gray-800"
+						@click="componentFilter = ''"
+					/>
+				</template>
+			</TextInput>
 		</div>
 
 		<div class="grid grid-cols-3 items-center gap-x-2 gap-y-4">

--- a/frontend/src/components/ComponentStyles.vue
+++ b/frontend/src/components/ComponentStyles.vue
@@ -9,12 +9,19 @@
 				variant="outline"
 				placeholder="Search properties"
 				v-model="store.stylePropertyFilter"
-				@input="
-					(e: Event) => {
-						store.stylePropertyFilter = (e.target as HTMLInputElement).value
-					}
-				"
-			/>
+			>
+				<template #prefix>
+					<FeatherIcon name="search" class="h-4 w-4 text-gray-500" />
+				</template>
+
+				<template #suffix v-if="store.stylePropertyFilter">
+					<FeatherIcon
+						name="x"
+						class="h-4 w-4 cursor-pointer text-gray-500 hover:text-gray-800"
+						@click="store.stylePropertyFilter = ''"
+					/>
+				</template>
+			</TextInput>
 		</div>
 		<div class="flex flex-col gap-3">
 			<CollapsibleSection

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -22,15 +22,23 @@
 			<div class="flex w-full flex-row justify-between">
 				<div class="text-lg font-semibold text-gray-800">All Apps</div>
 				<TextInput
-					class="w-48"
+					class="w-50"
 					placeholder="Search"
 					type="text"
 					variant="outline"
 					autofocus
-					@input="(e: Event) => (searchFilter = (e.target as HTMLInputElement).value)"
+					v-model="searchFilter"
 				>
 					<template #prefix>
 						<FeatherIcon name="search" class="h-4 w-4 text-gray-500" />
+					</template>
+
+					<template #suffix v-if="searchFilter">
+						<FeatherIcon
+							name="x"
+							class="h-4 w-4 cursor-pointer text-gray-500 hover:text-gray-800"
+							@click="searchFilter = ''"
+						/>
 					</template>
 				</TextInput>
 			</div>


### PR DESCRIPTION
- Replaced manual `@input` handlers with `v-model` for cleaner two-way binding
- Added prefix (search) and suffix (clear) icons to the following components:
  - ComponentPanel.vue
  - ComponentStyles.vue
  - Home.vue
- Improves UX for clearing filters quickly
- Ensures visual and behavioral consistency across the Studio interface
