### PR TITLE
fix: remove null fields before app & page export

### DIFF
--- a/studio/export.py
+++ b/studio/export.py
@@ -43,3 +43,17 @@ def can_export(doc) -> bool:
 		and not frappe.flags.in_uninstall
 		and not frappe.flags.in_import
 	)
+
+
+def remove_null_fields(docdict):
+	"""remove null and empty fields"""
+	to_remove = []
+	for attr, value in docdict.items():
+		if isinstance(value, list):
+			for v in value:
+				remove_null_fields(v)
+		elif not value:
+			to_remove.append(attr)
+
+	for attr in to_remove:
+		del docdict[attr]

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -8,7 +8,7 @@ from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.website_generator import WebsiteGenerator
 
 from studio.api import get_app_components
-from studio.export import can_export, delete_folder, write_document_file
+from studio.export import can_export, delete_folder, remove_null_fields, write_document_file
 
 
 class StudioAppRenderer(DocumentPage):
@@ -102,6 +102,9 @@ class StudioApp(WebsiteGenerator):
 		self.export_app()
 		if not self.flags.in_insert and self.has_value_changed("is_standard") and not self.is_standard:
 			self.delete_app_folder()
+
+	def before_export(self, doc):
+		remove_null_fields(doc)
 
 	def on_trash(self):
 		for page in frappe.get_all("Studio Page", filters={"studio_app": self.name}, pluck="name"):

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -5,7 +5,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 
-from studio.export import can_export, delete_file, write_document_file
+from studio.export import can_export, delete_file, remove_null_fields, write_document_file
 from studio.utils import camel_case_to_kebab_case
 
 
@@ -152,6 +152,7 @@ class StudioPage(Document):
 
 	def before_export(self, doc):
 		doc.name = self.get_export_docname()
+		remove_null_fields(doc)
 
 	def before_import(self):
 		self.name = self.page_name


### PR DESCRIPTION
Fields like idx, unused keys were also getting exported

