### PR TITLE
feat: register Studio in add_to_apps_screen with permission check

### DIFF
--- a/studio/api.py
+++ b/studio/api.py
@@ -48,12 +48,10 @@ def get_whitelisted_methods(doctype: str) -> list[str]:
 def has_permission() -> bool:
 	if frappe.session.user == "Administrator":
 		return True
-
-	if all(
-		[
-			frappe.has_permission("Studio App", ptype="write"),
-			frappe.has_permission("Studio Page", ptype="write"),
-		]
+	if (
+		"Studio User" in frappe.get_roles()
+		and frappe.has_permission("Studio App", ptype="write")
+		and frappe.has_permission("Studio Page", ptype="write")
 	):
 		return True
 	return False

--- a/studio/hooks.py
+++ b/studio/hooks.py
@@ -6,6 +6,17 @@ app_email = "rucha@frappe.io"
 app_license = "mit"
 # required_apps = []
 
+
+add_to_apps_screen = [
+    {
+        "name": app_name,
+        "logo": "/assets/studio/frontend/studio-logo.svg",
+        "title": app_title,
+        "route": "/studio",
+        "has_permission": "studio.api.has_permission",
+    }
+]
+
 # Includes in <head>
 # ------------------
 


### PR DESCRIPTION

Adds Studio to the Frappe Apps screen using `add_to_apps_screen`. Access is controlled via a `has_permission` method that allows:

* Administrator
* Users with the "Studio User" role and write permissions on **Studio App** and **Studio Page**
