### PR TITLE
feat!: allow passing params in API Call

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -47,6 +47,7 @@ import {
 	executeUserScript,
 	getValueFromObject,
 	setValueInObject,
+	getAPIParams,
 } from "@/utils/helpers"
 import { useScreenSize } from "@/utils/useScreenSize"
 
@@ -191,7 +192,7 @@ const componentEvents = computed(() => {
 						createResource({
 							url: event.api_endpoint,
 							auto: true,
-							params: event.params,
+							params: getAPIParams(event.params, evaluationContext.value),
 						})
 					}
 				}

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -191,6 +191,7 @@ const componentEvents = computed(() => {
 						createResource({
 							url: event.api_endpoint,
 							auto: true,
+							params: event.params,
 						})
 					}
 				}

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -170,7 +170,7 @@ import useStudioStore from "@/stores/studioStore"
 import Block from "@/utils/block"
 import EmptyState from "@/components/EmptyState.vue"
 
-import { isObjectEmpty, confirm } from "@/utils/helpers"
+import { isObjectEmpty, confirm, getParamsArray } from "@/utils/helpers"
 
 import type { SelectOption } from "@/types"
 import type { Actions, ActionConfigurations, ComponentEvent } from "@/types/ComponentEvent"
@@ -181,6 +181,7 @@ import { useStudioCompletions } from "@/utils/useStudioCompletions"
 import type { DocTypeField } from "@/types"
 import { toast } from "vue-sonner"
 import type { CompletionContext } from "@codemirror/autocomplete"
+import { getParamsObj } from "@/utils/helpers"
 
 const props = defineProps<{
 	block?: Block
@@ -194,7 +195,9 @@ const emptyEvent: ComponentEvent = {
 	action: "Run Script",
 	page: "",
 	url: "",
+	// call api
 	api_endpoint: "",
+	params: [],
 	// insert document
 	doctype: "",
 	fields: [],
@@ -302,6 +305,30 @@ const actions: ActionConfigurations = {
 			events: {
 				"update:modelValue": (val: string) => {
 					newEvent.value.api_endpoint = val
+				},
+			},
+		},
+		{
+			component: Grid,
+			getProps: () => {
+				return {
+					label: "Parameters",
+					columns: [
+						{ label: "Key", fieldname: "key", fieldtype: "Data" },
+						{
+							label: "Value",
+							fieldname: "value",
+							fieldtype: "Code",
+							completions: getCompletions,
+						},
+					],
+					rows: newEvent.value.params || [],
+					showDeleteBtn: true,
+				}
+			},
+			events: {
+				"update:rows": (val: any) => {
+					newEvent.value.params = val
 				},
 			},
 		},
@@ -424,6 +451,9 @@ function getEvent(event: ComponentEvent): ComponentEvent {
 	} else if (event.action === "Call API") {
 		_event.api_endpoint = event.api_endpoint
 		setEventCallbackFields(_event, event)
+		if (Array.isArray(event.params)) {
+			_event.params = getParamsObj(event.params)
+		}
 	} else if (event.action === "Insert a Document") {
 		_event.doctype = event.doctype
 		_event.fields = event.fields
@@ -481,7 +511,12 @@ const getEventMenu = (event: ComponentEvent) => {
 			label: "Edit",
 			icon: "edit",
 			onClick: async () => {
-				newEvent.value = { ...event, isEditing: true, oldEvent: event.event }
+				newEvent.value = {
+					...event,
+					isEditing: true,
+					oldEvent: event.event,
+					params: getParamsArray(event.params),
+				}
 				showAddEventDialog.value = true
 			},
 		},

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -187,7 +187,8 @@ const props = defineProps<{
 	block?: Block
 }>()
 const store = useStudioStore()
-const getCompletions = useStudioCompletions(true)
+const getEditorCompletions = useStudioCompletions(true)
+const getCompletions = useStudioCompletions()
 
 const showAddEventDialog = ref(false)
 const emptyEvent: ComponentEvent = {
@@ -281,7 +282,8 @@ const actions: ActionConfigurations = {
 					height: "400px",
 					maxHeight: "400px",
 					emitOnChange: true,
-					completions: (context: CompletionContext) => getCompletions(context, props.block?.getCompletions()),
+					completions: (context: CompletionContext) =>
+						getEditorCompletions(context, props.block?.getCompletions()),
 				}
 			},
 			events: {

--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -252,6 +252,7 @@ const getResourceValues = (resource: Resource) => {
 		name: resource.resource_id,
 		fields: getAutocompleteValues(resource.fields),
 		whitelisted_methods: getAutocompleteValues(resource.whitelisted_methods),
+		params: getResourceParams(resource.params),
 	}
 }
 
@@ -284,6 +285,16 @@ const getResourceMenu = (resource: Resource, resource_name: string) => {
 			},
 		},
 	]
+}
+
+const getResourceParams = (params: { key: string; value: string }[]) => {
+	const paramsObj: { [key: string]: string } = {}
+	params.forEach((param) => {
+		if (param.key) {
+			paramsObj[param.key] = param.value
+		}
+	})
+	return paramsObj
 }
 
 // variables

