### PR TITLE
feat(Code Editor): Indentation markers, window completions, line wrapping

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
 		"@codemirror/lang-javascript": "^6.2.4",
 		"@codemirror/lang-json": "^6.0.1",
 		"@codemirror/lang-python": "^6.2.1",
+		"@replit/codemirror-indentation-markers": "^6.5.3",
 		"@vitejs/plugin-vue": "^5.2.0",
 		"@vueuse/components": "^10.11.1",
 		"@vueuse/core": "^10.11.1",

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -123,6 +123,7 @@ const emitEditorValue = () => {
 
 const languageExtension = ref<LanguageSupport>()
 const autocompleteExtension = ref()
+const customCompletionsExtension = ref()
 
 async function setLanguageExtension() {
 	const importMap = {
@@ -138,11 +139,18 @@ async function setLanguageExtension() {
 
 	const module = await languageImport()
 	languageExtension.value = (module as any)[props.language]()
+	const languageData = (module as any)[`${props.language}Language`]
 
 	if (props.completions) {
-		const languageData = (module as any)[`${props.language}Language`]
 		autocompleteExtension.value = languageData.data.of({
 			autocomplete: props.completions,
+		})
+	}
+
+	if (props.language === "javascript") {
+		const { scopeCompletionSource } = module as any
+		customCompletionsExtension.value = languageData.data.of({
+			autocomplete: scopeCompletionSource(window),
 		})
 	}
 }
@@ -214,6 +222,9 @@ const extensions = computed(() => {
 	}
 	if (autocompleteExtension.value) {
 		baseExtensions.push(autocompleteExtension.value)
+	}
+	if (customCompletionsExtension.value) {
+		baseExtensions.push(customCompletionsExtension.value)
 	}
 	const autocompletionOptions = {
 		activateOnTyping: true,

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -27,6 +27,7 @@ import { autocompletion, closeBrackets } from "@codemirror/autocomplete"
 import { LanguageSupport } from "@codemirror/language"
 import { EditorView, keymap } from "@codemirror/view"
 import { indentWithTab } from "@codemirror/commands"
+import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import { jsToJson, jsonToJs } from "@/utils/helpers"
 
@@ -172,6 +173,7 @@ const extensions = computed(() => {
 	const baseExtensions = [
 		keymap.of([indentWithTab]),
 		closeBrackets(),
+		indentationMarkers(),
 		props.showLineNumbers ? EditorView.lineWrapping : [],
 		tomorrow,
 		EditorView.theme({

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -26,7 +26,6 @@ import { Codemirror } from "vue-codemirror"
 import { autocompletion, closeBrackets } from "@codemirror/autocomplete"
 import { LanguageSupport } from "@codemirror/language"
 import { EditorView, keymap } from "@codemirror/view"
-import { indentWithTab } from "@codemirror/commands"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import { jsToJson, jsonToJs } from "@/utils/helpers"
@@ -171,7 +170,6 @@ watch(code, () => {
 
 const extensions = computed(() => {
 	const baseExtensions = [
-		keymap.of([indentWithTab]),
 		closeBrackets(),
 		indentationMarkers(),
 		props.showLineNumbers ? EditorView.lineWrapping : [],
@@ -191,6 +189,25 @@ const extensions = computed(() => {
 				},
 			}),
 		}),
+		keymap.of([
+			{
+				key: "Tab",
+				run: (view) => {
+					const tabs = "	"
+					view.dispatch({
+						changes: {
+							from: view.state.selection.main.from,
+							to: view.state.selection.main.to,
+							insert: tabs,
+						},
+						selection: {
+							anchor: view.state.selection.main.from + tabs.length,
+						},
+					})
+					return true
+				},
+			},
+		]),
 	]
 	if (languageExtension.value) {
 		baseExtensions.push(languageExtension.value)

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -172,6 +172,7 @@ const extensions = computed(() => {
 	const baseExtensions = [
 		keymap.of([indentWithTab]),
 		closeBrackets(),
+		props.showLineNumbers ? EditorView.lineWrapping : [],
 		tomorrow,
 		EditorView.theme({
 			"&": {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -227,6 +227,10 @@ function setValueInObject(obj: Record<string, any>, key: string, value: any) {
 	}
 }
 
+function isPrivateKey(key: string) {
+	return key.startsWith("_") || key.startsWith("__")
+}
+
 function isJSONString(str: string) {
 	try {
 		jsonToJs(str)
@@ -790,6 +794,7 @@ export {
 	isObjectEmpty,
 	getValueFromObject,
 	setValueInObject,
+	isPrivateKey,
 	isJSONString,
 	jsToJson,
 	jsonToJs,

--- a/frontend/src/utils/useStudioCompletions.ts
+++ b/frontend/src/utils/useStudioCompletions.ts
@@ -1,6 +1,7 @@
 import { computed } from "vue"
 import useStudioStore from "@/stores/studioStore"
 import type { CompletionSource } from "@/types"
+import { isPrivateKey } from "@/utils/helpers"
 import { getCompletions } from "./autocompletions"
 import type { CompletionContext } from "@codemirror/autocomplete"
 
@@ -48,6 +49,10 @@ export const useStudioCompletions = (canEditValues: boolean = false) => {
 
 		if (window.studio) {
 			Object.entries(window.studio).forEach(([funcName, func]) => {
+				if (isPrivateKey(funcName)) {
+					return
+				}
+
 				sources.push({
 					item: func,
 					completion: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,11 @@
   resolved "https://registry.yarnpkg.com/@remirror/core-constants/-/core-constants-3.0.0.tgz#96fdb89d25c62e7b6a5d08caf0ce5114370e3b8f"
   integrity sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==
 
+"@replit/codemirror-indentation-markers@^6.5.3":
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.3.tgz#1cfe5c557c45dd7f2988cbee278f17607010591b"
+  integrity sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==
+
 "@rollup/rollup-android-arm-eabi@4.41.1":
   version "4.41.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz#f39f09f60d4a562de727c960d7b202a2cf797424"


### PR DESCRIPTION
### Indentation markers

**Before:**

<img width="764" height="339" alt="image" src="https://github.com/user-attachments/assets/f14c3561-3807-4ddf-a277-121bb35f64b6" />

**After:**
<img width="764" height="304" alt="image" src="https://github.com/user-attachments/assets/742b8eac-6868-41c3-9415-04fce4a367c8" />

## Window completions

Added completions for window functions - console, setTimeout, etc

<img width="764" height="339" alt="image" src="https://github.com/user-attachments/assets/e4d5a29b-5591-4211-ada5-1e787de2d6c9" />

### Line Wrapping

Enabled line wrapping if line numbers are enabled

Other:
- fix: pressing tab anywhere indents the whole line, not just the text that follows
- exclude private object keys from window & studio completions - completions like __VUE_APP__ were also being shown although they don't exist in the eval context
