### PR TITLE
fix(renderer): explicitly set styles for components with `inheritAttrs: false`

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -30,6 +30,7 @@
 <script setup lang="ts">
 import Block from "@/utils/block"
 import { computed, onMounted, ref, useAttrs, inject } from "vue"
+import type { ComponentPublicInstance } from "vue"
 import { useRouter, useRoute } from "vue-router"
 import { createResource } from "frappe-ui"
 import { getComponentRoot, isDynamicValue, getDynamicValue, isHTML, executeUserScript } from "@/utils/helpers"
@@ -48,7 +49,7 @@ const componentName = computed(() => {
 	return props.block.componentName
 })
 
-const componentRef = ref(null)
+const componentRef = ref<ComponentPublicInstance | null>(null)
 
 const { currentBreakpoint } = useScreenSize()
 const styles = computed(() => props.block.getStyles(currentBreakpoint.value))
@@ -229,10 +230,13 @@ function getPageRoute(appRoute: string, page: string) {
 }
 
 onMounted(() => {
-	// set data-component-id on mount since some frappeui components have inheritAttrs: false
 	const componentRoot = getComponentRoot(componentRef)
 	if (componentRoot) {
+		// explicitly set data-component-id & styles for frappeui components with inheritAttrs: false
 		componentRoot.setAttribute("data-component-id", props.block.componentId)
+		for (const key in styles.value) {
+			componentRef.value?.$el?.style?.setProperty(key, styles.value[key])
+		}
 	}
 })
 </script>

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -286,16 +286,16 @@ watch(
 )
 
 watch(
-	() => props.block.baseStyles,
+	() => [props.block.baseStyles, props.block.tabletStyles, props.block.mobileStyles],
 	() => {
 		if (!componentRef.value) return
-		// update styles when baseStyles change for frappeui components with inheritAttrs: false
+		// explicitly set styles when any style changes for frappeui components with inheritAttrs: false
 		const styles = props.block.getStyles(props.breakpoint)
 		for (const key in styles) {
 			componentRef.value?.$el?.style?.setProperty(key, styles[key])
 		}
 	},
-	{ deep: true },
+	{ deep: true, immediate: true },
 )
 
 watch(


### PR DESCRIPTION
## Before:

Padding applied to ListView component in editor:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ade77882-fe8f-47e0-8c86-a5c0d91e6ff7" />

Not reflected in the renderer:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/6e89daa2-e4fd-451d-a630-4c9e5198030f" />

## After:

- This is because some components like ListView have `inheritAttrs` set to false. So styles don't fall through to the correct element. Explicitly set styles on component's root HTML element on mount
- Also watch changes in tablet & mobile styles in editor for the changes to reflect on the components

> [!NOTE]  
> Its better to always wrap such components inside a container. You might pollute listview's actual styles

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/2367c80b-2d45-4d16-b818-a4ee7f0458f9" />