### PR TITLE
fix: Preview Mode

### DIFF
--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -35,6 +35,9 @@ class StudioAppRenderer(DocumentPage):
 			self.context.is_preview = True
 			self.context.app_route = f"dev/{self.context.app_route}"
 			self.context.template = "templates/generators/studio_renderer.html"
+			self.context.app_pages = frappe.get_all(
+				"Studio Page", dict(studio_app=self.context.app_name), ["name", "page_title", "route"]
+			)
 		else:
 			self.context.template = "templates/generators/app_renderer.html"
 			manifest = self.context.doc.get_assets_from_manifest()

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -250,7 +250,7 @@ def find_page_with_route(app_name: str, page_route: str) -> str | None:
 		page_route = f"/{page_route}"
 	try:
 		return frappe.db.get_value(
-			"Studio Page", dict(studio_app=app_name, route=page_route, published=1), "name", cache=True
+			"Studio Page", dict(studio_app=app_name, route=page_route), "name", cache=True
 		)
 	except frappe.DoesNotExistError:
 		pass


### PR DESCRIPTION
Pages that weren’t published even once:

- weren't being registered in the preview mode render
- blocks weren't rendering in preview mode
