### PR TITLE
feat: toggle and persist Studio Left Panel state

### DIFF
--- a/frontend/src/components/StudioLeftPanel.vue
+++ b/frontend/src/components/StudioLeftPanel.vue
@@ -115,10 +115,12 @@ const canvasStore = useCanvasStore()
 const activeTab = computed(() => store.studioLayout.leftPanelActiveTab)
 
 const setActiveTab = (tab: LeftPanelOptions) => {
-	if (!store.studioLayout.showLeftPanel) {
+	if (store.studioLayout.leftPanelActiveTab === tab && store.studioLayout.showLeftPanel) {
+		store.studioLayout.showLeftPanel = false
+	} else {
+		store.studioLayout.leftPanelActiveTab = tab
 		store.studioLayout.showLeftPanel = true
 	}
-	store.studioLayout.leftPanelActiveTab = tab
 }
 
 // moved out of ComponentLayers for performance

--- a/frontend/src/components/StudioLeftPanel.vue
+++ b/frontend/src/components/StudioLeftPanel.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch, computed, nextTick } from "vue"
+import { watch, computed, nextTick, onMounted } from "vue"
 import { Tooltip, FeatherIcon } from "frappe-ui"
 
 import PagesPanel from "@/components/PagesPanel.vue"
@@ -117,9 +117,12 @@ const activeTab = computed(() => store.studioLayout.leftPanelActiveTab)
 const setActiveTab = (tab: LeftPanelOptions) => {
 	if (store.studioLayout.leftPanelActiveTab === tab && store.studioLayout.showLeftPanel) {
 		store.studioLayout.showLeftPanel = false
+		localStorage.setItem("studioLeftPanelVisible", "false")
 	} else {
 		store.studioLayout.leftPanelActiveTab = tab
 		store.studioLayout.showLeftPanel = true
+		localStorage.setItem("studioLeftPanelActiveTab", tab)
+		localStorage.setItem("studioLeftPanelVisible", "true")
 	}
 }
 
@@ -170,4 +173,15 @@ watch(
 	},
 	{ deep: true },
 )
+
+onMounted(() => {
+	const savedTab = localStorage.getItem("studioLeftPanelActiveTab")
+	const isVisible = localStorage.getItem("studioLeftPanelVisible") === "true"
+
+	if (savedTab) {
+		store.studioLayout.leftPanelActiveTab = savedTab as LeftPanelOptions
+		store.studioLayout.showLeftPanel = isVisible
+	}
+})
+
 </script>


### PR DESCRIPTION
This PR improves the user experience of the Studio Left Panel by:

- Toggling the visibility of the left panel when clicking the same tab again.
- Persisting the active tab and visibility state using localStorage.
- Automatically restoring the last selected tab and panel visibility on page reload.

This makes navigation smoother and remembers user preferences across sessions.
