### PR TITLE
fix(Code Editor): allow JS object literals, make object editing more forgiving

### DIFF
--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -70,17 +70,28 @@ const setEditorValue = () => {
 	code.value = value
 }
 
+const parseObjectString = (text: string) => {
+	const objString = text.trim()
+	if (
+		!(objString.startsWith("{") && objString.endsWith("}")) &&
+		!(objString.startsWith("[") && objString.endsWith("]"))
+	) {
+		throw new Error("Invalid object")
+	}
+	return new Function("return " + objString)()
+}
+
 const errorMessage = ref("")
 const emitEditorValue = () => {
 	try {
 		errorMessage.value = ""
 		let value = code.value || ""
-		if (
-			value &&
-			!value.startsWith("{{") &&
-			(props.language === "json" || typeof props.modelValue === "object")
-		) {
-			value = jsonToJs(value)
+		if (value && !value.startsWith("{{")) {
+			if (props.language === "json") {
+				value = jsonToJs(value)
+			} else if (props.language === "javascript" && typeof props.modelValue === "object") {
+				value = parseObjectString(value)
+			}
 		}
 
 		if (!props.showSaveButton && !props.readonly) {

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -160,4 +160,9 @@ const extensions = computed(() => {
 	baseExtensions.push(autocompletion(autocompletionOptions))
 	return baseExtensions
 })
+
+defineExpose({
+	errorMessage,
+	emitEditorValue,
+})
 </script>

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -97,7 +97,13 @@ const emitEditorValue = () => {
 			if (props.language === "json") {
 				value = jsonToJs(value)
 			} else if (props.language === "javascript" && isValidObjectString(value)) {
-				value = parseObjectString(value)
+				try {
+					// forgiving single-quoted/unquoted keys; trailing commas
+					value = parseObjectString(value)
+				} catch (e) {
+					// fallback to JSON parsing
+					value = jsonToJs(value)
+				}
 			}
 		}
 

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -70,15 +70,22 @@ const setEditorValue = () => {
 	code.value = value
 }
 
-const parseObjectString = (text: string) => {
+const isValidObjectString = (text: string) => {
 	const objString = text.trim()
 	if (
-		!(objString.startsWith("{") && objString.endsWith("}")) &&
-		!(objString.startsWith("[") && objString.endsWith("]"))
+		(objString.startsWith("{") && objString.endsWith("}")) ||
+		(objString.startsWith("[") && objString.endsWith("]"))
 	) {
+		return true
+	}
+	return false
+}
+
+const parseObjectString = (text: string) => {
+	if (!isValidObjectString(text)) {
 		throw new Error("Invalid object")
 	}
-	return new Function("return " + objString)()
+	return new Function("return " + text)()
 }
 
 const errorMessage = ref("")
@@ -89,7 +96,7 @@ const emitEditorValue = () => {
 		if (value && !value.startsWith("{{")) {
 			if (props.language === "json") {
 				value = jsonToJs(value)
-			} else if (props.language === "javascript" && typeof props.modelValue === "object") {
+			} else if (props.language === "javascript" && isValidObjectString(value)) {
 				value = parseObjectString(value)
 			}
 		}

--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -114,6 +114,7 @@
 							/>
 							<Code
 								v-if="variableRef.variable_type === 'Object'"
+								ref="variableEditor"
 								label="Initial Value"
 								language="javascript"
 								height="250px"
@@ -141,6 +142,8 @@
 							:label="variableRef.name ? 'Update' : 'Add'"
 							@click="
 								() => {
+									const validated = validateVariable(variableRef)
+									if (!validated) return
 									if (variableRef.name) {
 										editVariable(variableRef)
 									} else {
@@ -285,6 +288,7 @@ const getResourceMenu = (resource: Resource, resource_name: string) => {
 
 // variables
 const showVariableDialog = ref(false)
+const variableEditor = ref()
 const variableRef = ref<Variable>({
 	name: "",
 	variable_name: "",
@@ -412,5 +416,15 @@ const getVariableMenu = (variable_name: string, value: any) => {
 			},
 		},
 	]
+}
+
+const validateVariable = (variable: Variable) => {
+	if (variable.variable_type === "Object") {
+		variableEditor.value.emitEditorValue()
+		if (variableEditor.value?.errorMessage) {
+			return false
+		}
+	}
+	return true
 }
 </script>


### PR DESCRIPTION
## Before

Trailing comma not allowed

<img width="1440" height="812" alt="image" src="https://github.com/user-attachments/assets/640573d5-3e0e-4154-ae96-d0fe2a1f45fa" />

Unquoted/single-quoted keys not allowed

<img width="1275" height="668" alt="image" src="https://github.com/user-attachments/assets/a81b38cb-56eb-45a9-be0a-abd10188b9ea" />

## After

Code fields now allow declaring objects by writing JS object literals

https://github.com/user-attachments/assets/3af3073d-860b-4e31-906d-7b5a4c55e81c

Prop editing also allows the same but falls back to json parsing if parsing object literal fails since JSON gives a better error message about the missing portion

<img width="275" height="337" alt="image" src="https://github.com/user-attachments/assets/a96a9195-0e76-447a-bf46-66b26fe88538" />

<hr>

Fixed another bug where the layouts used to break if we set an object editor code field to empty and then pasted the object again because it depended on props.modelValue
Now it parses the object if the editor's value is an object/array, doesn't depend on the passed modelValue
