### PR TITLE
fix: Adding container inside slot & Wrap in Container operation for slot block

### DIFF
--- a/frontend/src/components/ComponentContextMenu.vue
+++ b/frontend/src/components/ComponentContextMenu.vue
@@ -73,7 +73,6 @@ const contextMenuOptions: ContextMenuOption[] = [
 			const newBlockObj = getBlockTemplate("fit-container")
 			if (block.value.isSlotBlock()) {
 				newBlockObj.parentSlotName = block.value.parentSlotName
-				delete block.value.parentSlotName
 			}
 
 			const selectedBlocks = canvasStore.activeCanvas?.selectedBlocks || []
@@ -85,7 +84,9 @@ const contextMenuOptions: ContextMenuOption[] = [
 			selectedBlocks
 				.sort((a, b) => parentBlock.getChildIndex(a) - parentBlock.getChildIndex(b))
 				.forEach((block) => {
+					// Remove from parent first
 					parentBlock?.removeChild(block)
+					// Clear slot reference before adding to container
 					if (block.parentSlotName) {
 						delete block.parentSlotName
 					}

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -291,6 +291,7 @@ onMounted(() => {
 		history as CanvasHistory,
 		getRootBlock,
 		findBlock,
+		selectedSlot,
 	)
 	setPanAndZoom(canvasEl, canvasContainerEl, canvasProps)
 })

--- a/frontend/src/utils/useCanvasEvents.ts
+++ b/frontend/src/utils/useCanvasEvents.ts
@@ -8,6 +8,7 @@ import {
 import { clamp, useEventListener } from "@vueuse/core";
 import { Ref } from "vue";
 import type { CanvasProps, CanvasHistory } from "@/types/StudioCanvas"
+import type { Slot } from "@/types";
 
 const store = useStudioStore();
 
@@ -17,6 +18,7 @@ export function useCanvasEvents(
 	canvasHistory: CanvasHistory,
 	getRootBlock: () => Block,
 	findBlock: (componentId: string) => Block | null,
+	selectedSlot: Ref<Slot | null>,
 ) {
 	useEventListener(container, "mousedown", (ev: MouseEvent) => {
 		const initialX = ev.clientX;
@@ -54,7 +56,14 @@ export function useCanvasEvents(
 			const parentWidth = pxToNumber(getComputedStyle(parentElement).width);
 			const parentHeight = pxToNumber(getComputedStyle(parentElement).height);
 
-			const childBlock = parentBlock.addChild(child);
+			let childBlock
+			// if a slot is selected and the slot belongs to the parent block, add the new block to the slot
+			if (selectedSlot.value && selectedSlot.value?.parentBlockId === parentBlock.componentId) {
+				childBlock = parentBlock.updateSlot(selectedSlot.value.slotName, child)
+			} else {
+				childBlock = parentBlock.addChild(child);
+			}
+
 			if (!childBlock) return
 
 			childBlock.setBaseStyle("position", "absolute");


### PR DESCRIPTION
**Adding a container to the selected slot doesn't work. If the selected slot belongs to a block parent, drop the new child block in the slot; else, add it as a block child**

_Before:_

https://github.com/user-attachments/assets/a250cc82-5756-4a24-912e-d07646d9db91

_After:_

https://github.com/user-attachments/assets/6cc11e28-986c-4835-bbbb-38dd5a48b952

<hr>

**'Wrap in container' for a slot block was faulty. It wrapped the block in a container inside the slot but did not remove/clear the old block - resulting in 2 blocks inside the slot - one within the container & one outside**


_Before:_

https://github.com/user-attachments/assets/99752230-d0f4-4d1e-be08-74295732348c

_After:_

https://github.com/user-attachments/assets/f5c90114-c331-4094-9ac5-ffecebecd502

ToDo: make slot interaction code less convoluted