### PR TITLE
fix: show options prop for select/autocomplete FormControl

### DIFF
--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -130,12 +130,18 @@ const componentProps = computed(() => {
 	const filteredProps: typeof propConfig = {}
 
 	Object.entries(propConfig).forEach(([propName, config]) => {
-		const isVisible = config.condition ? config.condition(currentProps) : true
-		if (!isVisible) return
+		const showProp = config.condition ? config.condition(currentProps) : true
+		if (!showProp) {
+			props.block?.removeProp(propName)
+			return
+		}
 
 		if (props.block?.componentProps[propName] === undefined) {
 			const defaultValue = typeof config.default === "function" ? config.default() : config.default
 			config.modelValue = defaultValue
+			if (defaultValue !== undefined) {
+				props.block?.setProp(propName, defaultValue)
+			}
 		} else {
 			config.modelValue = props.block.componentProps[propName]
 		}

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -126,7 +126,13 @@ const componentProps = computed(() => {
 	}
 	if (!propConfig) return {}
 
+	const currentProps = props.block?.componentProps
+	const filteredProps: typeof propConfig = {}
+
 	Object.entries(propConfig).forEach(([propName, config]) => {
+		const isVisible = config.condition ? config.condition(currentProps) : true
+		if (!isVisible) return
+
 		if (props.block?.componentProps[propName] === undefined) {
 			const defaultValue = typeof config.default === "function" ? config.default() : config.default
 			config.modelValue = defaultValue
@@ -137,9 +143,10 @@ const componentProps = computed(() => {
 		if (isDynamicValue(config.modelValue) && ["select", "checkbox"].includes(config.inputType)) {
 			config.inputType = "text"
 		}
+		filteredProps[propName] = config
 	})
 
-	return propConfig
+	return filteredProps
 })
 
 function getStudioComponentProps(componentInputs: ComponentInput[]): ComponentProps {

--- a/frontend/src/data/components.ts
+++ b/frontend/src/data/components.ts
@@ -367,7 +367,7 @@ export const COMPONENTS: FrappeUIComponents = {
 			options: {
 				required: false,
 				type: Array,
-				default: ["John Doe", "Jane Doe"],
+				default: () => ["John Doe", "Jane Doe"],
 				condition: (state: Record<string, any>) => state.type === "select" || state.type === "autocomplete"
 			}
 		},

--- a/frontend/src/data/components.ts
+++ b/frontend/src/data/components.ts
@@ -364,6 +364,12 @@ export const COMPONENTS: FrappeUIComponents = {
 		additionalProps: {
 			modelValue: { required: false },
 			placeholder: { required: false, type: String },
+			options: {
+				required: false,
+				type: Array,
+				default: ["John Doe", "Jane Doe"],
+				condition: (state: Record<string, any>) => state.type === "select" || state.type === "autocomplete"
+			}
 		},
 	},
 	FormLabel: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,7 @@ export type ComponentProp = {
 	modelValue?: any
 	required?: boolean
 	options?: Array<SelectOption> | Array<string>
+	condition?: (state: object | null | undefined) => boolean
 }
 
 export type ComponentProps = Record<string, ComponentProp>

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -551,6 +551,10 @@ class Block implements BlockOptions {
 		this.componentProps[propName] = value
 	}
 
+	removeProp(propName: string) {
+		delete this.componentProps[propName]
+	}
+
 	// component slots
 	initializeSlots() {
 		Object.entries(this.componentSlots).forEach(([slotName, slot]) => {

--- a/frontend/src/utils/components.ts
+++ b/frontend/src/utils/components.ts
@@ -78,6 +78,7 @@ function getComponentProps(componentName: string, component: ConcreteComponent |
 				default: prop.default,
 				inputType: getPropInputType(propType),
 				required: isRequired,
+				condition: prop.condition,
 			}
 
 			if (propType === "string") {


### PR DESCRIPTION
"Select" is not explicitly defined as a prop in FormControl (frappe-ui). It works as a fallthrough attribute. Explicitly define it in additionalProps for FormControl conditionally

https://github.com/user-attachments/assets/6e47a6cc-a1dc-4ec4-8828-96e13efc5890


Closes https://github.com/frappe/studio/issues/116