### PR TITLE
refactor: set app name as app title slug instead of the app-{hash} format

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -73,9 +73,10 @@
 						type="text"
 						variant="outline"
 						v-model="newApp.app_title"
-						@input="setAppRoute"
+						@input="setAppFields"
 					/>
 					<FormControl label="App Route" type="text" variant="outline" v-model="newApp.route" />
+					<FormControl label="App Name" type="text" variant="outline" v-model="newApp.app_name" />
 				</div>
 			</template>
 		</Dialog>
@@ -84,7 +85,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue"
-import { Dialog } from "frappe-ui"
+import { Dialog, FormControl } from "frappe-ui"
 import { useRouter } from "vue-router"
 import { studioApps } from "@/data/studioApps"
 import { UseTimeAgo } from "@vueuse/components"
@@ -98,6 +99,7 @@ const showDialog = ref(false)
 const emptyAppState = {
 	app_title: "",
 	route: "",
+	app_name: "",
 }
 const newApp = ref({ ...emptyAppState })
 const router = useRouter()
@@ -121,6 +123,7 @@ const createStudioApp = (app: NewStudioApp) => {
 		.submit({
 			app_title: app.app_title,
 			route: app.route,
+			app_name: app.app_name,
 		})
 		.then((res: StudioApp) => {
 			showDialog.value = false
@@ -128,7 +131,8 @@ const createStudioApp = (app: NewStudioApp) => {
 		})
 }
 
-function setAppRoute(e: Event) {
-	newApp.value.route = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
+function setAppFields(e: Event) {
+	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
+	newApp.value.route = newApp.value.app_name = kebabCasedTitle
 }
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -74,9 +74,16 @@
 						variant="outline"
 						v-model="newApp.app_title"
 						@input="setAppFields"
+						:required="true"
 					/>
 					<FormControl label="App Route" type="text" variant="outline" v-model="newApp.route" />
-					<FormControl label="App Name" type="text" variant="outline" v-model="newApp.app_name" />
+					<FormControl
+						label="App Name"
+						type="text"
+						variant="outline"
+						v-model="newApp.app_name"
+						:placeholder="newApp.app_name_placeholder"
+					/>
 				</div>
 			</template>
 		</Dialog>
@@ -100,6 +107,7 @@ const emptyAppState = {
 	app_title: "",
 	route: "",
 	app_name: "",
+	app_name_placeholder: "",
 }
 const newApp = ref({ ...emptyAppState })
 const router = useRouter()
@@ -133,6 +141,6 @@ const createStudioApp = (app: NewStudioApp) => {
 
 function setAppFields(e: Event) {
 	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
-	newApp.value.route = newApp.value.app_name = kebabCasedTitle
+	newApp.value.route = newApp.value.app_name_placeholder = kebabCasedTitle
 }
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -64,10 +64,17 @@
 					},
 				],
 			}"
+			@after-leave="newApp = { ...emptyAppState }"
 		>
 			<template #body-content>
 				<div class="flex flex-col gap-3">
-					<FormControl label="App Title" type="text" variant="outline" v-model="newApp.app_title" />
+					<FormControl
+						label="Title"
+						type="text"
+						variant="outline"
+						v-model="newApp.app_title"
+						@input="setAppRoute"
+					/>
 					<FormControl label="App Route" type="text" variant="outline" v-model="newApp.route" />
 				</div>
 			</template>
@@ -117,8 +124,11 @@ const createStudioApp = (app: NewStudioApp) => {
 		})
 		.then((res: StudioApp) => {
 			showDialog.value = false
-			newApp.value = { ...emptyAppState }
 			router.push({ name: "StudioApp", params: { appID: res.name } })
 		})
+}
+
+function setAppRoute(e: Event) {
+	newApp.value.route = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
 }
 </script>

--- a/frontend/src/types/Studio/StudioApp.ts
+++ b/frontend/src/types/Studio/StudioApp.ts
@@ -16,4 +16,6 @@ export interface StudioApp {
 	app_home: string
 }
 
-export type NewStudioApp = Pick<StudioApp, "app_title" | "route" | "app_name">
+export type NewStudioApp = Pick<StudioApp, "app_title" | "route" | "app_name"> & {
+	app_name_placeholder?: string
+}

--- a/frontend/src/types/Studio/StudioApp.ts
+++ b/frontend/src/types/Studio/StudioApp.ts
@@ -16,4 +16,4 @@ export interface StudioApp {
 	app_home: string
 }
 
-export type NewStudioApp = Pick<StudioApp, "app_title" | "route">
+export type NewStudioApp = Pick<StudioApp, "app_title" | "route" | "app_name">

--- a/studio/patches.txt
+++ b/studio/patches.txt
@@ -5,3 +5,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 studio.studio.doctype.studio_page.patches.replace_frappeUI_namespace_references
+studio.studio.doctype.studio_app.patches.rename_studio_app_based_on_app_title

