### PR TITLE
fix: set full height for app's root element (app screens are almost always fullscreen)

### DIFF
--- a/frontend/renderer.html
+++ b/frontend/renderer.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <!-- Built with Frappe Studio -->
-<html lang="en">
+<html lang="en" class="h-full">
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{{ app_title }}</title>
 	</head>
-	<body>
-		<div id="app"></div>
+	<body class="h-full">
+		<div id="app" class="h-full"></div>
 		<div id="modals"></div>
 		<div id="popovers"></div>
 		<script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,12 +1,14 @@
 <template>
-	<router-view v-slot="{ Component }">
-		<keep-alive>
-			<component :is="Component" />
-		</keep-alive>
-	</router-view>
+	<div class="h-full">
+		<router-view v-slot="{ Component }">
+			<keep-alive>
+				<component :is="Component" />
+			</keep-alive>
+		</router-view>
 
-	<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
-	<Dialogs></Dialogs>
+		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
+		<Dialogs></Dialogs>
+	</div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,12 @@
 <template>
-	<div>
-		<router-view v-slot="{ Component }">
-			<keep-alive>
-				<component :is="Component" />
-			</keep-alive>
-		</router-view>
+	<router-view v-slot="{ Component }">
+		<keep-alive>
+			<component :is="Component" />
+		</keep-alive>
+	</router-view>
 
-		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
-		<Dialogs></Dialogs>
-	</div>
+	<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
+	<Dialogs></Dialogs>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/AppRenderer.vue
+++ b/frontend/src/AppRenderer.vue
@@ -1,0 +1,18 @@
+<template>
+	<div class="h-full">
+		<router-view />
+		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
+		<Dialogs></Dialogs>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { Dialogs } from "frappe-ui"
+import { Toaster } from "vue-sonner"
+</script>
+
+<style>
+[id^="headlessui-dialog"] {
+	@apply z-50;
+}
+</style>

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -17,7 +17,7 @@
 		</Transition>
 
 		<div
-			class="fixed flex gap-40"
+			class="fixed flex h-full gap-40"
 			ref="canvas"
 			:style="{
 				transformOrigin: 'top center',

--- a/frontend/src/renderer.ts
+++ b/frontend/src/renderer.ts
@@ -4,12 +4,12 @@ import { createApp } from "vue"
 import { createPinia } from "pinia"
 import "./setupFrappeUIResource"
 import app_router from "@/router/app_router"
-import App from "./App.vue"
+import AppRenderer from "./AppRenderer.vue"
 import { resourcesPlugin } from "frappe-ui"
 import { registerGlobalComponents } from "./globals"
 
 // For rendering apps built by studio
-const app = createApp(App)
+const app = createApp(AppRenderer)
 const pinia = createPinia()
 
 app.use(app_router)

--- a/frontend/src/utils/blockTemplate.ts
+++ b/frontend/src/utils/blockTemplate.ts
@@ -21,6 +21,7 @@ function getBlockTemplate(
 					alignItems: "center",
 					width: "inherit",
 					overflowX: "hidden",
+					height: "100%",
 				}
 			};
 


### PR DESCRIPTION
## Before

By default, the element root wasn't full-height. 
What the user had to do to make it span full height?

- Height: 100% or flex grow showed correct results on canvas but not in the app renderer because the app renderer's main body & app div wasn't full height. So, even if root is set to stretch the full height, it will still span only the parent's height. 
- User had to explicitly set 100vh on the root to make the app full-screen. [But there are issues with 100vh on mobile browsers](https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/)

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/667c8d41-0c80-4380-aced-a1531e483d8b" />


## After

- App screens are almost always full screen. So set the root element + all ancestors to span full height
- Also separated out AppRenderer.vue because it doesn't need `keep-alive` unlike the studio editor.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/12709531-f8c0-467b-938f-4eed311010ef" />

Closes https://github.com/frappe/studio/issues/54
