### PR TITLE
fix: prevent deleting app home page

### DIFF
--- a/frontend/src/components/PagesPanel.vue
+++ b/frontend/src/components/PagesPanel.vue
@@ -84,6 +84,7 @@ const getPageMenu = (page: StudioPage) => {
 		{
 			label: "Delete",
 			icon: "trash",
+			condition: () => !isAppHome(page),
 			onClick: async () => {
 				await store.deleteAppPage(app.name, page)
 				if (isPageActive(page)) {

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -75,11 +75,10 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	async function deleteAppPage(appName: string, page: StudioPage) {
-
-		const isHome = activeApp.value?.app_home === page.name;
+		const isHome = activeApp.value?.app_home === page.name
 		if (isHome) {
-			toast.error("Cannot delete this page because it is set as the App Home.");
-			return;
+			toast.error("Cannot delete this page because it is set as the App Home.")
+			return
 		}
 
 		const confirmed = await confirm(`Are you sure you want to delete the page <b>${page.page_title}</b>?`)
@@ -89,7 +88,7 @@ const useStudioStore = defineStore("store", () => {
 				await setApp(appName)
 				toast.success(`Page "${page.page_title}" deleted successfully`)
 			} catch (error) {
-				toast.error("An unexpected error occurred while deleting the page.");
+				toast.error("An unexpected error occurred while deleting the page.")
 			}
 		}
 	}
@@ -112,7 +111,7 @@ const useStudioStore = defineStore("store", () => {
 						name: "StudioPage",
 						params: { appID: appName, pageID: page.name },
 					})
-					return `Page "${page.page_title}" duplicated successfully`;
+					return `Page "${page.page_title}" duplicated successfully`
 				},
 			},
 		)

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -75,11 +75,22 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	async function deleteAppPage(appName: string, page: StudioPage) {
-		// TODO: disallow deleting app home or app with only one page
+
+		const isHome = activeApp.value?.app_home === page.name;
+		if (isHome) {
+			toast.error("Cannot delete this page because it is set as the App Home.");
+			return;
+		}
+
 		const confirmed = await confirm(`Are you sure you want to delete the page <b>${page.page_title}</b>?`)
 		if (confirmed) {
-			await studioPages.delete.submit(page.name)
-			await setApp(appName)
+			try {
+				await studioPages.delete.submit(page.name)
+				await setApp(appName)
+				toast.success(`Page "${page.page_title}" deleted successfully`)
+			} catch (error) {
+				toast.error("An unexpected error occurred while deleting the page.");
+			}
 		}
 	}
 
@@ -101,7 +112,7 @@ const useStudioStore = defineStore("store", () => {
 						name: "StudioPage",
 						params: { appID: appName, pageID: page.name },
 					})
-					return "Page duplicated"
+					return `Page "${page.page_title}" duplicated successfully`;
 				},
 			},
 		)


### PR DESCRIPTION
**Summary**
- Hides the delete button for the App Home page.
- Adds a backend check to stop deleting the App Home page, even if the delete function is triggered manually or from somewhere else.
- Shows a green success message when a page is deleted.
- No need to check if only one page is left — the Home page check is enough because there will always be at least one page.

**Why**
- Prevents delete errors like `LinkExistsError`.

**Before:**  

[Screencast from 2025-05-06 21-44-28.webm](https://github.com/user-attachments/assets/db6670ba-ac6b-412a-9d7b-56e79598cecf)

**After:**  

![image](https://github.com/user-attachments/assets/b6157a1c-ea35-4d9e-9d29-4be5b821e6dc)

