### PR TITLE
feat: Options to Delete app, Edit App details

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -9,6 +9,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     AppComponent: typeof import('./src/components/AppComponent.vue')['default']
+    AppDialog: typeof import('./src/components/AppDialog.vue')['default']
     AppHeader: typeof import('./src/components/AppLayout/AppHeader.vue')['default']
     AppLogo: typeof import('./src/components/Icons/AppLogo.vue')['default']
     Audio: typeof import('./src/components/AppLayout/Audio.vue')['default']

--- a/frontend/src/components/AppDialog.vue
+++ b/frontend/src/components/AppDialog.vue
@@ -1,0 +1,147 @@
+<template>
+	<Dialog
+		v-model="showDialog"
+		:options="{
+			title: isEditing ? 'Edit App' : 'New App',
+			width: 'md',
+		}"
+		@after-leave="
+			() => {
+				activeApp = { ...emptyAppState }
+				error = ''
+			}
+		"
+	>
+		<template #body-content>
+			<div class="flex flex-col gap-3">
+				<FormControl
+					label="Title"
+					type="text"
+					variant="outline"
+					v-model="activeApp.app_title"
+					@input="setAppFields"
+					:required="true"
+				/>
+				<FormControl label="App Route" type="text" variant="outline" v-model="activeApp.route" />
+				<FormControl
+					label="App Name"
+					type="text"
+					variant="outline"
+					v-model="activeApp.app_name"
+					:placeholder="activeApp.app_name_placeholder"
+				/>
+			</div>
+		</template>
+
+		<template #actions>
+			<div class="space-y-1">
+				<ErrorMessage class="mb-2" :message="error" />
+				<Button
+					variant="solid"
+					:label="isEditing ? 'Update' : 'Create'"
+					@click="() => handleSave()"
+					class="w-full"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from "vue"
+import { useRouter } from "vue-router"
+import { studioApps } from "@/data/studioApps"
+import { Dialog, FormControl } from "frappe-ui"
+import type { StudioApp } from "@/types/Studio/StudioApp"
+import { toast } from "vue-sonner"
+
+const props = defineProps<{ app?: StudioApp | null }>()
+const showDialog = defineModel("showDialog", { type: Boolean, required: true })
+
+const emptyAppState = {
+	app_title: "",
+	route: "",
+	app_name: "",
+	app_name_placeholder: "",
+	name: "",
+}
+const activeApp = ref({ ...emptyAppState })
+watch(
+	() => props.app,
+	() => {
+		if (props.app?.name) {
+			activeApp.value = {
+				app_title: props.app.app_title,
+				route: props.app.route,
+				app_name: props.app.app_name,
+				app_name_placeholder: props.app.name,
+				name: props.app.name,
+			}
+		} else {
+			activeApp.value = { ...emptyAppState }
+		}
+	},
+	{ immediate: true },
+)
+
+const error = ref("")
+const router = useRouter()
+
+const isEditing = computed(() => props.app?.name)
+
+function handleSave() {
+	if (isEditing.value) {
+		updateStudioApp()
+	} else {
+		createStudioApp()
+	}
+}
+
+const createStudioApp = () => {
+	const { app_title, route, app_name } = activeApp.value
+	studioApps.insert.submit(
+		{
+			app_title: app_title,
+			route: route,
+			app_name: app_name,
+		},
+		{
+			onSuccess(res: StudioApp) {
+				showDialog.value = false
+				error.value = ""
+				router.push({ name: "StudioApp", params: { appID: res.name } })
+			},
+			onError(error: any) {
+				error.value = error.messages.join(", ")
+			},
+		},
+	)
+}
+
+const updateStudioApp = () => {
+	studioApps.setValue.submit(
+		{
+			name: activeApp.value.name,
+			app_title: activeApp.value.app_title,
+			route: activeApp.value.route,
+			app_name: activeApp.value.app_name,
+		},
+		{
+			onSuccess() {
+				showDialog.value = false
+				error.value = ""
+				toast.success(`App ${activeApp.value.app_title} updated`)
+			},
+			onError(error: any) {
+				error.value = error.messages.join(", ")
+			},
+		},
+	)
+}
+
+function setAppFields(e: Event) {
+	if (isEditing.value) return
+	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
+	activeApp.value.route = activeApp.value.app_name_placeholder = kebabCasedTitle
+}
+</script>

