### PR TITLE
feat: Pass additional attributes or props to components

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -75,6 +75,7 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     ScriptSection: typeof import('./src/components/ScriptSection.vue')['default']
+    SectionContainer: typeof import('./src/components/SectionContainer.vue')['default']
     SettingItem: typeof import('./src/components/SettingItem.vue')['default']
     Sidebar: typeof import('./src/components/AppLayout/Sidebar.vue')['default']
     SlotIcon: typeof import('./src/components/Icons/SlotIcon.vue')['default']

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -91,7 +91,7 @@ const evaluationContext = computed(() => {
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
-	const propValues = { ...props.block.componentProps }
+	const propValues = { ...props.block.componentProps, ...props.block.attributes }
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -91,7 +91,7 @@ const evaluationContext = computed(() => {
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
-	const propValues = { ...props.block.componentProps, ...props.block.attributes }
+	const propValues = props.block.getPropsAndAttributes()
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {

--- a/frontend/src/components/CollapsibleSection.vue
+++ b/frontend/src/components/CollapsibleSection.vue
@@ -1,8 +1,11 @@
 <!-- Extracted from Builder -->
 <template>
 	<div>
-		<div class="dark:text-zinc-400 flex items-center justify-between text-sm font-medium">
-			<h3 class="dark:text-zinc-300 cursor-pointer text-base text-gray-900" @click="toggleCollapsed">
+		<div class="flex items-center justify-between">
+			<h3
+				class="dark:text-zinc-300 cursor-pointer text-base font-medium text-gray-900"
+				@click="toggleCollapsed"
+			>
 				{{ sectionName }}
 			</h3>
 			<Button

--- a/frontend/src/components/ComponentInterface.vue
+++ b/frontend/src/components/ComponentInterface.vue
@@ -2,7 +2,7 @@
 	<div class="flex select-none flex-col pb-16">
 		<div class="flex flex-col gap-3">
 			<!-- inputs -->
-			<SectionContainer title="Inputs" class="mb-4">
+			<SectionContainer title="Inputs">
 				<template #actions>
 					<Autocomplete
 						:options="fieldTypeOptions"

--- a/frontend/src/components/ComponentInterface.vue
+++ b/frontend/src/components/ComponentInterface.vue
@@ -2,145 +2,145 @@
 	<div class="flex select-none flex-col pb-16">
 		<div class="flex flex-col gap-3">
 			<!-- inputs -->
-			<div class="flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Inputs</h3>
-				<Autocomplete
-					:options="fieldTypeOptions"
-					@update:modelValue="(option: SelectOption) => showAddInputPopover(option.value)"
-					class="!w-auto"
-				>
-					<template #target="{ togglePopover }">
-						<Button @click="togglePopover" size="sm" variant="ghost" icon="plus" />
-					</template>
-				</Autocomplete>
-			</div>
+			<SectionContainer title="Inputs" class="mb-4">
+				<template #actions>
+					<Autocomplete
+						:options="fieldTypeOptions"
+						@update:modelValue="(option: SelectOption) => showAddInputPopover(option.value)"
+						class="!w-auto"
+					>
+						<template #target="{ togglePopover }">
+							<Button @click="togglePopover" size="sm" variant="ghost" icon="plus" />
+						</template>
+					</Autocomplete>
+				</template>
 
-			<div class="mb-4 flex flex-col gap-1" v-if="componentInputs.length > 0">
-				<Popover
-					v-for="(input, index) in componentInputs"
-					:key="input.input_name"
-					:show="showEditPopover && editingIndex === index"
-					@update:show="
-						(show: boolean) => {
-							if (!show) cancelEdit()
-						}
-					"
-					placement="bottom-center"
-				>
-					<template #target>
-						<div
-							class="group flex flex-1 cursor-pointer justify-between rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
-							@click="editInput(input, index)"
-						>
-							<div class="flex items-center gap-2">
-								<FeatherIcon :name="getFieldTypeIcon(input.type)" class="h-4 w-4 text-gray-500" />
-								<span class="text-sm text-gray-800">{{ input.input_name }}</span>
-							</div>
-							<button
-								class="flex cursor-pointer items-center rounded-sm p-1 text-gray-700 opacity-0 transition-opacity hover:text-gray-900 group-hover:opacity-100"
-								@click.stop="componentEditorStore.removeComponentInput(index)"
+				<div class="flex flex-col gap-1" v-if="componentInputs.length > 0">
+					<Popover
+						v-for="(input, index) in componentInputs"
+						:key="input.input_name"
+						:show="showEditPopover && editingIndex === index"
+						@update:show="
+							(show: boolean) => {
+								if (!show) cancelEdit()
+							}
+						"
+						placement="bottom-center"
+					>
+						<template #target>
+							<div
+								class="group flex flex-1 cursor-pointer justify-between rounded border border-gray-300 px-2 py-1 hover:bg-gray-50"
+								@click="editInput(input, index)"
 							>
-								<FeatherIcon name="x" class="h-4 w-4" />
-							</button>
-						</div>
-					</template>
-					<template #body-main>
-						<div
-							class="w-64 space-y-4 p-4"
-							v-if="editingInput && editingIndex === index"
-							@keydown="handleInputKeydown"
-						>
-							<FormControl
-								type="text"
-								label="Name"
-								v-model="editingInput.input_name"
-								placeholder="e.g. user_name"
-								autocomplete="off"
-								:required="true"
-							/>
-							<FormControl
-								type="autocomplete"
-								label="Type"
-								:options="fieldTypeOptions"
-								:modelValue="
-									editingInput ? fieldTypeOptions.find((opt) => opt.value === editingInput!.type) : null
-								"
-								@update:modelValue="
-									(option: SelectOption) => {
-										if (editingInput) {
-											editingInput.type = option.value
-											setInputControl()
+								<div class="flex items-center gap-2">
+									<FeatherIcon :name="getFieldTypeIcon(input.type)" class="h-4 w-4 text-gray-500" />
+									<span class="text-sm text-gray-800">{{ input.input_name }}</span>
+								</div>
+								<button
+									class="flex cursor-pointer items-center rounded-sm p-1 text-gray-700 opacity-0 transition-opacity hover:text-gray-900 group-hover:opacity-100"
+									@click.stop="componentEditorStore.removeComponentInput(index)"
+								>
+									<FeatherIcon name="x" class="h-4 w-4" />
+								</button>
+							</div>
+						</template>
+						<template #body-main>
+							<div
+								class="w-64 space-y-4 p-4"
+								v-if="editingInput && editingIndex === index"
+								@keydown="handleInputKeydown"
+							>
+								<FormControl
+									type="text"
+									label="Name"
+									v-model="editingInput.input_name"
+									placeholder="e.g. user_name"
+									autocomplete="off"
+									:required="true"
+								/>
+								<FormControl
+									type="autocomplete"
+									label="Type"
+									:options="fieldTypeOptions"
+									:modelValue="
+										editingInput ? fieldTypeOptions.find((opt) => opt.value === editingInput!.type) : null
+									"
+									@update:modelValue="
+										(option: SelectOption) => {
+											if (editingInput) {
+												editingInput.type = option.value
+												setInputControl()
+											}
 										}
-									}
-								"
-								:required="true"
-							>
-								<template #prefix>
-									<FeatherIcon
-										:name="editingInput ? getFieldTypeIcon(editingInput.type) : 'help-circle'"
-										class="mr-1 h-3 w-3 text-gray-500"
-									/>
-								</template>
-								<template #item-prefix="{ option }">
-									<FeatherIcon :name="getFieldTypeIcon(option.value)" class="h-3 w-3 text-gray-500" />
-								</template>
-							</FormControl>
-							<FormControl
-								v-if="editingInput.type === 'select'"
-								type="textarea"
-								label="Options"
-								v-model="editingInput.options"
-								:required="true"
-								placeholder="Enter list of options, each on a new line"
-							/>
+									"
+									:required="true"
+								>
+									<template #prefix>
+										<FeatherIcon
+											:name="editingInput ? getFieldTypeIcon(editingInput.type) : 'help-circle'"
+											class="mr-1 h-3 w-3 text-gray-500"
+										/>
+									</template>
+									<template #item-prefix="{ option }">
+										<FeatherIcon :name="getFieldTypeIcon(option.value)" class="h-3 w-3 text-gray-500" />
+									</template>
+								</FormControl>
+								<FormControl
+									v-if="editingInput.type === 'select'"
+									type="textarea"
+									label="Options"
+									v-model="editingInput.options"
+									:required="true"
+									placeholder="Enter list of options, each on a new line"
+								/>
 
-							<!-- Default value -->
-							<component
-								:is="editingInput.inputControl"
-								:type="editingInput.inputType"
-								label="Default Value"
-								v-model="editingInput.default"
-							/>
-							<FormControl
-								type="textarea"
-								label="Description"
-								v-model="editingInput.description"
-								placeholder="Enter description (optional)"
-							/>
-							<FormControl
-								type="checkbox"
-								label="Is Required"
-								size="sm"
-								v-model="editingInput.required"
-								class="[&>label]:text-sm [&>label]:text-ink-gray-5"
-							/>
-							<div class="flex gap-2">
-								<Button variant="solid" @click="saveInput">Save</Button>
-								<Button variant="outline" @click="cancelEdit">Cancel</Button>
+								<!-- Default value -->
+								<component
+									:is="editingInput.inputControl"
+									:type="editingInput.inputType"
+									label="Default Value"
+									v-model="editingInput.default"
+								/>
+								<FormControl
+									type="textarea"
+									label="Description"
+									v-model="editingInput.description"
+									placeholder="Enter description (optional)"
+								/>
+								<FormControl
+									type="checkbox"
+									label="Is Required"
+									size="sm"
+									v-model="editingInput.required"
+									class="[&>label]:text-sm [&>label]:text-ink-gray-5"
+								/>
+								<div class="flex gap-2">
+									<Button variant="solid" @click="saveInput">Save</Button>
+									<Button variant="outline" @click="cancelEdit">Cancel</Button>
+								</div>
+								<div class="text-xs text-gray-500">
+									Press
+									<kbd class="rounded bg-gray-100 px-1 py-0.5">⌘</kbd>
+									+
+									<kbd class="rounded bg-gray-100 px-1 py-0.5">S</kbd>
+									to save
+								</div>
 							</div>
-							<div class="text-xs text-gray-500">
-								Press
-								<kbd class="rounded bg-gray-100 px-1 py-0.5">⌘</kbd>
-								+
-								<kbd class="rounded bg-gray-100 px-1 py-0.5">S</kbd>
-								to save
-							</div>
-						</div>
-					</template>
-				</Popover>
-			</div>
+						</template>
+					</Popover>
+				</div>
 
-			<EmptyState v-else message="No inputs added" />
+				<EmptyState v-else message="No inputs added" />
+			</SectionContainer>
 
 			<!-- Test Inputs -->
-			<div class="flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Test Inputs</h3>
-			</div>
-			<PropsEditor
-				v-if="componentEditorStore.studioComponentBlock"
-				:block="componentEditorStore.studioComponentBlock"
-				:isTestingComponent="true"
-			/>
+			<SectionContainer title="Test Inputs">
+				<PropsEditor
+					v-if="componentEditorStore.studioComponentBlock"
+					:block="componentEditorStore.studioComponentBlock"
+					:isTestingComponent="true"
+				/>
+			</SectionContainer>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -52,17 +52,13 @@
 				<EmptyState v-else message="No slots added" />
 			</SectionContainer>
 
-			<!-- Attributes -->
+			<!-- attributes -->
 			<SectionContainer title="Attributes">
-				<template #actions>
-					<Button @click="attributesEditor?.addObjectKey()" size="sm" variant="ghost" icon="plus" />
-				</template>
 				<ObjectEditor
 					ref="attributesEditor"
 					:obj="blockController.getAttributes() || {}"
 					@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
-					description="Pass additional HTML attributes or props not explicitly defined in the component"
-					:showAddButton="false"
+					description="Pass additional HTML attributes or props that are not explicitly defined in the component"
 				/>
 			</SectionContainer>
 

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -22,7 +22,7 @@
 				</Autocomplete>
 			</div>
 
-			<div class="mb-4 mt-3 flex flex-col gap-3" v-if="!isObjectEmpty(block?.componentSlots)">
+			<div class="mb-4 flex flex-col gap-3" v-if="!isObjectEmpty(block?.componentSlots)">
 				<div
 					v-for="(slot, name) in block?.componentSlots"
 					:key="name"

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -3,81 +3,80 @@
 		<EmptyState v-if="!block?.componentName || block?.isRoot()" message="Select a block to edit properties" />
 		<div v-else class="flex flex-col gap-3">
 			<!-- props -->
-			<div class="flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Props</h3>
-			</div>
-			<PropsEditor :block="block" />
+			<SectionContainer title="Props" class="mb-4">
+				<PropsEditor :block="block" />
+			</SectionContainer>
 
 			<!-- slots -->
-			<div class="mt-3 flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Slots</h3>
-				<Autocomplete
-					:options="componentSlots"
-					@update:modelValue="(slot: SelectOption) => block?.addSlot(slot.value)"
-					class="!w-auto"
-				>
-					<template #target="{ togglePopover }">
-						<Button @click="togglePopover" size="sm" variant="ghost" icon="plus" />
-					</template>
-				</Autocomplete>
-			</div>
+			<SectionContainer title="Slots" class="mb-4">
+				<template #actions>
+					<Autocomplete
+						:options="componentSlots"
+						@update:modelValue="(slot: SelectOption) => block?.addSlot(slot.value)"
+						class="!w-auto"
+					>
+						<template #target="{ togglePopover }">
+							<Button @click="togglePopover" size="sm" variant="ghost" icon="plus" />
+						</template>
+					</Autocomplete>
+				</template>
 
-			<div class="mb-4 flex flex-col gap-3" v-if="!isObjectEmpty(block?.componentSlots)">
-				<div
-					v-for="(slot, name) in block?.componentSlots"
-					:key="name"
-					class="flex w-full flex-row justify-between"
-				>
-					<div class="flex w-full cursor-pointer items-center justify-between gap-2">
-						<div class="relative w-full">
-							<InlineInput
-								:label="name"
-								type="textarea"
-								:modelValue="getSlotContent(slot)"
-								@update:modelValue="(slotContent) => block?.updateSlot(name, slotContent)"
-								:disabled="Array.isArray(slot.slotContent)"
-							/>
-							<Badge
-								v-if="Array.isArray(slot.slotContent)"
-								variant="subtle"
-								theme="blue"
-								class="absolute left-2 top-8"
-							>
-								Component Tree
-							</Badge>
+				<div class="flex flex-col gap-3" v-if="!isObjectEmpty(block?.componentSlots)">
+					<div
+						v-for="(slot, name) in block?.componentSlots"
+						:key="name"
+						class="flex w-full flex-row justify-between"
+					>
+						<div class="flex w-full cursor-pointer items-center justify-between gap-2">
+							<div class="relative w-full">
+								<InlineInput
+									:label="name"
+									type="textarea"
+									:modelValue="getSlotContent(slot)"
+									@update:modelValue="(slotContent) => block?.updateSlot(name, slotContent)"
+									:disabled="Array.isArray(slot.slotContent)"
+								/>
+								<Badge
+									v-if="Array.isArray(slot.slotContent)"
+									variant="subtle"
+									theme="blue"
+									class="absolute left-2 top-8"
+								>
+									Component Tree
+								</Badge>
+							</div>
+							<Button variant="outline" size="sm" icon="x" @click="block?.removeSlot(name)" />
 						</div>
-						<Button variant="outline" size="sm" icon="x" @click="block?.removeSlot(name)" />
 					</div>
 				</div>
-			</div>
-
-			<EmptyState v-else message="No slots added" />
+				<EmptyState v-else message="No slots added" />
+			</SectionContainer>
 
 			<!-- Attributes -->
-			<div class="mt-3 flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Attributes</h3>
-				<Button @click="attributesEditor?.addObjectKey()" size="sm" variant="ghost" icon="plus" />
-			</div>
-			<ObjectEditor
-				ref="attributesEditor"
-				:obj="blockController.getAttributes() || {}"
-				@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
-				description="Pass additional HTML attributes or props not explicitly defined in the component"
-				:showAddButton="false"
-			/>
+			<SectionContainer title="Attributes" class="mb-4">
+				<template #actions>
+					<Button @click="attributesEditor?.addObjectKey()" size="sm" variant="ghost" icon="plus" />
+				</template>
+				<ObjectEditor
+					ref="attributesEditor"
+					:obj="blockController.getAttributes() || {}"
+					@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
+					description="Pass additional HTML attributes or props not explicitly defined in the component"
+					:showAddButton="false"
+				/>
+			</SectionContainer>
 
 			<!-- Visibility Condition -->
-			<div class="mt-7 flex items-center justify-between text-sm font-medium">
-				<h3 class="cursor-pointer text-base text-gray-900">Visibility Condition</h3>
-			</div>
-			<Code
-				language="javascript"
-				height="60px"
-				:showLineNumbers="false"
-				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
-				:modelValue="block?.visibilityCondition"
-				@update:modelValue="blockController.setKeyValue('visibilityCondition', $event)"
-			/>
+			<SectionContainer title="Visibility Condition">
+				<Code
+					language="javascript"
+					height="60px"
+					:showLineNumbers="false"
+					:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
+					:modelValue="block?.visibilityCondition"
+					@update:modelValue="blockController.setKeyValue('visibilityCondition', $event)"
+				/>
+			</SectionContainer>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -45,7 +45,7 @@
 									Component Tree
 								</Badge>
 							</div>
-							<Button variant="outline" size="sm" icon="x" @click="block?.removeSlot(name)" />
+							<Button variant="subtle" size="sm" icon="x" @click="block?.removeSlot(name)" />
 						</div>
 					</div>
 				</div>

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -52,16 +52,6 @@
 				<EmptyState v-else message="No slots added" />
 			</SectionContainer>
 
-			<!-- attributes -->
-			<SectionContainer title="Attributes">
-				<ObjectEditor
-					ref="attributesEditor"
-					:obj="blockController.getAttributes() || {}"
-					@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
-					description="Pass additional HTML attributes or props that are not explicitly defined in the component"
-				/>
-			</SectionContainer>
-
 			<!-- Visibility Condition -->
 			<SectionContainer title="Visibility Condition">
 				<Code
@@ -71,6 +61,16 @@
 					:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 					:modelValue="block?.visibilityCondition"
 					@update:modelValue="blockController.setKeyValue('visibilityCondition', $event)"
+				/>
+			</SectionContainer>
+
+			<!-- attributes -->
+			<SectionContainer title="Attributes">
+				<ObjectEditor
+					ref="attributesEditor"
+					:obj="blockController.getAttributes() || {}"
+					@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
+					description="Pass additional HTML attributes or props that are not explicitly defined in the component"
 				/>
 			</SectionContainer>
 		</div>

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -53,6 +53,19 @@
 
 			<EmptyState v-else message="No slots added" />
 
+			<!-- Attributes -->
+			<div class="mt-3 flex items-center justify-between text-sm font-medium">
+				<h3 class="cursor-pointer text-base text-gray-900">Attributes</h3>
+				<Button @click="attributesEditor?.addObjectKey()" size="sm" variant="ghost" icon="plus" />
+			</div>
+			<ObjectEditor
+				ref="attributesEditor"
+				:obj="blockController.getAttributes() || {}"
+				@update:obj="(obj: Record<string, any>) => blockController.setAttributes(obj)"
+				description="Pass additional HTML attributes or props not explicitly defined in the component"
+				:showAddButton="false"
+			/>
+
 			<!-- Visibility Condition -->
 			<div class="mt-7 flex items-center justify-between text-sm font-medium">
 				<h3 class="cursor-pointer text-base text-gray-900">Visibility Condition</h3>
@@ -76,6 +89,7 @@ import Block from "@/utils/block"
 
 import { getComponentSlots } from "@/utils/components"
 import PropsEditor from "@/components/PropsEditor.vue"
+import ObjectEditor from "@/components/ObjectEditor.vue"
 import InlineInput from "@/components/InlineInput.vue"
 import EmptyState from "@/components/EmptyState.vue"
 import type { SelectOption, Slot } from "@/types"
@@ -90,12 +104,12 @@ const props = defineProps<{
 }>()
 const getCompletions = useStudioCompletions()
 
+const attributesEditor = ref<InstanceType<typeof ObjectEditor> | null>(null)
+
 const componentSlots = ref<string[]>([])
 watch(
 	() => props.block?.componentName,
-	async () => {
-		await updateAvailableSlots()
-	},
+	() => updateAvailableSlots(),
 )
 
 watch(

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -3,12 +3,12 @@
 		<EmptyState v-if="!block?.componentName || block?.isRoot()" message="Select a block to edit properties" />
 		<div v-else class="flex flex-col gap-3">
 			<!-- props -->
-			<SectionContainer title="Props" class="mb-4">
+			<SectionContainer title="Props">
 				<PropsEditor :block="block" />
 			</SectionContainer>
 
 			<!-- slots -->
-			<SectionContainer title="Slots" class="mb-4">
+			<SectionContainer title="Slots">
 				<template #actions>
 					<Autocomplete
 						:options="componentSlots"
@@ -53,7 +53,7 @@
 			</SectionContainer>
 
 			<!-- Attributes -->
-			<SectionContainer title="Attributes" class="mb-4">
+			<SectionContainer title="Attributes">
 				<template #actions>
 					<Button @click="attributesEditor?.addObjectKey()" size="sm" variant="ghost" icon="plus" />
 				</template>

--- a/frontend/src/components/Input.vue
+++ b/frontend/src/components/Input.vue
@@ -1,6 +1,6 @@
 <!-- Extracted from Builder -->
 <template>
-	<div class="relative w-full">
+	<div class="relative w-full" :class="type === 'checkbox' ? 'flex items-center' : ''">
 		<FormControl
 			:class="classes"
 			:type="type"
@@ -52,6 +52,8 @@ const data = useVModel(props, "modelValue", emit)
 defineOptions({
 	inheritAttrs: false,
 })
+
+const attrs = useAttrs()
 
 const classes = computed(() => {
 	const _classes = []
@@ -113,8 +115,6 @@ const classes = computed(() => {
 	}
 	return _classes
 })
-
-const attrs = useAttrs()
 
 const clearValue = () => {
 	data.value = ""

--- a/frontend/src/components/ObjectEditor.vue
+++ b/frontend/src/components/ObjectEditor.vue
@@ -22,7 +22,6 @@
 			></Button>
 		</div>
 		<Button
-			v-if="showAddButton"
 			variant="subtle"
 			label="Add"
 			class="dark:bg-zinc-800 dark:text-gray-100"
@@ -41,16 +40,10 @@
 import { mapToObject, replaceMapKey } from "@/utils/helpers"
 import { ref } from "vue"
 
-const props = withDefaults(
-	defineProps<{
-		obj: Record<string, string>
-		description?: string
-		showAddButton?: boolean
-	}>(),
-	{
-		showAddButton: true,
-	},
-)
+const props = defineProps<{
+	obj: Record<string, string>
+	description?: string
+}>()
 
 const emit = defineEmits({
 	"update:obj": (obj: Record<string, string>) => true,
@@ -109,8 +102,4 @@ const pasteObj = (e: ClipboardEvent) => {
 		emit("update:obj", mapToObject(map))
 	}
 }
-
-defineExpose({
-	addObjectKey,
-})
 </script>

--- a/frontend/src/components/ObjectEditor.vue
+++ b/frontend/src/components/ObjectEditor.vue
@@ -22,6 +22,7 @@
 			></Button>
 		</div>
 		<Button
+			v-if="showAddButton"
 			variant="subtle"
 			label="Add"
 			class="dark:bg-zinc-800 dark:text-gray-100"
@@ -40,10 +41,16 @@
 import { mapToObject, replaceMapKey } from "@/utils/helpers"
 import { ref } from "vue"
 
-const props = defineProps<{
-	obj: Record<string, string>
-	description?: string
-}>()
+const props = withDefaults(
+	defineProps<{
+		obj: Record<string, string>
+		description?: string
+		showAddButton?: boolean
+	}>(),
+	{
+		showAddButton: true,
+	},
+)
 
 const emit = defineEmits({
 	"update:obj": (obj: Record<string, string>) => true,
@@ -102,4 +109,8 @@ const pasteObj = (e: ClipboardEvent) => {
 		emit("update:obj", mapToObject(map))
 	}
 }
+
+defineExpose({
+	addObjectKey,
+})
 </script>

--- a/frontend/src/components/ObjectEditor.vue
+++ b/frontend/src/components/ObjectEditor.vue
@@ -1,44 +1,36 @@
 <!-- Extracted from Builder -->
 <template>
 	<div ref="objectEditor" class="flex flex-col gap-2" @paste="pasteObj">
-		<div v-for="(value, key) in obj" :key="key" class="flex gap-2">
+		<div v-for="(value, key, index) in obj" :key="index" class="flex gap-2">
 			<Input
 				placeholder="Property"
 				:modelValue="key"
 				@update:modelValue="(val: string) => replaceKey(key, val)"
-				class="dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:bg-zinc-700 rounded-md text-sm text-gray-800"
 			/>
 			<Input
 				placeholder="Value"
 				:modelValue="value"
 				@update:modelValue="(val: string) => updateObjectValue(key, val)"
-				class="dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:bg-zinc-700 rounded-md text-sm text-gray-800"
 			/>
 			<Button
-				variant="outline"
+				class="flex-shrink-0 text-xs"
+				variant="subtle"
 				icon="x"
-				class="dark:border-zinc-600 dark:bg-zinc-800 dark:hover:bg-zinc-700 p-2 dark:text-gray-100 dark:outline-0 dark:hover:text-gray-100"
 				@click="deleteObjectKey(key as string)"
 			></Button>
 		</div>
-		<Button
-			variant="subtle"
-			label="Add"
-			class="dark:bg-zinc-800 dark:text-gray-100"
-			@click="addObjectKey"
-		></Button>
-		<p
-			class="dark:bg-zinc-800 dark:text-zinc-300 rounded-sm bg-gray-100 p-2 text-2xs text-gray-800"
-			v-show="description"
-		>
+		<Button variant="subtle" label="Add" @click="addObjectKey"></Button>
+		<p class="rounded-sm bg-surface-gray-1 p-2 text-xs text-ink-gray-7" v-show="description">
 			<span v-html="description"></span>
 		</p>
 	</div>
 </template>
 
 <script setup lang="ts">
+import { Button } from "frappe-ui"
+import Input from "@/components/Input.vue"
 import { mapToObject, replaceMapKey } from "@/utils/helpers"
-import { ref } from "vue"
+import { nextTick, ref } from "vue"
 
 const props = defineProps<{
 	obj: Record<string, string>
@@ -49,10 +41,16 @@ const emit = defineEmits({
 	"update:obj": (obj: Record<string, string>) => true,
 })
 
-const addObjectKey = () => {
+const addObjectKey = async () => {
 	const map = new Map(Object.entries(props.obj))
 	map.set("", "")
 	emit("update:obj", mapToObject(map))
+	await nextTick()
+	const inputs = objectEditor.value?.querySelectorAll("input")
+	if (inputs) {
+		const lastInput = inputs[inputs.length - 2]
+		lastInput.focus()
+	}
 }
 
 const updateObjectValue = (key: string, value: string) => {

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -3,7 +3,7 @@
 		v-if="isObjectEmpty(componentProps)"
 		:message="`${block?.getBlockDescription()} has no editable properties`"
 	/>
-	<div v-else class="mb-4 mt-3 flex flex-col gap-3">
+	<div v-else class="mt-3 flex flex-col gap-3">
 		<div v-for="(config, propName) in componentProps" :key="propName" class="group flex w-full items-center">
 			<DynamicValueSelector
 				v-if="propName === 'modelValue'"

--- a/frontend/src/components/SectionContainer.vue
+++ b/frontend/src/components/SectionContainer.vue
@@ -1,0 +1,15 @@
+<template>
+	<div class="flex flex-col gap-3">
+		<div class="flex items-center justify-between text-sm font-medium">
+			<h3 class="text-base text-gray-900">{{ title }}</h3>
+			<slot name="actions"></slot>
+		</div>
+		<slot></slot>
+	</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+	title: string
+}>()
+</script>

--- a/frontend/src/components/SectionContainer.vue
+++ b/frontend/src/components/SectionContainer.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="mb-4 flex flex-col gap-3">
-		<div class="flex items-center justify-between text-sm">
-			<h3 class="text-base text-ink-gray-9">{{ title }}</h3>
+		<div class="flex items-center justify-between">
+			<h3 class="dark:text-zinc-300 text-base font-medium text-ink-gray-9">{{ title }}</h3>
 			<slot name="actions"></slot>
 		</div>
 		<slot></slot>

--- a/frontend/src/components/SectionContainer.vue
+++ b/frontend/src/components/SectionContainer.vue
@@ -1,7 +1,7 @@
 <template>
-	<div class="flex flex-col gap-3">
-		<div class="flex items-center justify-between text-sm font-medium">
-			<h3 class="text-base text-gray-900">{{ title }}</h3>
+	<div class="mb-4 flex flex-col gap-3">
+		<div class="flex items-center justify-between text-sm">
+			<h3 class="text-base text-ink-gray-9">{{ title }}</h3>
 			<slot name="actions"></slot>
 		</div>
 		<slot></slot>

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -176,7 +176,7 @@ const evaluationContext = computed(() => {
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
-	const propValues = { ...props.block.componentProps, ...props.block.attributes }
+	const propValues = props.block.getPropsAndAttributes()
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -176,7 +176,7 @@ const evaluationContext = computed(() => {
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
-	const propValues = { ...props.block.componentProps }
+	const propValues = { ...props.block.componentProps, ...props.block.attributes }
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {

--- a/frontend/src/components/StudioComponentEditorWrapper.vue
+++ b/frontend/src/components/StudioComponentEditorWrapper.vue
@@ -17,7 +17,7 @@ const componentEditorStore = useComponentEditorStore()
 const componentBlock = computed(() => componentEditorStore.studioComponentBlock!)
 
 const componentContext = computed(() => {
-	const context = { ...componentBlock.value.componentProps }
+	const context = componentBlock.value.getPropsAndAttributes()
 	componentEditorStore.componentInputs.forEach((input) => {
 		if (!(input.input_name in context) && input.default !== undefined) {
 			context[input.input_name] = input.default

--- a/frontend/src/components/StudioComponentRenderer.vue
+++ b/frontend/src/components/StudioComponentRenderer.vue
@@ -19,7 +19,7 @@ const componentStore = useComponentStore()
 const codeStore = useCodeStore()
 
 const componentContext = computed(() => {
-	const context = { ...props.studioComponent.componentProps }
+	const context = props.studioComponent.getPropsAndAttributes()
 	const componentDoc = componentStore.getComponentDoc(props.studioComponent.componentName)
 	if (componentDoc?.inputs) {
 		componentDoc.inputs.forEach((input: any) => {

--- a/frontend/src/components/StudioComponentWrapper.vue
+++ b/frontend/src/components/StudioComponentWrapper.vue
@@ -19,7 +19,7 @@ const componentStore = useComponentStore()
 const codeStore = useCodeStore()
 
 const componentContext = computed(() => {
-	const context = { ...props.studioComponent.componentProps }
+	const context = props.studioComponent.getPropsAndAttributes()
 	const componentDoc = componentStore.getComponentDoc(props.studioComponent.componentName)
 	if (componentDoc?.inputs) {
 		componentDoc.inputs.forEach((input: any) => {

--- a/frontend/src/components/StudioLeftPanel.vue
+++ b/frontend/src/components/StudioLeftPanel.vue
@@ -51,7 +51,7 @@
 
 				<PagesPanel v-show="activeTab === 'Pages'" class="mx-2 my-3" />
 				<ComponentPanel v-show="activeTab === 'Add Component'" class="mx-2 my-3" />
-				<div v-show="activeTab === 'Layers'" class="p-4 pt-3">
+				<div v-show="activeTab === 'Layers'" class="p-3">
 					<ComponentLayers
 						v-if="canvasStore.activeCanvas"
 						class="no-scrollbar overflow-auto"

--- a/frontend/src/components/StudioRightPanel.vue
+++ b/frontend/src/components/StudioRightPanel.vue
@@ -13,7 +13,7 @@
 				:max-dimension="400"
 			/>
 
-			<div class="sticky top-0 z-[12] flex w-full border-gray-200 bg-white px-2 text-base">
+			<div class="sticky top-0 z-[12] flex w-full border-gray-200 bg-white px-1 text-base">
 				<button
 					v-for="tab of tabs"
 					:key="tab"
@@ -31,12 +31,12 @@
 
 			<ComponentProperties
 				v-show="activeTab === 'Properties'"
-				class="p-4"
+				class="p-3"
 				:block="canvasStore.activeCanvas?.selectedBlocks[0]"
 			/>
 			<ComponentEvents
 				v-show="activeTab === 'Events'"
-				class="p-4"
+				class="p-3"
 				:block="canvasStore.activeCanvas?.selectedBlocks[0]"
 			/>
 			<ComponentStyles
@@ -46,7 +46,7 @@
 			/>
 			<ComponentInterface
 				v-if="activeTab === 'Interface' && showInterfaceTab"
-				class="p-4"
+				class="p-3"
 				@vue:unmounted="store.studioLayout.rightPanelActiveTab = 'Properties'"
 			/>
 		</div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,7 @@ export interface BlockOptions {
 	componentProps?: Record<string, any>
 	componentSlots?: Record<string, Slot>
 	componentEvents?: Record<string, any>
+	attributes?: Record<string, any>
 	originalElement?: string
 	children?: Array<Block | BlockOptions>
 	baseStyles?: BlockStyleMap

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -20,6 +20,7 @@ class Block implements BlockOptions {
 	componentProps: Record<string, any>
 	componentSlots: Record<string, Slot>
 	componentEvents: Record<string, any>
+	attributes: Record<string, any>
 	blockName: string
 	children: Block[]
 	parentBlock: Block | null
@@ -82,6 +83,7 @@ class Block implements BlockOptions {
 		}
 
 		this.componentEvents = options.componentEvents || {}
+		this.attributes = reactive(options.attributes || {})
 		this.initializeSlots()
 
 		// Define as non-reactive property
@@ -553,6 +555,20 @@ class Block implements BlockOptions {
 
 	removeProp(propName: string) {
 		delete this.componentProps[propName]
+	}
+
+	// attributes
+	getAttributes() {
+		return { ...this.attributes }
+	}
+
+	setAttributes(attributes: Record<string, any>) {
+		Object.keys(this.attributes).forEach((key) => {
+			if (!(key in attributes)) {
+				delete this.attributes[key]
+			}
+		})
+		Object.assign(this.attributes, attributes)
 	}
 
 	// component slots

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -571,6 +571,10 @@ class Block implements BlockOptions {
 		Object.assign(this.attributes, attributes)
 	}
 
+	getPropsAndAttributes() {
+		return { ...this.componentProps, ...this.attributes }
+	}
+
 	// component slots
 	initializeSlots() {
 		Object.entries(this.componentSlots).forEach(([slotName, slot]) => {

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -73,6 +73,7 @@ class Block implements BlockOptions {
 		} else {
 			this.componentProps = options.componentProps
 		}
+		this.attributes = reactive(options.attributes || {})
 
 		this.componentSlots = options.componentSlots || {}
 		if (!options.componentSlots) {
@@ -83,7 +84,6 @@ class Block implements BlockOptions {
 		}
 
 		this.componentEvents = options.componentEvents || {}
-		this.attributes = reactive(options.attributes || {})
 		this.initializeSlots()
 
 		// Define as non-reactive property

--- a/frontend/src/utils/blockController.ts
+++ b/frontend/src/utils/blockController.ts
@@ -130,6 +130,14 @@ const blockController = {
 			block[key] = value;
 		});
 	},
+	getAttributes: () => {
+		return blockController.isAnyBlockSelected() && blockController.getFirstSelectedBlock().getAttributes()
+	},
+	setAttributes: (attributes: Record<string, any>) => {
+		canvasStore.activeCanvas?.selectedBlocks.forEach((block) => {
+			block.setAttributes(attributes)
+		})
+	},
 }
 
 export default blockController


### PR DESCRIPTION
Some component definitions are not transparent in frappe-ui. Passing an attribute might have effects on the component but its not explicitly defined on the component definition especially for wrapper components. Eg: FormControl doesn't explicitly define options (applicable for select type only), disabled. Such non-prop attrs + HTML attrs can be passed using the Attributes section

Closes https://github.com/frappe/studio/issues/131
<img width="1624" height="1056" alt="additional-attributes" src="https://github.com/user-attachments/assets/4502d55e-0786-4388-acc6-3973a734a1f0" />

https://github.com/user-attachments/assets/44294aad-3bf2-4515-acc0-358953b1d726