### PR TITLE
feat: allow passing params in API Data Source

### DIFF
--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
 		label?: string
 		required?: boolean
 		readonly?: boolean
+		borderless?: boolean
 	}>(),
 	{
 		language: "javascript",
@@ -52,6 +53,7 @@ const props = withDefaults(
 		maxHeight: "250px",
 		showLineNumbers: true,
 		completions: null,
+		borderless: false,
 	},
 )
 const emit = defineEmits(["update:modelValue", "save"])
@@ -168,6 +170,12 @@ const extensions = computed(() => {
 			".cm-gutters": {
 				display: props.showLineNumbers ? "flex" : "none",
 			},
+			...(props.borderless && {
+				"&.cm-editor": {
+					border: "none !important",
+					borderRadius: "0 !important",
+				},
+			}),
 		}),
 	]
 	if (languageExtension.value) {

--- a/frontend/src/components/Filters.vue
+++ b/frontend/src/components/Filters.vue
@@ -31,7 +31,7 @@
 								placeholder="Operator"
 							/>
 						</div>
-						<div id="value" class="!min-w-[140px] flex-1">
+						<div id="value" class="flex-1">
 							<Link
 								v-if="typeLink.includes(filter.field.fieldtype) && ['=', '!='].includes(filter.operator)"
 								:doctype="filter.field.options as string"

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -178,6 +178,7 @@ const deleteRows = () => {
 .grid-row input:focus,
 .grid-row input:hover {
 	box-shadow: none;
+	outline: none;
 }
 
 .grid-row input:focus-within {

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -56,6 +56,16 @@
 									class="text-sm text-gray-800"
 									@update:modelValue="(e) => column.onChange && column.onChange(e, index)"
 								/>
+								<Code
+									v-else-if="column.fieldtype === 'Code'"
+									language="javascript"
+									v-model="row[column.fieldname]"
+									:showLineNumbers="false"
+									@change="
+										(e: Event) =>
+											column.onChange && column.onChange((e.target as HTMLInputElement).value, index)
+									"
+								/>
 								<FormControl
 									v-else
 									:type="column.fieldtype.toLowerCase()"

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -26,7 +26,6 @@
 				>
 					{{ column.label }}
 				</div>
-				<div class="p-1 text-center text-base text-gray-900"></div>
 			</div>
 
 			<!-- Rows -->
@@ -82,9 +81,6 @@
 									"
 								/>
 							</div>
-							<button @click="" class="flex items-center justify-center">
-								<FeatherIcon name="edit-2" class="h-3 w-3 text-gray-800" />
-							</button>
 						</div>
 					</template>
 				</Draggable>
@@ -123,9 +119,6 @@ const gridTemplateColumns = computed(() => {
 	// for the checkbox & sr no. columns
 	let columns = "0.75fr 0.75fr"
 	columns += " " + props.columns.map((col) => `minmax(0, ${col.width || 2}fr)`).join(" ")
-	// for the edit button column
-	columns += " 0.75fr"
-
 	return columns
 })
 

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -61,6 +61,7 @@
 									language="javascript"
 									v-model="row[column.fieldname]"
 									:showLineNumbers="false"
+									:borderless="true"
 									@change="
 										(e: Event) =>
 											column.onChange && column.onChange((e.target as HTMLInputElement).value, index)

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -62,6 +62,7 @@
 									v-model="row[column.fieldname]"
 									:showLineNumbers="false"
 									:borderless="true"
+									:completions="column.completions || null"
 									@change="
 										(e: Event) =>
 											column.onChange && column.onChange((e.target as HTMLInputElement).value, index)

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -36,7 +36,7 @@
 						label="Parameters"
 						:columns="[
 							{ label: 'Key', fieldname: 'key', fieldtype: 'Data' },
-							{ label: 'Value', fieldname: 'value', fieldtype: 'Code' },
+							{ label: 'Value', fieldname: 'value', fieldtype: 'Code', completions: getCompletions },
 						]"
 						:rows="newResource.params || []"
 						:showDeleteBtn="true"

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -32,6 +32,16 @@
 						:options="['GET', 'POST', 'PUT', 'DELETE']"
 						v-model="newResource.method"
 					/>
+					<Grid
+						label="Parameters"
+						:columns="[
+							{ label: 'Key', fieldname: 'key', fieldtype: 'Data' },
+							{ label: 'Value', fieldname: 'value', fieldtype: 'Data' },
+						]"
+						:rows="newResource.params || []"
+						:showDeleteBtn="true"
+						@update:rows="(val) => (newResource.params = val)"
+					/>
 				</template>
 
 				<Link
@@ -139,6 +149,7 @@ import Link from "@/components/Link.vue"
 import Code from "@/components/Code.vue"
 import InputLabel from "@/components/InputLabel.vue"
 import Filters from "@/components/Filters.vue"
+import Grid from "@/components/Grid.vue"
 
 import type { DocTypeField } from "@/types"
 import type { ResourceType, Resource } from "@/types/Studio/StudioResource"
@@ -158,6 +169,7 @@ const emptyResource: Resource = {
 	resource_type: "Document List",
 	url: "",
 	method: "GET",
+	params: [],
 	document_type: "",
 	document_name: "",
 	fetch_document_using_filters: false,
@@ -196,6 +208,7 @@ async function getResourceToEdit() {
 		resource_name: props.resource?.resource_name,
 		filters: filters,
 		fields: JSON.parse(props.resource?.fields || "[]"),
+		params: JSON.parse(props.resource?.params || "[]"),
 		limit: props.resource?.limit || null,
 		whitelisted_methods: JSON.parse(props.resource?.whitelisted_methods || "[]"),
 	} as Resource
@@ -272,7 +285,9 @@ watch(
 	() => [newResource.value?.resource_type, newResource.value?.transform_results],
 	([resource_type, transform_results]) => {
 		if (!resource_type || !transform_results || newResource.value.transform) return
-		newResource.value.transform = getTransformFnBoilerplate(resource_type)
+		if (typeof resource_type === "string") {
+			newResource.value.transform = getTransformFnBoilerplate(resource_type as ResourceType)
+		}
 	},
 )
 

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -36,7 +36,7 @@
 						label="Parameters"
 						:columns="[
 							{ label: 'Key', fieldname: 'key', fieldtype: 'Data' },
-							{ label: 'Value', fieldname: 'value', fieldtype: 'Data' },
+							{ label: 'Value', fieldname: 'value', fieldtype: 'Code' },
 						]"
 						:rows="newResource.params || []"
 						:showDeleteBtn="true"

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -82,7 +82,7 @@
 						v-model="newResource.document_name"
 					/>
 
-					<div class="flex w-full flex-row gap-1.5">
+					<div class="flex w-full flex-row items-center gap-1.5">
 						<FormControl size="sm" type="checkbox" v-model="newResource.fetch_document_using_filters" />
 						<InputLabel class="max-w-full">Dynamically fetch document using filters</InputLabel>
 					</div>

--- a/frontend/src/data/studioResources.ts
+++ b/frontend/src/data/studioResources.ts
@@ -14,6 +14,7 @@ export const studioPageResources = createListResource({
 		"fetch_document_using_filters",
 		"url",
 		"method",
+		"params",
 		"whitelisted_methods",
 		"transform_results",
 		"transform",

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -37,7 +37,6 @@ watch(
 		if (currentPath) {
 			page.value = await findPageWithRoute(window.app_name, currentPath)
 			if (!page.value) return
-			await store.setLocalState({ route: route })
 			await store.setPageData(page.value)
 			await store.setPageWatchers(page.value)
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -291,8 +291,8 @@ const useStudioStore = defineStore("store", () => {
 	const variables = ref<Record<string, any>>({})
 
 	async function setPageData(page: StudioPage) {
-		await setPageResources(page)
 		await setPageVariables(page)
+		await setPageResources(page)
 	}
 
 	async function setPageResources(page: StudioPage) {
@@ -301,7 +301,10 @@ const useStudioStore = defineStore("store", () => {
 		resources.value = {}
 
 		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
-			const newResource = await getNewResource(resource)
+			const newResource = await getNewResource(resource, {
+				...variables.value,
+				route: routeObject.value,
+			})
 			return {
 				resource_name: resource.resource_name,
 				value: newResource,

--- a/frontend/src/styles/codemirror.css
+++ b/frontend/src/styles/codemirror.css
@@ -1,8 +1,3 @@
-.cm-editor {
-	user-select: text;
-	padding: 0px !important;
-	position: relative !important;
-}
 .cm-gutters {
 	@apply !border-0 !bg-transparent !px-1.5 !text-xs !leading-6 !text-gray-500;
 }
@@ -21,6 +16,8 @@
 .cm-editor {
 	width: 100%;
 	user-select: text;
+	padding: 0px !important;
+	position: relative !important;
 	@apply rounded border border-outline-gray-2;
 }
 .cm-placeholder {

--- a/frontend/src/types/Studio/StudioResource.ts
+++ b/frontend/src/types/Studio/StudioResource.ts
@@ -34,6 +34,7 @@ export interface APIResource extends BaseResource {
 	url: string
 	method: "GET" | "POST" | "PUT" | "DELETE"
 	filters?: Filters
+	params?: string
 }
 
 export type Resource = DocumentResource | DocumentListResource | APIResource

--- a/frontend/src/types/doctype.ts
+++ b/frontend/src/types/doctype.ts
@@ -41,6 +41,8 @@ export interface GridColumn {
 	options?: string | string[]
 	width?: number
 	onChange?: (value: string, index: number) => void
+	// for code field
+	completions?: Function | null
 }
 
 export interface GridRow {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -400,6 +400,29 @@ function getEvaluatedFilters(filters: Filters | null = null, context: Expression
 	return evaluatedFilters
 }
 
+function getAPIParams(params: string | null = null, context: ExpressionEvaluationContext) {
+	if (!params) return null
+	if (typeof params === "string") {
+		params = JSON.parse(params)
+	}
+
+	console.log("API params before evaluation:", params, context)
+
+	if (params && Array.isArray(params)) {
+		const evaluatedParams: Record<string, any> = {}
+		params.forEach((param) => {
+			let value = param.value
+			if (isDynamicValue(value)) {
+				evaluatedParams[param.key] = getDynamicValue(value, context)
+			} else {
+				evaluatedParams[param.key] = value
+			}
+		})
+		return evaluatedParams
+	}
+	return params
+}
+
 function evaluateExpression(expression: string, context: ExpressionEvaluationContext) {
 	try {
 		// Replace dot notation with optional chaining
@@ -533,6 +556,7 @@ function getNewResource(resource: Resource, context?: ExpressionEvaluationContex
 			return createResource({
 				url: resource.url,
 				method: resource.method,
+				params: getAPIParams(resource.params, context),
 				auto: true,
 				...getTransforms(resource),
 			})

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -406,8 +406,6 @@ function getAPIParams(params: string | null = null, context: ExpressionEvaluatio
 		params = JSON.parse(params)
 	}
 
-	console.log("API params before evaluation:", params, context)
-
 	if (params && Array.isArray(params)) {
 		const evaluatedParams: Record<string, any> = {}
 		params.forEach((param) => {

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -190,6 +190,9 @@ class StudioPage(Document):
 		if isinstance(resource.whitelisted_methods, list):
 			resource.whitelisted_methods = frappe.as_json(resource.whitelisted_methods, indent=None)
 
+		if isinstance(resource.params, list):
+			resource.params = frappe.as_json(resource.params, indent=None)
+
 	def before_export(self, doc):
 		doc.name = self.get_export_docname()
 		remove_null_fields(doc)

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.json
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.json
@@ -20,8 +20,9 @@
   "whitelisted_methods",
   "api_resource_section",
   "url",
-  "column_break_cvbv",
   "method",
+  "column_break_cvbv",
+  "params",
   "transform_section",
   "transform_results",
   "transform"
@@ -79,6 +80,12 @@
    "fieldtype": "Select",
    "label": "API Method",
    "options": "GET\nPOST\nPUT\nDELETE"
+  },
+  {
+   "fieldname": "params",
+   "fieldtype": "JSON",
+   "label": "API Parameters",
+   "max_height": "100px"
   },
   {
    "fieldname": "transform_section",
@@ -143,7 +150,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-27 12:04:03.047249",
+ "modified": "2025-09-08 23:48:04.431164",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Resource",

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.py
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.py
@@ -21,6 +21,7 @@ class StudioPageResource(Document):
 		filters: DF.JSON | None
 		limit: DF.Int
 		method: DF.Literal["GET", "POST", "PUT", "DELETE"]
+		params: DF.JSON | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data


### PR DESCRIPTION
**Before**:

Data Source of type API did not support providing params

**After:**

**Static param value:**

<img width="779" height="694" alt="image" src="https://github.com/user-attachments/assets/543c6093-438a-4c13-b3ff-5ee1cc575e0e" />
<br>

**Dynamic param value referencing a variable. You can use variables/route object properties here**


<img width="779" height="694" alt="image" src="https://github.com/user-attachments/assets/f964a735-9d24-43d2-947b-317e89ba1f9f" />
<br>

**Output:**


<img width="408" height="598" alt="image" src="https://github.com/user-attachments/assets/35213d94-ee3b-44a0-8515-9cefd8a10416" />

## Other

- Support Code field in Grid.
- Option to make the Code editor borderless using a prop. Used it in Grid control
- fix: remove unused edit button from Grid
- fix: removed outline from Grid input fields
- fix: Filter bar was overflowing