### PR TITLE
fix(publish): continue publishing even if app build errors out

### DIFF
--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -195,7 +195,11 @@ const useStudioStore = defineStore("store", () => {
 	async function publishPage() {
 		if (!selectedPage.value) return
 
-		await generateAppBuild()
+		try {
+			await generateAppBuild()
+		} catch (error) {
+			// continue to publish page even if app build generation fails
+		}
 		return studioPages.runDocMethod
 			.submit(
 				{
@@ -255,7 +259,7 @@ const useStudioStore = defineStore("store", () => {
 				toast.success("App build generated")
 			},
 			onError(error: any) {
-				toast.error("Failed to generate app build", {
+				toast.warning("Skipped app build due to errors", {
 					description: error?.messages?.join(", "),
 					duration: Infinity,
 				})

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import frappe
+from frappe.commands import popen
 from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.website_generator import WebsiteGenerator
 
@@ -144,7 +145,7 @@ class StudioApp(WebsiteGenerator):
 		try:
 			command = f"yarn build-studio-app {self.name} --components {','.join(list(components))}"
 			studio_app_path = frappe.get_app_source_path("studio")
-			frappe.commands.popen(command, cwd=studio_app_path, raise_err=True)
+			popen(command, cwd=studio_app_path, raise_err=True)
 		except Exception as e:
 			raise Exception(f"Build process failed: {str(e)}")
 


### PR DESCRIPTION
- Explicitly import `popen`. It's not available on prod

- Continue publishing even if the app build fails on prod and warn.

<img width="458" height="141" alt="image" src="https://github.com/user-attachments/assets/9789180c-a259-4388-80af-2b4bafd1f5fb" />

On-the-fly yarn builds are failing on prod. Will dig into this later. Might be memory issues