--- a/studio/studio/doctype/studio_app/patches/rename_studio_app_based_on_app_title.py
+++ b/studio/studio/doctype/studio_app/patches/rename_studio_app_based_on_app_title.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	"""Renames Studio App documents to slugified app titles instead of the app-{hash} format"""
+	studio_apps = frappe.get_all("Studio App", fields=["name", "app_title"])
+	for app in studio_apps:
+		new_name = app.app_title.lower().replace(" ", "-")
+		frappe.rename_doc("Studio App", app.name, new_name)

--- a/studio/studio/doctype/studio_app/studio_app.json
+++ b/studio/studio/doctype/studio_app/studio_app.json
@@ -1,12 +1,13 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:app_name",
  "creation": "2024-09-25 20:56:56.296301",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "app_name",
   "app_title",
+  "app_name",
   "route",
   "column_break_aroi",
   "app_home",
@@ -39,7 +40,8 @@
   {
    "fieldname": "app_title",
    "fieldtype": "Data",
-   "label": "App Title"
+   "label": "App Title",
+   "reqd": 1
   },
   {
    "default": "0",
@@ -57,11 +59,11 @@
    "link_fieldname": "studio_app"
   }
  ],
- "modified": "2025-07-14 12:50:59.049640",
+ "modified": "2025-07-15 10:57:08.869756",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio App",
- "naming_rule": "By script",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/studio/studio/doctype/studio_app/studio_app.json
+++ b/studio/studio/doctype/studio_app/studio_app.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:app_name",
  "creation": "2024-09-25 20:56:56.296301",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -58,11 +57,11 @@
    "link_fieldname": "studio_app"
   }
  ],
- "modified": "2025-07-08 12:00:13.847967",
+ "modified": "2025-07-14 12:50:59.049640",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio App",
- "naming_rule": "By fieldname",
+ "naming_rule": "By script",
  "owner": "Administrator",
  "permissions": [
   {

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -58,7 +58,7 @@ class StudioApp(WebsiteGenerator):
 
 		app_home: DF.Link | None
 		app_name: DF.Data | None
-		app_title: DF.Data | None
+		app_title: DF.Data
 		published: DF.Check
 		route: DF.Data | None
 	# end: auto-generated types
@@ -75,7 +75,7 @@ class StudioApp(WebsiteGenerator):
 		context.csrf_token = csrf_token
 		context.no_cache = 1
 
-		context.app_name = self.name
+		context.app_name = self.app_name
 		context.app_route = self.route
 		context.app_title = self.app_title
 		context.base_url = frappe.utils.get_url(self.route)
@@ -85,7 +85,7 @@ class StudioApp(WebsiteGenerator):
 
 	def autoname(self):
 		if not self.name:
-			self.name = self.app_title.lower().replace(" ", "-")
+			self.name = self.app_name or self.app_title.lower().replace(" ", "-")
 
 	def before_insert(self):
 		if not self.app_title:

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -95,6 +95,10 @@ class StudioApp(WebsiteGenerator):
 				self.autoname()
 			self.route = self.name
 
+	def on_trash(self):
+		for page in frappe.get_all("Studio Page", filters={"studio_app": self.name}, pluck="name"):
+			frappe.delete_doc("Studio Page", page, force=True)
+
 	def get_studio_pages(self):
 		return frappe.get_all(
 			"Studio Page", dict(studio_app=self.name, published=1), ["name", "page_title", "route"]

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -8,7 +8,6 @@ from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.website_generator import WebsiteGenerator
 
 from studio.api import get_app_components
-from studio.utils import camel_case_to_kebab_case
 
 
 class StudioAppRenderer(DocumentPage):
@@ -86,13 +85,15 @@ class StudioApp(WebsiteGenerator):
 
 	def autoname(self):
 		if not self.name:
-			self.name = f"app-{frappe.generate_hash(length=8)}"
+			self.name = self.app_title.lower().replace(" ", "-")
 
 	def before_insert(self):
 		if not self.app_title:
 			self.app_title = "My App"
 		if not self.route:
-			self.route = f"{camel_case_to_kebab_case(self.app_title, True)}-{frappe.generate_hash(length=4)}"
+			if not self.name:
+				self.autoname()
+			self.route = self.name
 
 	def get_studio_pages(self):
 		return frappe.get_all(


### PR DESCRIPTION
## Before

App ID was app-{hash}, which didn't make sense

<img width="1440" height="818" alt="app-id-before" src="https://github.com/user-attachments/assets/6400f508-c662-40de-bc6b-0accbb2135d5" />

User had no control over setting the app name

## After

App ID is now set as the app title slug. This change is required for more readable app exports (upcoming feature).

<img width="1433" height="791" alt="app-id-after" src="https://github.com/user-attachments/assets/e95542f8-245f-4ee0-88b6-a56347942583" />

The user can change the name if required

https://github.com/user-attachments/assets/2f8975c8-453b-4a0c-8c8b-929a4c543ed9

**More:**
1. Added patch to rename existing apps
2. Delete app pages on deleting the app
