### PR TITLE
fix(Code Editor): prevent cut event propogating to document causing block deletion

### DIFF
--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -188,6 +188,11 @@ const extensions = computed(() => {
 				},
 			}),
 		}),
+		EditorView.domEventHandlers({
+			cut: (event, _view) => {
+				event.stopPropagation()
+			},
+		}),
 	]
 	if (languageExtension.value) {
 		baseExtensions.push(languageExtension.value)


### PR DESCRIPTION
Closes https://github.com/frappe/studio/issues/85