--- a/frontend/src/components/AppDialog.vue
+++ b/frontend/src/components/AppDialog.vue
@@ -29,6 +29,7 @@
 					variant="outline"
 					v-model="activeApp.app_name"
 					:placeholder="activeApp.app_name_placeholder"
+					:disabled="isEditing"
 				/>
 			</div>
 		</template>

--- a/frontend/src/components/AppDialog.vue
+++ b/frontend/src/components/AppDialog.vue
@@ -68,7 +68,7 @@ const emptyAppState = {
 }
 const activeApp = ref({ ...emptyAppState })
 watch(
-	() => props.app,
+	() => showDialog.value,
 	() => {
 		if (props.app?.name) {
 			activeApp.value = {
@@ -88,7 +88,7 @@ watch(
 const error = ref("")
 const router = useRouter()
 
-const isEditing = computed(() => props.app?.name)
+const isEditing = computed(() => !!props.app?.name)
 
 function handleSave() {
 	if (isEditing.value) {
@@ -119,6 +119,7 @@ const createStudioApp = () => {
 	)
 }
 
+const emit = defineEmits(["update"])
 const updateStudioApp = () => {
 	studioApps.setValue.submit(
 		{
@@ -128,10 +129,11 @@ const updateStudioApp = () => {
 			app_name: activeApp.value.app_name,
 		},
 		{
-			onSuccess() {
+			onSuccess(data: StudioApp) {
 				showDialog.value = false
 				error.value = ""
 				toast.success(`App ${activeApp.value.app_title} updated`)
+				emit("update", data)
 			},
 			onError(error: any) {
 				error.value = error.messages.join(", ")

--- a/frontend/src/components/ComponentPanel.vue
+++ b/frontend/src/components/ComponentPanel.vue
@@ -24,20 +24,22 @@
 
 		<template v-if="activeTab === 'Standard'">
 			<EmptyState v-if="!componentList.length" message="No matching components" />
-			<div v-else class="grid grid-cols-3 items-center gap-x-2 gap-y-4">
-				<div v-for="component in componentList" :key="component.name">
+			<div v-else class="grid grid-cols-3 items-start gap-x-2 gap-y-4">
+				<div v-for="component in componentList" :key="component.name" class="flex flex-col">
 					<div
-						class="flex cursor-grab flex-col items-center justify-center gap-2 text-gray-700"
+						class="group flex cursor-grab flex-col items-center justify-center gap-3 text-gray-700 transition-all duration-200 hover:scale-105"
 						draggable="true"
 						@dragstart="(ev) => canvasStore.handleDragStart(ev, component.name)"
 						@dragend="(_ev) => canvasStore.handleDragEnd()"
 					>
 						<div
-							class="flex flex-col items-center justify-center gap-2 truncate rounded border-[1px] border-gray-300 bg-gray-50 p-4 transition duration-300 ease-in-out"
+							class="flex h-16 w-16 flex-col items-center justify-center rounded-lg border border-gray-300 bg-gray-50 p-3 transition-all duration-200 group-hover:border-gray-400 group-hover:bg-gray-100 group-hover:shadow-sm"
 						>
 							<component :is="component.icon" class="h-6 w-6" />
 						</div>
-						<span class="truncate text-xs">{{ component.title }}</span>
+						<span class="wrap-normal w-full text-center text-xs">
+							{{ component.title }}
+						</span>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -275,6 +275,7 @@ const getResourceMenu = (resource: Resource, resource_name: string) => {
 		{
 			label: "Delete",
 			icon: "trash",
+			theme: "red",
 			onClick: () => deleteResource(resource, resource_name),
 		},
 		{
@@ -400,6 +401,7 @@ const getVariableMenu = (variable_name: string, value: any) => {
 		{
 			label: "Delete",
 			icon: "trash",
+			theme: "red",
 			onClick: () => deleteVariable(variableConfig),
 		},
 		{

--- a/frontend/src/components/PagesPanel.vue
+++ b/frontend/src/components/PagesPanel.vue
@@ -80,6 +80,7 @@ const getPageMenu = (page: StudioPage) => {
 		{
 			label: "Delete",
 			icon: "trash",
+			theme: "red",
 			condition: () => !isAppHome(page),
 			onClick: async () => {
 				await store.deleteAppPage(app.name, page)

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -12,6 +12,7 @@
 								icon: 'arrow-left',
 								onClick: () => $router.push({ name: 'Home' }),
 							},
+							{ label: 'View in Desk', onClick: () => openInDesk(store.activeApp!), icon: 'arrow-up-right' },
 							{
 								label: 'Delete App',
 								icon: 'trash-2',
@@ -147,7 +148,7 @@ import ExportAppDialog from "@/components/ExportAppDialog.vue"
 import type { StudioMode } from "@/types"
 import session from "@/utils/session"
 import LucideArrowUpFromLine from "~icons/lucide/arrow-up-from-line"
-import { isObjectEmpty } from "@/utils/helpers"
+import { isObjectEmpty, openInDesk } from "@/utils/helpers"
 
 const store = useStudioStore()
 const canvasStore = useCanvasStore()

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -3,8 +3,27 @@
 		<div class="absolute left-3 flex items-center justify-center gap-5">
 			<Dropdown
 				:options="[
-					{ label: 'Back to Dashboard', icon: 'arrow-left', onClick: () => $router.push({ name: 'Home' }) },
-					{ label: 'Logout', icon: 'log-out', onClick: () => session.logout() },
+					{
+						group: 'Studio',
+						hideLabel: true,
+						items: [
+							{
+								label: 'Back to Dashboard',
+								icon: 'arrow-left',
+								onClick: () => $router.push({ name: 'Home' }),
+							},
+							{
+								label: 'Delete App',
+								icon: 'trash-2',
+								onClick: () => store.deleteApp(store.activeApp?.app_name!, store.activeApp?.app_title!),
+							},
+						],
+					},
+					{
+						group: 'More',
+						hideLabel: true,
+						items: [{ label: 'Logout', icon: 'log-out', onClick: () => session.logout() }],
+					},
 				]"
 			>
 				<template v-slot="{ open }">

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -14,6 +14,11 @@
 							},
 							{ label: 'View in Desk', onClick: () => openInDesk(store.activeApp!), icon: 'arrow-up-right' },
 							{
+								label: 'App Settings',
+								icon: 'settings',
+								onClick: () => (showAppDialog = true),
+							},
+							{
 								label: 'Delete App',
 								icon: 'trash-2',
 								onClick: () => store.deleteApp(store.activeApp?.app_name!, store.activeApp?.app_title!),
@@ -132,6 +137,11 @@
 				Publish
 			</Button>
 		</div>
+		<AppDialog
+			v-model:showDialog="showAppDialog"
+			:app="store.activeApp"
+			@update="(app) => store.setApp(app.name)"
+		/>
 	</div>
 </template>
 
@@ -157,4 +167,6 @@ const publishing = ref(false)
 const routeString = computed(() => store.activePage?.route || "/")
 const showExportAppDialog = ref(false)
 const canExportApp = computed(() => window.is_developer_mode && !isObjectEmpty(store.activeApp))
+
+const showAppDialog = ref(false)
 </script>

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -21,6 +21,7 @@
 							{
 								label: 'Delete App',
 								icon: 'trash-2',
+								theme: 'red',
 								onClick: () => store.deleteApp(store.activeApp?.app_name!, store.activeApp?.app_title!),
 							},
 						],

--- a/frontend/src/data/studioApps.ts
+++ b/frontend/src/data/studioApps.ts
@@ -3,7 +3,7 @@ import { createListResource } from "frappe-ui"
 const studioApps = createListResource({
 	method: "GET",
 	doctype: "Studio App",
-	fields: ["name", "app_title", "route", "app_home", "is_standard", "frappe_app", "creation", "modified"],
+	fields: ["name", "app_name", "app_title", "route", "app_home", "is_standard", "frappe_app", "creation", "modified"],
 	auto: true,
 	cache: "apps",
 	orderBy: "modified desc",

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -43,18 +43,18 @@
 			</div>
 
 			<section class="mt-5 w-full">
-				<div v-if="!appList.length && !searchFilter" class="col-span-full">
+				<div v-if="!studioApps.data?.length && !searchFilter" class="col-span-full">
 					<p class="mt-4 text-base text-gray-500">
 						You don't have any apps yet. Click on the "+ New App" button to create a new app
 					</p>
 				</div>
-				<div v-else-if="!appList.length" class="col-span-full">
+				<div v-else-if="!studioApps.data?.length" class="col-span-full">
 					<p class="mt-4 text-base text-gray-500">No matching apps found</p>
 				</div>
 				<div v-else class="grid w-full grid-cols-5 items-start gap-5">
 					<router-link
 						class="flex flex-col justify-center gap-1 rounded-lg border-2 p-4"
-						v-for="app in appList"
+						v-for="app in studioApps.data"
 						:to="{ name: 'StudioApp', params: { appID: app.name } }"
 						:key="app.name"
 					>
@@ -155,15 +155,16 @@ const router = useRouter()
 const store = useStudioStore()
 
 const searchFilter = ref("")
-const appList = ref<StudioApp[]>([])
 
 const fetchApps = () => {
-	appList.value = studioApps.data
+	const filters = {} as any
 	if (searchFilter.value) {
-		appList.value = studioApps.data?.filter((app: StudioApp) =>
-			app.app_title.toLowerCase().includes(searchFilter.value?.toLowerCase()),
-		)
+		filters["app_title"] = ["like", `%${searchFilter.value}%`]
 	}
+	studioApps.update({
+		filters,
+	})
+	studioApps.fetch()
 }
 
 watchDebounced(searchFilter, fetchApps, { debounce: 300, immediate: true })

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -141,6 +141,7 @@ import type { NewStudioApp, StudioApp } from "@/types/Studio/StudioApp"
 import session from "@/utils/session"
 import { watchDebounced } from "@vueuse/core"
 import useStudioStore from "@/stores/studioStore"
+import { openInDesk } from "@/utils/helpers"
 
 const showDialog = ref(false)
 const emptyAppState = {
@@ -191,9 +192,5 @@ const createStudioApp = (app: NewStudioApp) => {
 function setAppFields(e: Event) {
 	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
 	newApp.value.route = newApp.value.app_name_placeholder = kebabCasedTitle
-}
-
-function openInDesk(app: StudioApp) {
-	window.open(`/app/studio-app/${app.name}`, "_blank")
 }
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -53,12 +53,30 @@
 				</div>
 				<div v-else class="grid w-full grid-cols-5 items-start gap-5">
 					<router-link
-						class="flex flex-col justify-center gap-1 rounded-lg border-2 p-5"
+						class="flex flex-col justify-center gap-1 rounded-lg border-2 p-4"
 						v-for="app in appList"
 						:to="{ name: 'StudioApp', params: { appID: app.name } }"
 						:key="app.name"
 					>
-						<div class="font-semibold text-gray-800">{{ app.app_title }}</div>
+						<div class="flex flex-row justify-between">
+							<div class="font-semibold text-gray-800">{{ app.app_title }}</div>
+							<Dropdown
+								:options="[
+									{ label: 'View in Desk', onClick: () => openInDesk(app), icon: 'arrow-up-right' },
+									{
+										label: 'Delete',
+										onClick: () => store.deleteApp(app.name, app.app_title),
+										icon: 'trash-2',
+									},
+								]"
+								size="sm"
+								placement="right"
+							>
+								<template v-slot="{ open }">
+									<Button icon="more-horizontal" variant="ghost" />
+								</template>
+							</Dropdown>
+						</div>
 						<UseTimeAgo v-slot="{ timeAgo }" :time="app.creation">
 							<p class="mt-1 block text-xs text-gray-500">Created {{ timeAgo }}</p>
 						</UseTimeAgo>
@@ -122,6 +140,7 @@ import StudioLogo from "@/components/Icons/StudioLogo.vue"
 import type { NewStudioApp, StudioApp } from "@/types/Studio/StudioApp"
 import session from "@/utils/session"
 import { watchDebounced } from "@vueuse/core"
+import useStudioStore from "@/stores/studioStore"
 
 const showDialog = ref(false)
 const emptyAppState = {
@@ -132,6 +151,7 @@ const emptyAppState = {
 }
 const newApp = ref({ ...emptyAppState })
 const router = useRouter()
+const store = useStudioStore()
 
 const searchFilter = ref("")
 const appList = ref<StudioApp[]>([])
@@ -171,5 +191,9 @@ const createStudioApp = (app: NewStudioApp) => {
 function setAppFields(e: Event) {
 	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
 	newApp.value.route = newApp.value.app_name_placeholder = kebabCasedTitle
+}
+
+function openInDesk(app: StudioApp) {
+	window.open(`/app/studio-app/${app.name}`, "_blank")
 }
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -58,32 +58,35 @@
 						:to="{ name: 'StudioApp', params: { appID: app.name } }"
 						:key="app.name"
 					>
-						<div class="flex flex-row justify-between">
+						<div class="group flex flex-row justify-between">
 							<div class="font-semibold text-gray-800">{{ app.app_title }}</div>
-							<Dropdown
-								:options="[
-									{
-										label: 'Edit',
-										onClick: () => {
-											activeApp = app
-											showAppDialog = true
+							<div class="invisible shrink-0 group-hover:visible has-[[data-state=open]]:visible">
+								<Dropdown
+									:options="[
+										{
+											label: 'Edit',
+											onClick: () => {
+												activeApp = app
+												showAppDialog = true
+											},
+											icon: 'edit',
 										},
-										icon: 'edit',
-									},
-									{ label: 'View in Desk', onClick: () => openInDesk(app), icon: 'arrow-up-right' },
-									{
-										label: 'Delete',
-										onClick: () => store.deleteApp(app.name, app.app_title),
-										icon: 'trash-2',
-									},
-								]"
-								size="sm"
-								placement="right"
-							>
-								<template v-slot="{ open }">
-									<Button icon="more-horizontal" variant="ghost" />
-								</template>
-							</Dropdown>
+										{ label: 'View in Desk', onClick: () => openInDesk(app), icon: 'arrow-up-right' },
+										{
+											label: 'Delete',
+											onClick: () => store.deleteApp(app.name, app.app_title),
+											icon: 'trash-2',
+										},
+									]"
+									:button="{
+										icon: 'more-horizontal',
+										label: 'App Options',
+										variant: 'ghost',
+									}"
+									size="sm"
+									placement="right"
+								/>
+							</div>
 						</div>
 						<UseTimeAgo v-slot="{ timeAgo }" :time="app.creation">
 							<p class="mt-1 block text-xs text-gray-500">Created {{ timeAgo }}</p>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -76,6 +76,7 @@
 											label: 'Delete',
 											onClick: () => store.deleteApp(app.name, app.app_title),
 											icon: 'trash-2',
+											theme: 'red',
 										},
 									]"
 									:button="{

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -15,7 +15,7 @@
 				</template>
 			</Dropdown>
 
-			<Button variant="solid" icon-left="plus" @click="showDialog = true">New App</Button>
+			<Button variant="solid" icon-left="plus" @click="showAppDialog = true">New App</Button>
 		</div>
 
 		<div class="flex h-full flex-col items-center px-20 py-10">
@@ -62,6 +62,14 @@
 							<div class="font-semibold text-gray-800">{{ app.app_title }}</div>
 							<Dropdown
 								:options="[
+									{
+										label: 'Edit',
+										onClick: () => {
+											activeApp = app
+											showAppDialog = true
+										},
+										icon: 'edit',
+									},
 									{ label: 'View in Desk', onClick: () => openInDesk(app), icon: 'arrow-up-right' },
 									{
 										label: 'Delete',
@@ -85,73 +93,21 @@
 			</section>
 		</div>
 
-		<Dialog
-			v-model="showDialog"
-			:options="{
-				title: 'New App',
-				width: 'md',
-			}"
-			@after-leave="
-				() => {
-					newApp = { ...emptyAppState }
-					appCreationError = ''
-				}
-			"
-		>
-			<template #body-content>
-				<div class="flex flex-col gap-3">
-					<FormControl
-						label="Title"
-						type="text"
-						variant="outline"
-						v-model="newApp.app_title"
-						@input="setAppFields"
-						:required="true"
-					/>
-					<FormControl label="App Route" type="text" variant="outline" v-model="newApp.route" />
-					<FormControl
-						label="App Name"
-						type="text"
-						variant="outline"
-						v-model="newApp.app_name"
-						:placeholder="newApp.app_name_placeholder"
-					/>
-				</div>
-			</template>
-
-			<template #actions>
-				<div class="space-y-1">
-					<ErrorMessage class="mb-2" :message="appCreationError" />
-					<Button variant="solid" label="Create" @click="() => createStudioApp(newApp)" class="w-full" />
-				</div>
-			</template>
-		</Dialog>
+		<AppDialog v-model:showDialog="showAppDialog" :app="activeApp" />
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue"
-import { Dialog, FormControl } from "frappe-ui"
-import { useRouter } from "vue-router"
+import { ref, watch } from "vue"
 import { studioApps } from "@/data/studioApps"
 import { UseTimeAgo } from "@vueuse/components"
 import Input from "@/components/Input.vue"
 import StudioLogo from "@/components/Icons/StudioLogo.vue"
-import type { NewStudioApp, StudioApp } from "@/types/Studio/StudioApp"
 import session from "@/utils/session"
 import { watchDebounced } from "@vueuse/core"
 import useStudioStore from "@/stores/studioStore"
 import { openInDesk } from "@/utils/helpers"
 
-const showDialog = ref(false)
-const emptyAppState = {
-	app_title: "",
-	route: "",
-	app_name: "",
-	app_name_placeholder: "",
-}
-const newApp = ref({ ...emptyAppState })
-const router = useRouter()
 const store = useStudioStore()
 
 const searchFilter = ref("")
@@ -169,29 +125,11 @@ const fetchApps = () => {
 
 watchDebounced(searchFilter, fetchApps, { debounce: 300, immediate: true })
 
-const appCreationError = ref("")
-const createStudioApp = (app: NewStudioApp) => {
-	studioApps.insert.submit(
-		{
-			app_title: app.app_title,
-			route: app.route,
-			app_name: app.app_name,
-		},
-		{
-			onSuccess(res: StudioApp) {
-				showDialog.value = false
-				appCreationError.value = ""
-				router.push({ name: "StudioApp", params: { appID: res.name } })
-			},
-			onError(error: any) {
-				appCreationError.value = error.messages.join(", ")
-			},
-		},
-	)
-}
-
-function setAppFields(e: Event) {
-	const kebabCasedTitle = (e.target as HTMLInputElement).value.toLowerCase().replace(/\s+/g, "-")
-	newApp.value.route = newApp.value.app_name_placeholder = kebabCasedTitle
-}
+const showAppDialog = ref(false)
+const activeApp = ref()
+watch(showAppDialog, (show) => {
+	if (!show) {
+		activeApp.value = null
+	}
+})
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -93,12 +93,12 @@
 			</section>
 		</div>
 
-		<AppDialog v-model:showDialog="showAppDialog" :app="activeApp" />
+		<AppDialog v-model:showDialog="showAppDialog" :app="activeApp" @after-leave="() => (activeApp = null)" />
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
+import { ref } from "vue"
 import { studioApps } from "@/data/studioApps"
 import { UseTimeAgo } from "@vueuse/components"
 import Input from "@/components/Input.vue"
@@ -127,9 +127,4 @@ watchDebounced(searchFilter, fetchApps, { debounce: 300, immediate: true })
 
 const showAppDialog = ref(false)
 const activeApp = ref()
-watch(showAppDialog, (show) => {
-	if (!show) {
-		activeApp.value = null
-	}
-})
 </script>

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -33,7 +33,7 @@ import { createResource } from "frappe-ui"
 
 const useStudioStore = defineStore("store", () => {
 	const studioLayout = reactive({
-		leftPanelWidth: 300,
+		leftPanelWidth: 338,
 		rightPanelWidth: 275,
 		showLeftPanel: true,
 		showRightPanel: true,
@@ -55,6 +55,24 @@ const useStudioStore = defineStore("store", () => {
 		const appDoc = await fetchApp(appName)
 		activeApp.value = appDoc
 		await setAppPages(appName)
+	}
+
+	async function deleteApp(appName: string, appTitle: string) {
+		if (!appName) return
+		const confirmed = await confirm(`Are you sure you want to delete the app <b>${appTitle}</b>?`)
+		if (confirmed) {
+			studioApps.delete.submit(appName, {
+				onSuccess() {
+					if (activeApp.value?.name === appName) {
+						router.replace({ name: "Home" })
+					}
+					toast.success(`App "${appTitle}" deleted successfully`)
+				},
+				onError() {
+					toast.error("An unexpected error occurred while deleting the app.")
+				}
+			})
+		}
 	}
 
 	async function setAppPages(appName: string) {
@@ -371,6 +389,7 @@ const useStudioStore = defineStore("store", () => {
 		// studio app
 		activeApp,
 		setApp,
+		deleteApp,
 		updateActiveApp,
 		deleteAppPage,
 		duplicateAppPage,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -8,6 +8,7 @@ import type { ObjectLiteral, BlockOptions, StyleValue, ExpressionEvaluationConte
 import type { DataResult, DocumentResource, DocumentResult, Filters, Resource } from "@/types/Studio/StudioResource"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
 import { call } from "frappe-ui"
+import type { StudioApp } from "@/types/Studio/StudioApp"
 
 function getBlockString(block: BlockOptions | Block): string {
 	return jsToJson(getBlockCopyWithoutParent(block))
@@ -314,6 +315,10 @@ async function fetchApp(appName: string) {
 	})
 	await appResource.get.promise
 	return appResource.doc
+}
+
+function openInDesk(app: StudioApp) {
+	window.open(`/app/studio-app/${app.name}`, "_blank")
 }
 
 // page
@@ -806,6 +811,7 @@ export {
 	isHTML,
 	// app
 	fetchApp,
+	openInDesk,
 	// page
 	fetchPage,
 	findPageWithRoute,


### PR DESCRIPTION
Previously, had to go to the desk to edit basic app details. Added options to:
- Edit app details - title, route 
- Delete App
- View in Desk

<img width="1512" height="332" alt="image" src="https://github.com/user-attachments/assets/4b7c4738-7db1-4929-bf4f-2138ab0b7262" />

From the editor:


<img width="1512" height="404" alt="menu" src="https://github.com/user-attachments/assets/e3015711-f3f2-47f9-b797-792bf6232ab0" />


On clicking App Settings > can edit app title & route

<img width="1512" height="637" alt="image" src="https://github.com/user-attachments/assets/54585002-237a-4877-9d66-00238c1792f1" />


**Other fix:** broken reactivity in app search