--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -170,7 +170,7 @@ import EmptyState from "@/components/EmptyState.vue"
 import ResourceDialog from "@/components/ResourceDialog.vue"
 import Code from "@/components/Code.vue"
 
-import { isObjectEmpty, getAutocompleteValues, confirm, copyToClipboard } from "@/utils/helpers"
+import { isObjectEmpty, getAutocompleteValues, getParamsObj, confirm, copyToClipboard } from "@/utils/helpers"
 import { studioPageResources } from "@/data/studioResources"
 import { studioVariables } from "@/data/studioVariables"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
@@ -252,7 +252,7 @@ const getResourceValues = (resource: Resource) => {
 		name: resource.resource_id,
 		fields: getAutocompleteValues(resource.fields),
 		whitelisted_methods: getAutocompleteValues(resource.whitelisted_methods),
-		params: getResourceParams(resource.params),
+		params: getParamsObj(resource.params),
 	}
 }
 
@@ -285,16 +285,6 @@ const getResourceMenu = (resource: Resource, resource_name: string) => {
 			},
 		},
 	]
-}
-
-const getResourceParams = (params: { key: string; value: string }[]) => {
-	const paramsObj: { [key: string]: string } = {}
-	params.forEach((param) => {
-		if (param.key) {
-			paramsObj[param.key] = param.value
-		}
-	})
-	return paramsObj
 }
 
 // variables

--- a/frontend/src/components/Filters.vue
+++ b/frontend/src/components/Filters.vue
@@ -91,6 +91,7 @@ import Link from "@/components/Link.vue"
 
 import type { DocTypeField, Fieldtype, Filter, Operators } from "@/types"
 import { isObjectEmpty } from "@/utils/helpers"
+import type { Filters } from "@/types/Studio/StudioResource"
 
 const typeCheck = ["Check"]
 const typeLink = ["Link"]
