### PR TITLE
fix: don't show default success/error message on API Call + other fixes

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -258,7 +258,11 @@ const handleSuccess = (event: any) => (data: DataResult) => {
 			return successFn(context)
 		}
 	} else {
-		toast.success(event.success_message || `${event.doctype} created successfully`)
+		if (event.action === "Insert a Document") {
+			toast.success(event.success_message || `${event.doctype} created successfully`)
+		} else if (event.action === "Call API" && event.success_message) {
+			toast.success(event.success_message)
+		}
 	}
 }
 
@@ -283,7 +287,11 @@ const handleError = (event: any) => (error: any) => {
 			return errorFn(context)
 		}
 	} else {
-		toast.error(event.error_message || `Error creating ${event.doctype}`)
+		if (event.action === "Insert a Document") {
+			toast.error(event.error_message || `Error creating ${event.doctype}`)
+		} else if (event.action === "Call API" && event.error_message) {
+			toast.error(event.error_message)
+		}
 	}
 }
 

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -79,7 +79,7 @@
 							:class="control.class || ''"
 						/>
 
-						<template v-if="['Insert a Document', 'Call API'].includes(newEvent.action)">
+						<template v-if="showSuccessFailureOptions">
 							<!-- Success Section -->
 							<div class="border-t border-gray-200 pt-4">
 								<div class="mb-3">
@@ -422,6 +422,13 @@ const actions: ActionConfigurations = {
 
 const actionControls = computed(() => {
 	return actions[newEvent.value.action] || []
+})
+
+const showSuccessFailureOptions = computed(() => {
+	return (
+		(newEvent.value.action === "Insert a Document" && newEvent.value.doctype) ||
+		newEvent.value.action === "Call API"
+	)
 })
 
 function getFnBoilerplate(event: "success" | "error") {


### PR DESCRIPTION
Follow up fix for: https://github.com/frappe/studio/pull/107

- Don't show default success/error message on API Call
- Show failure/success section only after the doctype is selected -> to avoid missing doctype name in the description