### PR TITLE
chore: upgrade frappe-ui to v0.1.186

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
 		"autoprefixer": "^10.4.2",
 		"codemirror": "^6.0.1",
 		"feather-icons": "^4.28.0",
-		"frappe-ui": "0.1.184",
+		"frappe-ui": "0.1.186",
 		"marked": "^15.0.6",
 		"pinia": "^2.2.1",
 		"thememirror": "^2.0.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,9 +15,3 @@
 import { Dialogs } from "frappe-ui"
 import { Toaster } from "vue-sonner"
 </script>
-
-<style>
-.dialog-overlay {
-	@apply z-50;
-}
-</style>

--- a/frontend/src/AppRenderer.vue
+++ b/frontend/src/AppRenderer.vue
@@ -10,9 +10,3 @@
 import { Dialogs } from "frappe-ui"
 import { Toaster } from "vue-sonner"
 </script>
-
-<style>
-.dialog-overlay {
-	@apply z-50;
-}
-</style>

--- a/frontend/src/components/ComponentProps.vue
+++ b/frontend/src/components/ComponentProps.vue
@@ -44,6 +44,7 @@
 							:options="store.variableOptions"
 							placeholder="Select variable"
 							@update:modelValue="(variable: SelectOption) => bindVariable(propName, variable.value)"
+							class="!w-auto"
 						>
 							<template #target="{ togglePopover }">
 								<IconButton
@@ -74,6 +75,7 @@
 				<Autocomplete
 					:options="componentSlots"
 					@update:modelValue="(slot: SelectOption) => block?.addSlot(slot.value)"
+					class="!w-auto"
 				>
 					<template #target="{ togglePopover }">
 						<Button @click="togglePopover" size="sm" variant="ghost" icon="plus" />

--- a/frontend/src/components/Filters.vue
+++ b/frontend/src/components/Filters.vue
@@ -61,6 +61,7 @@
 						:options="fields"
 						@update:modelValue="(field: DocTypeField) => addFilter(field.value)"
 						placeholder="Filter by..."
+						class="!w-auto"
 					>
 						<template #target="{ togglePopover }">
 							<Button class="!text-gray-600" variant="ghost" @click="togglePopover()" label="Add filter">

--- a/frontend/src/components/PageOptions.vue
+++ b/frontend/src/components/PageOptions.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue"
+import { computed, nextTick, ref, watch } from "vue"
 import useStudioStore from "@/stores/studioStore"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { StudioApp } from "@/types/Studio/StudioApp"
@@ -69,7 +69,7 @@ const setPageRoute = () => {
 }
 
 const dynamicPadding = computed(() => {
-	const prefixWidth = props.app?.route?.length * 8 + 15 // Assuming 8px per character plus 4px for padding
+	const prefixWidth = props.app?.route?.length * 8 + 2 // Assuming 8px per character plus 2px for padding
 	return `${Math.round(prefixWidth)}px`
 })
 
@@ -85,10 +85,12 @@ const applyDynamicPadding = () => {
 watch(
 	() => props.isOpen,
 	() => {
-		// apply dynamic padding to input element when the popover is opened
-		// to avoid overlapping with the prefix content
-		applyDynamicPadding()
-		setPageRoute()
+		nextTick(() => {
+			// apply dynamic padding to input element when the popover is opened
+			// to avoid overlapping with the prefix content
+			applyDynamicPadding()
+			setPageRoute()
+		})
 	},
 	{ immediate: true },
 )

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -93,7 +93,7 @@
 				</template>
 
 				<!-- Transform Results for any Resource Type -->
-				<div class="flex flex-row gap-1.5">
+				<div class="flex flex-row items-center gap-1.5">
 					<FormControl size="sm" type="checkbox" v-model="newResource.transform_results" />
 					<InputLabel>Transform Results</InputLabel>
 				</div>

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -134,11 +134,3 @@ const routeString = computed(() => store.activePage?.route || "/")
 const showExportAppDialog = ref(false)
 const canExportApp = computed(() => window.is_developer_mode && !isObjectEmpty(store.activeApp))
 </script>
-
-<style>
-/* dropdown menu popover */
-div[data-reka-popper-content-wrapper] > div[role="menu"] {
-	margin-top: 15px !important;
-	z-index: 20 !important;
-}
-</style>

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -36,7 +36,7 @@
 		</div>
 
 		<div>
-			<Popover transition="default" placement="bottom" popoverClass="!absolute top-0 !mt-[20px]">
+			<Popover transition="default" placement="bottom" popoverClass="!mt-[20px]">
 				<template #target="{ togglePopover, isOpen }">
 					<div class="flex cursor-pointer items-center gap-2 p-2">
 						<div class="flex h-6 items-center text-base text-gray-800" v-if="!store.activePage">

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="h-screen flex-col overflow-hidden bg-white">
+	<div class="isolate h-screen flex-col overflow-hidden bg-white">
 		<div
 			class="toolbar sticky top-0 z-10 flex h-14 items-center justify-between bg-white px-3 py-2 shadow-sm"
 		>
@@ -169,11 +169,3 @@ function setAppFields(e: Event) {
 	newApp.value.route = newApp.value.app_name_placeholder = kebabCasedTitle
 }
 </script>
-
-<style>
-/* dropdown menu popover */
-div[data-reka-popper-content-wrapper] > div[role="menu"] {
-	margin-top: 15px !important;
-	z-index: 20 !important;
-}
-</style>

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="studio h-screen flex-col overflow-hidden bg-gray-100">
+	<div class="studio isolate h-screen flex-col overflow-hidden bg-gray-100">
 		<ComponentContextMenu ref="componentContextMenu"></ComponentContextMenu>
 		<StudioToolbar class="relative z-30" />
 		<div class="flex flex-col">


### PR DESCRIPTION
Upgraded to frappe-ui 0.1.186 because Autocomplete selection was broken
Fixed the following 
- Isolated stacking context for studio page & home since toolbar, side panel and canvas's z-index was not going well with the new reka ui elements
- Fixed PageOptions popover - changes to inputs inside popover should now be made on next tick
- Autocomplete is suddenly taking full-width everywhere after the Popover update. Force w-auto wherever required
