### PR TITLE
feat: Dynamic Value Selector for props

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -38,6 +38,7 @@ declare module 'vue' {
     Cross: typeof import('./src/components/Icons/Cross.vue')['default']
     DataPanel: typeof import('./src/components/DataPanel.vue')['default']
     DimensionInput: typeof import('./src/components/DimensionInput.vue')['default']
+    DynamicValueSelector: typeof import('./src/components/DynamicValueSelector.vue')['default']
     EmptyState: typeof import('./src/components/EmptyState.vue')['default']
     ExportAppDialog: typeof import('./src/components/ExportAppDialog.vue')['default']
     EyeDropper: typeof import('./src/components/Icons/EyeDropper.vue')['default']

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -78,15 +78,12 @@ const repeaterContext = inject("repeaterContext", {})
 const componentContext = inject<ComputedRef | null>("componentContext", null)
 
 const evaluationContext = computed(() => {
-	const context: any = {
+	return {
 		...store.variables,
 		...store.resources,
 		...repeaterContext,
+		...componentContext?.value,
 	}
-	if (componentContext?.value) {
-		context["inputs"] = componentContext.value
-	}
-	return context
 })
 
 const getComponentProps = () => {
@@ -208,7 +205,13 @@ const componentEvents = computed(() => {
 				}
 			} else if (event.action === "Run Script") {
 				return () => {
-					executeUserScript(event.script, store.variables, store.resources, repeaterContext)
+					executeUserScript(
+						event.script,
+						store.variables,
+						store.resources,
+						repeaterContext,
+						componentContext?.value,
+					)
 				}
 			}
 		}

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -154,6 +154,8 @@ watch(
 	{ immediate: true },
 )
 
+watch(() => props.modelValue, setEditorValue)
+
 const extensions = computed(() => {
 	const baseExtensions = [
 		closeBrackets(),

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -332,8 +332,7 @@ const actions: ActionConfigurations = {
 					language: "javascript",
 					modelValue: newEvent.value.script,
 					height: "250px",
-					completions: (context: CompletionContext) =>
-						getCompletions(context, props.block?.getRepeaterDataCompletions()),
+					completions: (context: CompletionContext) => getCompletions(context, props.block?.getCompletions()),
 				}
 			},
 			events: {

--- a/frontend/src/components/ComponentInterface.vue
+++ b/frontend/src/components/ComponentInterface.vue
@@ -139,7 +139,7 @@
 			<PropsEditor
 				v-if="componentEditorStore.studioComponentBlock"
 				:block="componentEditorStore.studioComponentBlock"
-				:isEditingComponent="true"
+				:isTestingComponent="true"
 			/>
 		</div>
 	</div>

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -61,9 +61,7 @@
 				language="javascript"
 				height="60px"
 				:showLineNumbers="false"
-				:completions="
-					(context: CompletionContext) => getCompletions(context, block?.getRepeaterDataCompletions())
-				"
+				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 				:modelValue="block?.visibilityCondition"
 				@update:modelValue="blockController.setKeyValue('visibilityCondition', $event)"
 			/>

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -3,6 +3,7 @@
 		size="sm"
 		:options="dynamicValueOptions"
 		class="!w-auto"
+		modelValue=""
 		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value)"
 	>
 		<template #target="{ togglePopover }">
@@ -47,7 +48,7 @@ const dynamicValueOptions = computed(() => {
 			const inputOptions = Object.keys(componentContext).map((inputName) => ({
 				value: `{{ inputs.${inputName} }}`,
 				label: `inputs.${inputName}`,
-				type: "component input",
+				type: typeof componentContext[inputName],
 			}))
 			groups.push({
 				group: "Component Inputs",
@@ -69,7 +70,7 @@ const dynamicValueOptions = computed(() => {
 		const dataSourceOptions = Object.keys(store.resources).map((resourceName) => ({
 			value: `{{ ${resourceName}.data }}`,
 			label: resourceName,
-			type: "data source",
+			type: "array",
 		}))
 		if (dataSourceOptions.length > 0) {
 			groups.push({
@@ -85,7 +86,7 @@ const dynamicValueOptions = computed(() => {
 		const repeaterOptions = Object.keys(repeaterContext).map((key) => ({
 			value: `{{ dataItem.${key} }}`,
 			label: `dataItem.${key}`,
-			type: "repeater item",
+			type: typeof repeaterContext[key],
 		}))
 		groups.push({
 			group: "Repeater",

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -1,0 +1,97 @@
+<template>
+	<Autocomplete
+		size="sm"
+		:options="dynamicValueOptions"
+		class="!w-auto"
+		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value)"
+	>
+		<template #target="{ open }">
+			<Tooltip text="Set dynamic value" :placement="'bottom'">
+				<FeatherIcon
+					ref="dropdownTrigger"
+					name="zap"
+					class="mr-1 h-3 w-4 cursor-pointer select-none text-ink-gray-5 outline-none hover:text-ink-gray-9"
+					@click="open"
+				/>
+			</Tooltip>
+		</template>
+
+		<template #item-suffix="{ option }">
+			<span class="text-ink-gray-4">{{ option.type?.toLowerCase() }}</span>
+		</template>
+	</Autocomplete>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { Autocomplete, Tooltip } from "frappe-ui"
+import useStudioStore from "@/stores/studioStore"
+import Block from "@/utils/block"
+import type { VariableOption } from "@/types/Studio/StudioPageVariable"
+
+const props = defineProps<{ block?: Block; isEditingComponent?: boolean }>()
+const emit = defineEmits<{
+	(event: "update:modelValue", value: string): void
+}>()
+const store = useStudioStore()
+
+const dynamicValueOptions = computed(() => {
+	const groups = []
+
+	// Variables group
+	if (store.variableOptions.length > 0) {
+		groups.push({
+			group: "Variables",
+			items: store.variableOptions.map((option) => ({
+				...option,
+				value: `{{ ${option.value} }}`,
+			})),
+		})
+	}
+
+	// Data Sources group
+	const dataSourceOptions = Object.keys(store.resources).map((resourceName) => ({
+		value: `{{ ${resourceName}.data }}`,
+		label: resourceName,
+		type: "data source",
+	}))
+	if (dataSourceOptions.length > 0) {
+		groups.push({
+			group: "Data Sources",
+			items: dataSourceOptions,
+		})
+	}
+
+	// Repeater Data Item group
+	const repeaterContext = props.block?.repeaterDataItem
+	if (repeaterContext && Object.keys(repeaterContext).length > 0) {
+		const repeaterOptions = Object.keys(repeaterContext).map((key) => ({
+			value: `{{ dataItem.${key} }}`,
+			label: `dataItem.${key}`,
+			type: "repeater item",
+		}))
+		groups.push({
+			group: "Repeater",
+			items: repeaterOptions,
+		})
+	}
+
+	// Component context
+	if (props.isEditingComponent) {
+		const componentContext = props.block?.componentContext
+		if (componentContext && Object.keys(componentContext).length > 0) {
+			const inputOptions = Object.keys(componentContext).map((inputName) => ({
+				value: `inputs.${inputName}`,
+				label: `{{ inputs.${inputName} }}`,
+				type: "component input",
+			}))
+			groups.push({
+				group: "Component Inputs",
+				items: inputOptions,
+			})
+		}
+	}
+
+	return groups
+})
+</script>

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -7,10 +7,10 @@
 		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value)"
 	>
 		<template #target="{ togglePopover }">
-			<Tooltip text="Set dynamic value" :placement="'bottom'">
+			<Tooltip text="Click to set dynamic value" placement="bottom">
 				<FeatherIcon
 					ref="dropdownTrigger"
-					name="zap"
+					name="plus-circle"
 					class="mr-1 h-3 w-4 cursor-pointer select-none text-ink-gray-5 outline-none hover:text-ink-gray-9"
 					@click="togglePopover"
 				/>

--- a/frontend/src/components/InlineInput.vue
+++ b/frontend/src/components/InlineInput.vue
@@ -29,7 +29,7 @@
 		<Autocomplete
 			v-if="type === 'autocomplete'"
 			placeholder="unset"
-			:modelValue="modelValue"
+			:modelValue="modelValue || ''"
 			:options="inputOptions"
 			@update:modelValue="handleChange"
 			:showInputAsOption="showInputAsOption"

--- a/frontend/src/components/Input.vue
+++ b/frontend/src/components/Input.vue
@@ -36,7 +36,7 @@ import { computed, useAttrs } from "vue"
 
 const props = withDefaults(
 	defineProps<{
-		modelValue?: string | number | boolean | null
+		modelValue?: string | number | boolean | object | null
 		type?: string
 		hideClearButton?: boolean
 		autofocus?: boolean

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -4,71 +4,67 @@
 		:message="`${block?.getBlockDescription()} has no editable properties`"
 	/>
 	<div v-else class="mb-4 mt-3 flex flex-col gap-3">
-		<div v-for="(config, propName) in componentProps" :key="propName">
-			<div class="flex w-full items-center">
-				<DynamicValueSelector
-					v-if="!isTestingComponent"
-					:block="block"
-					@update:modelValue="(value) => props.block?.setProp(propName, value)"
-				/>
-				<Code
-					v-if="config.inputType === 'code'"
-					:label="propName"
-					language="javascript"
-					:modelValue="config.modelValue"
-					@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
-					:required="config.required"
-					:completions="
-						(context: CompletionContext) => getCompletions(context, block?.getRepeaterDataCompletions())
-					"
-					:showLineNumbers="false"
-				/>
-				<InlineInput
-					v-else-if="propName !== 'modelValue'"
-					:label="propName"
-					:type="config.inputType"
-					:options="config.options"
-					:required="config.required"
-					:modelValue="config.modelValue"
-					@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
-					class="flex-1"
-				/>
-				<InlineInput
-					v-else-if="propName === 'modelValue'"
-					:label="propName"
-					:type="config.inputType"
-					:options="config.options"
-					:required="config.required"
-					v-model="boundValue"
-					class="flex-1"
-				/>
-				<Autocomplete
-					v-if="propName === 'modelValue'"
-					:options="store.variableOptions"
-					placeholder="Select variable"
-					@update:modelValue="(variable: SelectOption) => bindVariable(propName, variable.value)"
-					class="!w-auto"
-				>
-					<template #target="{ togglePopover }">
-						<IconButton
-							:icon="isVariableBound(config.modelValue) ? Link2Off : Link2"
-							:label="
-								isVariableBound(config.modelValue) ? 'Disable sync with variable' : 'Sync with variable'
-							"
-							placement="bottom"
-							@click="
-								() => {
-									if (isVariableBound(config.modelValue)) {
-										unbindVariable(propName)
-									} else {
-										togglePopover()
-									}
+		<div v-for="(config, propName) in componentProps" :key="propName" class="group flex w-full items-center">
+			<DynamicValueSelector
+				v-if="!isTestingComponent"
+				:block="block"
+				@update:modelValue="(value) => props.block?.setProp(propName, value)"
+			/>
+			<Code
+				v-if="config.inputType === 'code'"
+				:label="propName"
+				language="javascript"
+				:modelValue="config.modelValue"
+				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
+				:required="config.required"
+				:completions="
+					(context: CompletionContext) => getCompletions(context, block?.getRepeaterDataCompletions())
+				"
+				:showLineNumbers="false"
+			/>
+			<InlineInput
+				v-else-if="propName !== 'modelValue'"
+				:label="propName"
+				:type="config.inputType"
+				:options="config.options"
+				:required="config.required"
+				:modelValue="config.modelValue"
+				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
+				class="flex-1"
+			/>
+			<InlineInput
+				v-else-if="propName === 'modelValue'"
+				:label="propName"
+				:type="config.inputType"
+				:options="config.options"
+				:required="config.required"
+				v-model="boundValue"
+				class="flex-1"
+			/>
+			<Autocomplete
+				v-if="propName === 'modelValue'"
+				:options="store.variableOptions"
+				placeholder="Select variable"
+				@update:modelValue="(variable: SelectOption) => bindVariable(propName, variable.value)"
+				class="!w-auto"
+			>
+				<template #target="{ togglePopover }">
+					<IconButton
+						:icon="isVariableBound(config.modelValue) ? Link2Off : Link2"
+						:label="isVariableBound(config.modelValue) ? 'Disable sync with variable' : 'Sync with variable'"
+						placement="bottom"
+						@click="
+							() => {
+								if (isVariableBound(config.modelValue)) {
+									unbindVariable(propName)
+								} else {
+									togglePopover()
 								}
-							"
-						/>
-					</template>
-				</Autocomplete>
-			</div>
+							}
+						"
+					/>
+				</template>
+			</Autocomplete>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -6,22 +6,11 @@
 	<div v-else class="mb-4 mt-3 flex flex-col gap-3">
 		<div v-for="(config, propName) in componentProps" :key="propName">
 			<div class="flex w-full items-center">
-				<Autocomplete size="sm" :options="store.variableOptions" class="!w-auto">
-					<template #target="{ open }">
-						<Tooltip text="Set dynamic value" :placement="'bottom'">
-							<FeatherIcon
-								ref="dropdownTrigger"
-								name="zap"
-								class="mr-1 h-3 w-4 cursor-pointer select-none text-ink-gray-5 outline-none hover:text-ink-gray-9"
-								@click="open"
-							/>
-						</Tooltip>
-					</template>
-
-					<template #item-suffix="{ active, selected, option }">
-						<span class="text-ink-gray-4">{{ option.type?.toLowerCase() }}</span>
-					</template>
-				</Autocomplete>
+				<DynamicValueSelector
+					:block="block"
+					:isEditingComponent="isEditingComponent"
+					@update:modelValue="(value) => props.block?.setProp(propName, value)"
+				/>
 				<Code
 					v-if="config.inputType === 'code'"
 					:label="propName"
@@ -87,7 +76,7 @@
 <script setup lang="ts">
 import { computed, resolveComponent } from "vue"
 import EmptyState from "@/components/EmptyState.vue"
-import { Autocomplete, FeatherIcon, Tooltip } from "frappe-ui"
+import { Autocomplete } from "frappe-ui"
 import Block from "@/utils/block"
 
 import InlineInput from "@/components/InlineInput.vue"
@@ -105,6 +94,7 @@ import { getComponentProps } from "@/utils/components"
 import useComponentEditorStore from "@/stores/componentEditorStore"
 import type { ComponentProps } from "@/types"
 import { ComponentInput } from "@/types/Studio/StudioComponent"
+import DynamicValueSelector from "@/components/DynamicValueSelector.vue"
 
 const props = defineProps<{
 	block?: Block

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -79,7 +79,7 @@ import EmptyState from "@/components/EmptyState.vue"
 import Block from "@/utils/block"
 
 import InlineInput from "@/components/InlineInput.vue"
-import { isObjectEmpty } from "@/utils/helpers"
+import { isDynamicValue, isObjectEmpty } from "@/utils/helpers"
 import IconButton from "@/components/IconButton.vue"
 import Link2 from "~icons/lucide/link-2"
 import Link2Off from "~icons/lucide/link-2-off"
@@ -135,7 +135,7 @@ const componentProps = computed(() => {
 			config.modelValue = props.block.componentProps[propName]
 		}
 
-		if (isVariableBound(config.modelValue)) {
+		if (isDynamicValue(config.modelValue) && ["select", "checkbox"].includes(config.inputType)) {
 			config.inputType = "text"
 		}
 	})

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -9,6 +9,7 @@
 				v-if="propName === 'modelValue'"
 				:block="block"
 				@update:modelValue="(value) => bindVariable(propName, value)"
+				:class="{ 'mt-1 self-start': config.inputType === 'code' }"
 				:formatValuesAsTemplate="false"
 			>
 				<template #target="{ togglePopover }">
@@ -33,6 +34,7 @@
 			<DynamicValueSelector
 				v-else-if="!isTestingComponent"
 				:block="block"
+				:class="{ 'mt-1 self-start': config.inputType === 'code' }"
 				@update:modelValue="(value) => props.block?.setProp(propName, value)"
 			/>
 

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -5,7 +5,23 @@
 	/>
 	<div v-else class="mb-4 mt-3 flex flex-col gap-3">
 		<div v-for="(config, propName) in componentProps" :key="propName">
-			<div class="flex w-full items-center gap-2">
+			<div class="flex w-full items-center">
+				<Autocomplete size="sm" :options="store.variableOptions" class="!w-auto">
+					<template #target="{ open }">
+						<Tooltip text="Set dynamic value" :placement="'bottom'">
+							<FeatherIcon
+								ref="dropdownTrigger"
+								name="zap"
+								class="mr-1 h-3 w-4 cursor-pointer select-none text-ink-gray-5 outline-none hover:text-ink-gray-9"
+								@click="open"
+							/>
+						</Tooltip>
+					</template>
+
+					<template #item-suffix="{ active, selected, option }">
+						<span class="text-ink-gray-4">{{ option.type?.toLowerCase() }}</span>
+					</template>
+				</Autocomplete>
 				<Code
 					v-if="config.inputType === 'code'"
 					:label="propName"
@@ -71,7 +87,7 @@
 <script setup lang="ts">
 import { computed, resolveComponent } from "vue"
 import EmptyState from "@/components/EmptyState.vue"
-import { Autocomplete } from "frappe-ui"
+import { Autocomplete, FeatherIcon, Tooltip } from "frappe-ui"
 import Block from "@/utils/block"
 
 import InlineInput from "@/components/InlineInput.vue"

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -6,10 +6,36 @@
 	<div v-else class="mb-4 mt-3 flex flex-col gap-3">
 		<div v-for="(config, propName) in componentProps" :key="propName" class="group flex w-full items-center">
 			<DynamicValueSelector
-				v-if="!isTestingComponent"
+				v-if="propName === 'modelValue'"
+				:block="block"
+				@update:modelValue="(value) => bindVariable(propName, value)"
+				:formatValuesAsTemplate="false"
+			>
+				<template #target="{ togglePopover }">
+					<IconButton
+						:icon="isVariableBound(config.modelValue) ? Link2Off : Link2"
+						:label="isVariableBound(config.modelValue) ? 'Disable sync with variable' : 'Sync with variable'"
+						placement="bottom"
+						class="mr-1"
+						@click="
+							() => {
+								if (isVariableBound(config.modelValue)) {
+									unbindVariable(propName)
+								} else {
+									togglePopover()
+								}
+							}
+						"
+					/>
+				</template>
+			</DynamicValueSelector>
+
+			<DynamicValueSelector
+				v-else-if="!isTestingComponent"
 				:block="block"
 				@update:modelValue="(value) => props.block?.setProp(propName, value)"
 			/>
+
 			<Code
 				v-if="config.inputType === 'code'"
 				:label="propName"
@@ -41,30 +67,6 @@
 				v-model="boundValue"
 				class="flex-1"
 			/>
-			<Autocomplete
-				v-if="propName === 'modelValue'"
-				:options="store.variableOptions"
-				placeholder="Select variable"
-				@update:modelValue="(variable: SelectOption) => bindVariable(propName, variable.value)"
-				class="!w-auto"
-			>
-				<template #target="{ togglePopover }">
-					<IconButton
-						:icon="isVariableBound(config.modelValue) ? Link2Off : Link2"
-						:label="isVariableBound(config.modelValue) ? 'Disable sync with variable' : 'Sync with variable'"
-						placement="bottom"
-						@click="
-							() => {
-								if (isVariableBound(config.modelValue)) {
-									unbindVariable(propName)
-								} else {
-									togglePopover()
-								}
-							}
-						"
-					/>
-				</template>
-			</Autocomplete>
 		</div>
 	</div>
 </template>
@@ -72,13 +74,10 @@
 <script setup lang="ts">
 import { computed, resolveComponent } from "vue"
 import EmptyState from "@/components/EmptyState.vue"
-import { Autocomplete } from "frappe-ui"
 import Block from "@/utils/block"
 
 import InlineInput from "@/components/InlineInput.vue"
-import type { SelectOption } from "@/types"
 import { isObjectEmpty } from "@/utils/helpers"
-import useStudioStore from "@/stores/studioStore"
 import IconButton from "@/components/IconButton.vue"
 import Link2 from "~icons/lucide/link-2"
 import Link2Off from "~icons/lucide/link-2-off"
@@ -97,7 +96,6 @@ const props = defineProps<{
 	isTestingComponent?: boolean
 }>()
 
-const store = useStudioStore()
 const getCompletions = useStudioCompletions()
 
 const componentInstance = computed(() => {

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -45,9 +45,7 @@
 				:modelValue="config.modelValue"
 				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
 				:required="config.required"
-				:completions="
-					(context: CompletionContext) => getCompletions(context, block?.getRepeaterDataCompletions())
-				"
+				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 				:showLineNumbers="false"
 			/>
 			<InlineInput

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -7,8 +7,8 @@
 		<div v-for="(config, propName) in componentProps" :key="propName">
 			<div class="flex w-full items-center">
 				<DynamicValueSelector
+					v-if="!isTestingComponent"
 					:block="block"
-					:isEditingComponent="isEditingComponent"
 					@update:modelValue="(value) => props.block?.setProp(propName, value)"
 				/>
 				<Code
@@ -98,7 +98,7 @@ import DynamicValueSelector from "@/components/DynamicValueSelector.vue"
 
 const props = defineProps<{
 	block?: Block
-	isEditingComponent?: boolean
+	isTestingComponent?: boolean
 }>()
 
 const store = useStudioStore()
@@ -117,7 +117,7 @@ const componentProps = computed(() => {
 	if (!props.block || props.block.isRoot()) return {}
 
 	let propConfig
-	if (props.isEditingComponent) {
+	if (props.isTestingComponent) {
 		const componentEditorStore = useComponentEditorStore()
 		propConfig = getStudioComponentProps(componentEditorStore.componentInputs)
 	} else if (props.block.isStudioComponent) {

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -292,7 +292,7 @@ onMounted(() => {
 		getRootBlock,
 		findBlock,
 	)
-	setPanAndZoom(canvasProps, canvasEl, canvasContainerEl)
+	setPanAndZoom(canvasEl, canvasContainerEl, canvasProps)
 })
 
 defineExpose({

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -269,6 +269,10 @@ const handleClick = (e: MouseEvent) => {
 		block.setRepeaterDataItem((repeaterContext as RepeaterContext).dataItem)
 	}
 
+	if (componentContext?.value) {
+		block.setComponentContext(componentContext.value)
+	}
+
 	const slotName = (e.target as HTMLElement).dataset.slotName
 	if (slotName) {
 		const slot = block.getSlot(slotName)

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -163,15 +163,12 @@ const componentName = computed(() => {
 const repeaterContext = inject<RepeaterContext | object>("repeaterContext", {})
 const componentContext = inject<ComputedRef | null>("componentContext", null)
 const evaluationContext = computed(() => {
-	const context: any = {
+	return {
 		...store.variables,
 		...store.resources,
 		...repeaterContext,
+		...componentContext?.value,
 	}
-	if (componentContext?.value) {
-		context["inputs"] = componentContext.value
-	}
-	return context
 })
 
 const getComponentProps = () => {

--- a/frontend/src/components/StudioComponentEditorWrapper.vue
+++ b/frontend/src/components/StudioComponentEditorWrapper.vue
@@ -23,7 +23,7 @@ const componentContext = computed(() => {
 			context[input.input_name] = input.default
 		}
 	})
-	return context
+	return { inputs: context }
 })
 
 provide("componentContext", componentContext)

--- a/frontend/src/components/StudioComponentRenderer.vue
+++ b/frontend/src/components/StudioComponentRenderer.vue
@@ -31,7 +31,7 @@ const componentContext = computed(() => {
 			})
 		})
 	}
-	return context
+	return { inputs: context }
 })
 provide("componentContext", componentContext)
 

--- a/frontend/src/components/StudioComponentWrapper.vue
+++ b/frontend/src/components/StudioComponentWrapper.vue
@@ -32,7 +32,7 @@ const componentContext = computed(() => {
 			})
 		})
 	}
-	return context
+	return { inputs: context }
 })
 provide("componentContext", componentContext)
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -27,7 +27,7 @@ import type { Resource } from "@/types/Studio/StudioResource"
 import type { LeftPanelOptions, RightPanelOptions, leftPanelComponentTabOptions, SelectOption, StudioMode } from "@/types"
 import ComponentContextMenu from "@/components/ComponentContextMenu.vue"
 import { studioVariables } from "@/data/studioVariables"
-import type { Variable } from "@/types/Studio/StudioPageVariable"
+import type { Variable, VariableOption } from "@/types/Studio/StudioPageVariable"
 import { toast } from "vue-sonner"
 import { createResource } from "frappe-ui"
 
@@ -315,12 +315,17 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	const variableOptions = computed(() => {
-		const options: SelectOption[] = []
+		const options: VariableOption[] = []
 
 		function traverse(obj: any, path = "") {
 			for (const key in obj) {
 				const currentPath = path ? `${path}.${key}` : key
-				options.push({ value: currentPath, label: currentPath })
+				const variableType = path === "" ? variableConfigs.value[key]?.variable_type : typeof obj[key]
+				options.push({
+					value: currentPath,
+					label: currentPath,
+					type: variableType
+				})
 
 				if (typeof obj[key] === "object" && obj[key] !== null) {
 					// add nested properties
@@ -330,9 +335,6 @@ const useStudioStore = defineStore("store", () => {
 		}
 
 		traverse(variables.value)
-		if (options.length) {
-			options.unshift({ value: "", label: "" })
-		}
 		return options
 	})
 

--- a/frontend/src/types/Studio/StudioPageVariable.ts
+++ b/frontend/src/types/Studio/StudioPageVariable.ts
@@ -1,6 +1,10 @@
+import { SelectOption } from "@/types"
+
 export type Variable = {
 	name: string
 	variable_name: string
 	variable_type: string
 	initial_value: string | number | boolean | null | object
 }
+
+export type VariableOption = SelectOption & { type: string }

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -35,8 +35,9 @@ class Block implements BlockOptions {
 	isStudioComponent?: boolean
 	isChildOfComponent?: string
 	extendedFromComponent?: Block // for the component root
-	// temporary property
+	// temporary properties
 	repeaterDataItem?: Record<string, any> | null
+	componentContext?: Record<string, any> | null
 
 	// @editor-only
 	private static components: FrappeUIComponents | null = null
@@ -86,6 +87,12 @@ class Block implements BlockOptions {
 		// Define as non-reactive property
 		Object.defineProperty(this, "repeaterDataItem", {
 			value: options.repeaterDataItem || null,
+			writable: true,
+			enumerable: false,
+			configurable: true
+		})
+		Object.defineProperty(this, "componentContext", {
+			value: options.componentContext || null,
 			writable: true,
 			enumerable: false,
 			configurable: true
@@ -700,6 +707,11 @@ class Block implements BlockOptions {
 			})
 		}
 		linkParentComponentId(this, studioComponent.componentId)
+	}
+
+	setComponentContext(componentContext: Record<string, any>) {
+		// temporarily set componentContext on selected block for autocompletions
+		this.componentContext = componentContext
 	}
 }
 

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -645,9 +645,10 @@ class Block implements BlockOptions {
 		this.repeaterDataItem = repeaterDataItem
 	}
 
-	getRepeaterDataCompletions(): CompletionSource[] {
+	getCompletions(): CompletionSource[] {
+		const completions = []
 		if (this.repeaterDataItem) {
-			return [
+			completions.push(
 				{
 					item: this.repeaterDataItem,
 					completion: {
@@ -655,7 +656,9 @@ class Block implements BlockOptions {
 						type: "data",
 						detail: "Repeater Data Item",
 					}
-				},
+				}
+			)
+			completions.push(
 				{
 					item: "dataIndex",
 					completion: {
@@ -664,9 +667,22 @@ class Block implements BlockOptions {
 						detail: "Repeater Data Index",
 					}
 				}
-			]
+			)
 		}
-		return []
+		if (this.componentContext) {
+			completions.push(
+				{
+					item: this.componentContext.inputs || {},
+					completion: {
+						label: "inputs",
+						type: "data",
+						detail: "Component Context",
+					}
+				},
+			)
+		}
+
+		return completions
 	}
 
 	// events

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -88,6 +88,7 @@ function getBlockCopyWithoutParent(block: BlockOptions | Block) {
 	const blockCopy = deepCloneObject(rawBlock, ["parentBlock"]) as BlockOptions
 	delete blockCopy.parentBlock
 	delete blockCopy.repeaterDataItem
+	delete blockCopy.componentContext
 
 	blockCopy.children = blockCopy.children?.map((child) => getBlockCopyWithoutParent(child))
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -425,12 +425,18 @@ function evaluateExpression(expression: string, context: ExpressionEvaluationCon
 	}
 }
 
-function executeUserScript(script: string, variables: Record<string, any>, resources: Record<string, any>, repeaterContext?: Record<string, any>) {
+function executeUserScript(
+	script: string,
+	variables: Record<string, any>,
+	resources: Record<string, any>,
+	repeaterContext?: Record<string, any>,
+	componentContext?: Record<string, any>,
+) {
 	try {
 		// Pass variable refs as context so that users can access variables without 'variable.' prefix
 		// eg: - {{ variable_name }} in templates or variable_name.value in scripts
 		const variablesRefs = toRefs(variables)
-		const context = { ...variablesRefs, ...resources, ...repeaterContext }
+		const context = { ...variablesRefs, ...resources, ...repeaterContext, ...componentContext }
 
 		const scriptToExecute = `
 			with (context) {


### PR DESCRIPTION
## Before:

Tedious. It's faster in code prop fields with autocompletion and bracket completion. But direct selection is still better

https://github.com/user-attachments/assets/bc51a4c2-fe1d-4193-8520-61f5347be8df

## After:

Faster dynamic value setting using a selector

https://github.com/user-attachments/assets/84356d2c-d14c-4439-8ad0-6bbbcb5cfae1

Displays variables, data sources, repeater & component context applicable for selected block. Types displayed inline

<img width="275" height="442" alt="image" src="https://github.com/user-attachments/assets/708859da-89f7-41a7-b341-8fdf95553e88" />

Other fixes:
- Code editor was not reflecting changes to modelValue after first load (reactivity broken)