@@ -102,8 +103,8 @@ const emits = defineEmits(["update:modelValue"])
 
 const props = withDefaults(
 	defineProps<{
-		label: string
-		modelValue: Record<string, any>
+		label?: string
+		modelValue?: Filters
 		docfields: DocTypeField[]
 	}>(),
 	{
@@ -147,7 +148,7 @@ watch(
 	{ deep: true },
 )
 
-function makeFiltersList(filtersDict: Record<string, [Operators, any]>) {
+function makeFiltersList(filtersDict: Filters) {
 	if (!fields.value.length || isObjectEmpty(filtersDict)) return []
 
 	return Object.entries(filtersDict).map(([fieldname, [operator, value]]) => {

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -38,7 +38,7 @@
 							{ label: 'Key', fieldname: 'key', fieldtype: 'Data' },
 							{ label: 'Value', fieldname: 'value', fieldtype: 'Code', completions: getCompletions },
 						]"
-						:rows="newResource.params || []"
+						:rows="Array.isArray(newResource.params) ? newResource.params : []"
 						:showDeleteBtn="true"
 						@update:rows="(val) => (newResource.params = val)"
 					/>
@@ -209,10 +209,19 @@ async function getResourceToEdit() {
 		resource_name: props.resource?.resource_name,
 		filters: filters,
 		fields: JSON.parse(props.resource?.fields || "[]"),
-		params: JSON.parse(props.resource?.params || "[]"),
+		params: getParams(props.resource?.params),
 		limit: props.resource?.limit || null,
 		whitelisted_methods: JSON.parse(props.resource?.whitelisted_methods || "[]"),
 	} as Resource
+}
+
+function getParams(params: string) {
+	params = JSON.parse(params || "{}")
+	const paramsArray: { key: string; value: string; name: string }[] = []
+	Object.entries(params).forEach(([key, value]) => {
+		paramsArray.push({ key, value, name: key })
+	})
+	return paramsArray
 }
 
 function getParsedFilters(filters: string | object | undefined) {

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -154,7 +154,7 @@ import Grid from "@/components/Grid.vue"
 
 import type { DocTypeField } from "@/types"
 import type { ResourceType, Resource } from "@/types/Studio/StudioResource"
-import { isObjectEmpty } from "@/utils/helpers"
+import { getParamsArray, isObjectEmpty } from "@/utils/helpers"
 import { useStudioCompletions } from "@/utils/useStudioCompletions"
 
 const props = defineProps<{
@@ -209,19 +209,10 @@ async function getResourceToEdit() {
 		resource_name: props.resource?.resource_name,
 		filters: filters,
 		fields: JSON.parse(props.resource?.fields || "[]"),
-		params: getParams(props.resource?.params),
+		params: getParamsArray(props.resource?.params),
 		limit: props.resource?.limit || null,
 		whitelisted_methods: JSON.parse(props.resource?.whitelisted_methods || "[]"),
 	} as Resource
-}
-
-function getParams(params: string) {
-	params = JSON.parse(params || "{}")
-	const paramsArray: { key: string; value: string; name: string }[] = []
-	Object.entries(params).forEach(([key, value]) => {
-		paramsArray.push({ key, value, name: key })
-	})
-	return paramsArray
 }
 
 function getParsedFilters(filters: string | object | undefined) {

--- a/frontend/src/types/ComponentEvent.ts
+++ b/frontend/src/types/ComponentEvent.ts
@@ -15,6 +15,7 @@ export type ComponentEvent = {
 	action: Actions
 	/** action = 'Call API */
 	api_endpoint?: string
+	params?: Record<string, any>
 	/** action = 'Switch App Page */
 	page?: string
 	/** action = 'Open Webpage' */

--- a/frontend/src/types/Studio/StudioResource.ts
+++ b/frontend/src/types/Studio/StudioResource.ts
@@ -1,5 +1,6 @@
+import type { Operators } from "@/types"
 export type ResourceType = "API Resource" | "Document List" | "Document"
-export type Filters = Record<string, string | string[]>
+export type Filters = Record<string, [Operators, any]>
 
 interface BaseResource {
 	/**	Child Table record name = Resource ID */
@@ -34,7 +35,7 @@ export interface APIResource extends BaseResource {
 	url: string
 	method: "GET" | "POST" | "PUT" | "DELETE"
 	filters?: Filters
-	params?: string
+	params?: Record<string, any>
 }
 
 export type Resource = DocumentResource | DocumentListResource | APIResource

--- a/frontend/src/types/doctype.ts
+++ b/frontend/src/types/doctype.ts
@@ -48,5 +48,5 @@ export interface GridColumn {
 
 export interface GridRow {
 	name: string
-	[fieldname: string]: string | number | boolean
+	[fieldname: string]: string | number | boolean | unknown
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -339,6 +339,28 @@ function getAutocompleteValues(data: SelectOption[]) {
 	return (data || []).map((d) => d["value"])
 }
 
+function getParamsObj(params: { key: string; value: string }[]) {
+	const paramsObj: { [key: string]: string } = {}
+	params.forEach((param) => {
+		if (param.key) {
+			paramsObj[param.key] = param.value
+		}
+	})
+	return paramsObj
+}
+
+function getParamsArray(params: string | { [key: string]: string }) {
+	if (!params) return []
+	if (typeof params == "string") {
+		params = JSON.parse(params || "{}")
+	}
+	const paramsArray: { key: string; value: string; name: string }[] = []
+	Object.entries(params).forEach(([key, value]) => {
+		paramsArray.push({ key, value, name: key })
+	})
+	return paramsArray
+}
+
 const isDynamicValue = (value: string) => {
 	// Check if the prop value is a string and contains a dynamic expression
 	if (typeof value !== "string") return false
@@ -786,6 +808,8 @@ export {
 	findPageWithRoute,
 	// data
 	getAutocompleteValues,
+	getParamsObj,
+	getParamsArray,
 	isDynamicValue,
 	getDynamicValue,
 	evaluateExpression,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -423,23 +423,17 @@ function getEvaluatedFilters(filters: Filters | null = null, context: Expression
 	return evaluatedFilters
 }
 
-function getAPIParams(params: string | null = null, context: ExpressionEvaluationContext) {
+function getAPIParams(params: Record<string, any> | string | null = null, context: ExpressionEvaluationContext) {
 	if (!params) return null
 	if (typeof params === "string") {
 		params = JSON.parse(params)
 	}
-
-	if (params && Array.isArray(params)) {
-		const evaluatedParams: Record<string, any> = {}
-		params.forEach((param) => {
-			let value = param.value
+	if (params && typeof params === "object") {
+		Object.entries(params).forEach(([key, value]) => {
 			if (isDynamicValue(value)) {
-				evaluatedParams[param.key] = getDynamicValue(value, context)
-			} else {
-				evaluatedParams[param.key] = value
+				params[key] = getDynamicValue(value, context)
 			}
 		})
-		return evaluatedParams
 	}
 	return params
 }
@@ -810,6 +804,7 @@ export {
 	getAutocompleteValues,
 	getParamsObj,
 	getParamsArray,
+	getAPIParams,
 	isDynamicValue,
 	getDynamicValue,
 	evaluateExpression,


### PR DESCRIPTION
<img width="884" height="866" alt="image" src="https://github.com/user-attachments/assets/08a98cb9-ea14-4f1f-8f14-434541145a67" />

Static & Dynamic Values allowed

<hr>

> [!IMPORTANT]
>  BREAKING CHANGE

API Params added here https://github.com/frappe/studio/pull/99 are now stored as an object instead of an array
`[{key: key, value: value}] -> {key: value}`

You will have to edit and re configure params on data sources if you used this feature before

Closes: https://github.com/frappe/studio/issues/83
