### PR TITLE
feat: Better 'Add fields from Doctype' utility

### DIFF
--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -79,7 +79,7 @@ const showDialog = defineModel("showDialog", { type: Boolean, required: true })
 
 type FormField = DocTypeField & {
 	componentName: string
-	componentType: string
+	componentType?: string
 	name: string
 	reqd: number
 	read_only: number
@@ -129,7 +129,7 @@ const fieldTypes = [
 	"Check",
 	"Date",
 	"Datetime",
-	"Markdown Editor",
+	"Text Editor",
 	"Small Text",
 ]
 
@@ -143,7 +143,7 @@ const getComponentFromFieldType = (fieldType: string) => {
 		case "Small Text":
 			return { componentName: "FormControl", componentType: "textarea" }
 		case "Link":
-			return { componentName: "Link", componentType: "Link" }
+			return { componentName: "Link" }
 		case "Select":
 			return { componentName: "FormControl", componentType: "select" }
 		case "Check":
@@ -152,8 +152,8 @@ const getComponentFromFieldType = (fieldType: string) => {
 			return { componentName: "FormControl", componentType: "date" }
 		case "Datetime":
 			return { componentName: "FormControl", componentType: "datetime-local" }
-		case "Markdown Editor":
-			return { componentName: "MarkdownEditor", componentType: "MarkdownEditor" }
+		case "Text Editor":
+			return { componentName: "TextEditor" }
 		default:
 			return { componentName: "FormControl", componentType: "text" }
 	}

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -35,7 +35,7 @@
 							fieldtype: 'Autocomplete',
 							options: fieldTypes,
 							onChange: (_value: string, index: number) => {
-								const { componentName, componentType } = getComponentFromFieldType(_value)
+								const { componentName, componentType } = getComponentForField(_value)
 								formMeta.fields[index].componentName = componentName
 								formMeta.fields[index].componentType = componentType
 							},
@@ -100,7 +100,7 @@ const doctypeFields = createResource({
 	},
 	transform: (data: DocTypeField[]) => {
 		return data.map((field) => {
-			const { componentName, componentType } = getComponentFromFieldType(field.fieldtype)
+			const { componentName, componentType } = getComponentForField(field)
 			return {
 				...field,
 				value: field.fieldname,
@@ -138,9 +138,15 @@ const fieldTypes = [
 	"Rating",
 ]
 
-const getComponentFromFieldType = (fieldType: string) => {
+const getComponentForField = (arg?: DocTypeField | string) => {
+	const fieldType = typeof arg === "string" ? arg : arg?.fieldtype
+	const field = typeof arg === "object" ? arg : null
+
 	switch (fieldType) {
 		case "Data":
+			if (field?.options === "Email") {
+				return { componentName: "FormControl", componentType: "email" }
+			}
 			return { componentName: "FormControl", componentType: "text" }
 		case "Int":
 		case "Float":

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -82,6 +82,7 @@ type FormField = DocTypeField & {
 	componentType: string
 	name: string
 	reqd: number
+	read_only: number
 	options?: string
 }
 const formMeta = ref<{
@@ -172,6 +173,9 @@ const addFields = () => {
 		}
 		if (field.reqd) {
 			newBlock?.setProp("required", true)
+		}
+		if (field.read_only) {
+			newBlock?.setProp("disabled", true)
 		}
 		if (field.options) {
 			if (field.componentType === "select") {

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -173,8 +173,12 @@ const addFields = () => {
 		if (field.reqd) {
 			newBlock?.setProp("required", true)
 		}
-		if (field.options && field.componentType === "select") {
-			newBlock?.setProp("options", field.options.split("\n"))
+		if (field.options) {
+			if (field.componentType === "select") {
+				newBlock?.setProp("options", field.options.split("\n"))
+			} else if (field.componentType === "Link") {
+				newBlock?.setProp("doctype", field.options)
+			}
 		}
 		props.block?.addChild(newBlock)
 	})

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -81,6 +81,8 @@ type FormField = DocTypeField & {
 	componentName: string
 	componentType: string
 	name: string
+	reqd: number
+	options?: string
 }
 const formMeta = ref<{
 	doctype: string
@@ -161,9 +163,18 @@ const addFields = () => {
 
 	formMeta.value.fields.forEach((field: FormField) => {
 		const newBlock = getComponentBlock(field.componentName)
-		newBlock?.setProp("label", field.label)
 		if (field.componentName === "FormControl") {
 			newBlock?.setProp("type", field.componentType)
+		}
+		if (field.label) {
+			newBlock?.setProp("label", field.label)
+			newBlock?.setProp("placeholder", "")
+		}
+		if (field.reqd) {
+			newBlock?.setProp("required", true)
+		}
+		if (field.options && field.componentType === "select") {
+			newBlock?.setProp("options", field.options.split("\n"))
 		}
 		props.block?.addChild(newBlock)
 	})

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -52,6 +52,14 @@
 					v-model:rows="formMeta.fields"
 					:showDeleteBtn="true"
 				/>
+				<FormControl
+					v-if="showVariantField"
+					label="Field Variant"
+					type="select"
+					:options="['subtle', 'outline']"
+					v-model="formMeta.variant"
+					description="Selected variant will be applied to all FormControl fields"
+				/>
 			</div>
 		</template>
 
@@ -62,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { createResource, Dialog } from "frappe-ui"
 import Block from "@/utils/block"
 import { getComponentBlock } from "@/utils/helpers"
@@ -88,6 +96,7 @@ type FormField = DocTypeField & {
 const formMeta = ref<{
 	doctype: string
 	fields: FormField[]
+	variant?: string
 }>({
 	doctype: "",
 	fields: [],
@@ -119,6 +128,10 @@ watch(
 		doctypeFields.fetch()
 	},
 )
+
+const showVariantField = computed(() => {
+	return formMeta.value.fields.some((field) => field.componentName === "FormControl")
+})
 
 const fieldTypes = [
 	"Data",
@@ -185,6 +198,9 @@ const addFields = () => {
 		const newBlock = getComponentBlock(field.componentName)
 		if (field.componentName === "FormControl") {
 			newBlock?.setProp("type", field.componentType)
+			if (formMeta.value.variant) {
+				newBlock?.setProp("variant", formMeta.value.variant)
+			}
 		}
 		if (field.label) {
 			newBlock?.setProp("label", field.label)

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -124,13 +124,16 @@ const fieldTypes = [
 	"Data",
 	"Int",
 	"Float",
-	"Link",
+	"Password",
+	"Text",
+	"Small Text",
+	"Long Text",
 	"Select",
 	"Check",
 	"Date",
 	"Datetime",
+	"Link",
 	"Text Editor",
-	"Small Text",
 ]
 
 const getComponentFromFieldType = (fieldType: string) => {
@@ -140,10 +143,12 @@ const getComponentFromFieldType = (fieldType: string) => {
 		case "Int":
 		case "Float":
 			return { componentName: "FormControl", componentType: "number" }
+		case "Password":
+			return { componentName: "FormControl", componentType: "password" }
+		case "Text":
 		case "Small Text":
+		case "Long Text":
 			return { componentName: "FormControl", componentType: "textarea" }
-		case "Link":
-			return { componentName: "Link" }
 		case "Select":
 			return { componentName: "FormControl", componentType: "select" }
 		case "Check":
@@ -152,6 +157,8 @@ const getComponentFromFieldType = (fieldType: string) => {
 			return { componentName: "FormControl", componentType: "date" }
 		case "Datetime":
 			return { componentName: "FormControl", componentType: "datetime-local" }
+		case "Link":
+			return { componentName: "Link" }
 		case "Text Editor":
 			return { componentName: "TextEditor" }
 		default:

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -89,9 +89,6 @@ type FormField = DocTypeField & {
 	componentName: string
 	componentType?: string
 	name: string
-	reqd: number
-	read_only: number
-	options?: string
 }
 const formMeta = ref<{
 	doctype: string
@@ -200,6 +197,9 @@ const addFields = () => {
 			newBlock?.setProp("type", field.componentType)
 			if (formMeta.value.variant) {
 				newBlock?.setProp("variant", formMeta.value.variant)
+			}
+			if (field.description) {
+				newBlock?.setProp("description", field.description)
 			}
 		}
 		if (field.label) {

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -135,6 +135,7 @@ const fieldTypes = [
 	"Time",
 	"Link",
 	"Text Editor",
+	"Rating",
 ]
 
 const getComponentFromFieldType = (fieldType: string) => {
@@ -164,6 +165,8 @@ const getComponentFromFieldType = (fieldType: string) => {
 			return { componentName: "Link" }
 		case "Text Editor":
 			return { componentName: "TextEditor" }
+		case "Rating":
+			return { componentName: "Rating" }
 		default:
 			return { componentName: "FormControl", componentType: "text" }
 	}

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -132,6 +132,7 @@ const fieldTypes = [
 	"Check",
 	"Date",
 	"Datetime",
+	"Time",
 	"Link",
 	"Text Editor",
 ]
@@ -157,6 +158,8 @@ const getComponentFromFieldType = (fieldType: string) => {
 			return { componentName: "FormControl", componentType: "date" }
 		case "Datetime":
 			return { componentName: "FormControl", componentType: "datetime-local" }
+		case "Time":
+			return { componentName: "FormControl", componentType: "time" }
 		case "Link":
 			return { componentName: "Link" }
 		case "Text Editor":

--- a/frontend/src/data/components.ts
+++ b/frontend/src/data/components.ts
@@ -26,6 +26,7 @@ import LucideBookType from "~icons/lucide/book-type"
 import LucideTag from "~icons/lucide/tag"
 import LucideListCheck from "~icons/lucide/list-check"
 import LucideEllipsis from "~icons/lucide/ellipsis"
+import LucideStar from "~icons/lucide/star"
 import LucideMousePointer2 from "~icons/lucide/mouse-pointer-2"
 import LucideToggleLeft from "~icons/lucide/toggle-left"
 import LucideArrowRightLeft from "~icons/lucide/arrow-right-left"
@@ -523,6 +524,14 @@ export const COMPONENTS: FrappeUIComponents = {
 			value: 50,
 			size: "sm",
 			label: "Progress",
+		},
+	},
+	Rating: {
+		name: "Rating",
+		title: "Rating",
+		icon: LucideStar,
+		initialState: {
+			label: "Rating",
 		},
 	},
 	Select: {

--- a/frontend/src/globals.ts
+++ b/frontend/src/globals.ts
@@ -29,6 +29,7 @@ import {
 	LoadingText,
 	Progress,
 	Popover,
+	Rating,
 	Select,
 	Spinner,
 	Switch,
@@ -95,6 +96,7 @@ export function registerGlobalComponents(app: App) {
 	app.component("LoadingText", LoadingText)
 	app.component("Progress", Progress)
 	app.component("Popover", Popover)
+	app.component("Rating", Rating)
 	app.component("Select", Select)
 	app.component("Spinner", Spinner)
 	app.component("Switch", Switch)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,9 @@ export type DocTypeField = {
 	is_virtual?: boolean
 	options?: string
 	value?: any
+	reqd: number
+	read_only: number
+	description?: string
 }
 export type Operators = "=" | "!=" | ">" | "<" | ">=" | "<=" | "like" | "not like" | "in" | "not in" | "between" | "not between" | "is" | "is not"
 

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -23,6 +23,7 @@ export const FRAPPE_UI_COMPONENTS = [
 	"FormControl",
 	"ListView",
 	"Progress",
+	"Rating",
 	"Select",
 	"Switch",
 	"Tabs",


### PR DESCRIPTION
## Option to set field variant while adding fields from doctype

So that you don't have to individually change it for all fields after adding them to the canvas

## Support new fieldtypes
- Password
- Link
- Email
- Small Text, Long Text
- Text Editor
- Rating
- Time

## Map properties from docfields -> component props

Mapping:
<table>
<tr>
 <th>Docfield Property
 <th>Component Prop
<tr>
 <td>reqd
 <td>required
<tr>
 <td>read_only
 <td>disabled
<tr>
 <td>options
 <td>doctype for Link component, options for Select component
<tr>
 <td>label
 <td>label
<tr>
 <td>description
 <td>description
</table>

https://github.com/user-attachments/assets/0a277a32-27a9-49c4-97f9-3c6c1c670b3c
