### PR TITLE
fix: Switch App Page event action + app routing fixes

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -164,7 +164,6 @@ const boundValue = computed({
 
 // events
 const router = useRouter()
-const route = useRoute()
 
 const componentEvents = computed(() => {
 	const events: Record<string, Function | undefined> = {}

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -172,13 +172,7 @@ const componentEvents = computed(() => {
 		const getEventFn = () => {
 			if (event.action === "Switch App Page") {
 				return () => {
-					router.push({
-						name: "AppContainer",
-						params: {
-							appRoute: route.params.appRoute,
-							pageRoute: getPageRoute(route.params.appRoute as string, event.page),
-						},
-					})
+					router.push(event.page)
 				}
 			} else if (event.action === "Call API") {
 				return () => {
@@ -293,11 +287,6 @@ const handleError = (event: any) => (error: any) => {
 			toast.error(event.error_message)
 		}
 	}
-}
-
-function getPageRoute(appRoute: string, page: string) {
-	// extract page route from full page route
-	return page.replace(`studio-app/${appRoute}/`, "")
 }
 
 onMounted(() => {

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -149,20 +149,20 @@ watch(
 async function setPage() {
 	if (route.params.pageID === store.selectedPage) return
 
+	const appID = route.params.appID as string
 	if (route.params.pageID === "new") {
 		await studioPages.insert
 			.submit({
 				draft_blocks: [getRootBlock()],
-				studio_app: route.params.appID as string,
+				studio_app: appID,
 			})
 			.then(async (data: StudioPage) => {
-				const appID = route.params.appID as string
 				router.push({ name: "StudioPage", params: { appID: appID, pageID: data.name }, force: true })
 				store.setApp(appID)
 				await store.setPage(data.name)
 			})
 	} else {
-		store.setApp(route.params.appID as string)
+		store.setApp(appID)
 		await store.setPage(route.params.pageID as string)
 	}
 }

--- a/frontend/src/router/app_router.ts
+++ b/frontend/src/router/app_router.ts
@@ -29,6 +29,7 @@ let router = createRouter({
 })
 
 const addDynamicRoutes = (appRoute: string, pages: Page[]) => {
+	router.removeRoute("AppContainer")
 	pages.forEach((page) => {
 		router.addRoute({
 			path: page.route,

--- a/frontend/src/router/app_router.ts
+++ b/frontend/src/router/app_router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router"
 import AppContainer from "@/pages/AppContainer.vue"
+import { toast } from "vue-sonner"
 
 const routes = [
 	{
@@ -55,6 +56,12 @@ router.beforeEach((to, _, next) => {
 			console.error("Error adding dynamic routes:", error)
 			return next()
 		}
+	}
+	if (!to.matched.length) {
+		toast.error(`Failed to navigate to ${to.fullPath}`, {
+			description: "Page does not exist or is not published"
+		})
+		return false
 	}
 	next()
 })


### PR DESCRIPTION
- The Switch App Page event action was not working. It was using the old router mechanism
- Added a toast notification to display a user-friendly error when navigation fails due to a non-existent or unpublished page in the router's `beforeEach` hook.
- Remove the catch-all AppContainer route before registering new dynamic app routes. If the catch-all route is registered, all non-existent app routes are also considered valid

<img width="1029" height="439" alt="image" src="https://github.com/user-attachments/assets/1d430953-7fd8-4460-a9d9-62752059d78d" />

https://github.com/user-attachments/assets/af775a18-5b29-4087-a01b-a989ceada6cd

Closes: https://github.com/frappe/studio/issues/113

Other:
- fix: New Page button doesn't work for the first time due to undefined appID