### PR TITLE
feat: Support function props & dynamic values inside object props

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
 		"codemirror": "^6.0.1",
 		"feather-icons": "^4.28.0",
 		"frappe-ui": "0.1.213",
+		"json5": "^2.2.3",
 		"marked": "^15.0.6",
 		"pinia": "^2.2.1",
 		"thememirror": "^2.0.1",

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -95,9 +95,7 @@ const getComponentProps = () => {
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {
-		if (isDynamicValue(config)) {
-			propValues[propName] = codeStore.getDynamicValue(config, evaluationContext.value)
-		}
+		propValues[propName] = codeStore.evaluateDynamicValues(config, evaluationContext.value)
 	})
 	return propValues
 }
@@ -113,18 +111,7 @@ const componentProps = computed(() => {
 // visibility
 const showComponent = computed(() => {
 	if (props.block.visibilityCondition) {
-		const value = codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
-		// Handle different return types:
-		// - Boolean: return as-is
-		// - String "true"/"false": convert to boolean
-		// - Other values: check truthiness
-		if (typeof value === "boolean") {
-			return value
-		} else if (typeof value === "string" && (value === "true" || value === "false")) {
-			return value === "true"
-		} else {
-			return value
-		}
+		return codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
 	}
 	return true
 })

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -74,11 +74,11 @@ const setEditorValue = () => {
 		if (props.language === "json" || typeof value === "object") {
 			value = JSON5.stringify(value, { replacer: null, space: 2, quote: '"' })
 		}
+		code.value = value
 	} catch (e) {
 		console.log("Error while converting value to JSON", e)
 		// do nothing
 	}
-	code.value = value
 }
 
 const isValidObjectString = (text: string) => {

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -34,7 +34,8 @@ import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import JSON5 from "json5"
-import { isPrivateKey, unquoteFunctions } from "@/utils/helpers"
+import { isPrivateKey } from "@/utils/helpers"
+import { unquoteFunctions, unquoteDynamicExpressions } from "@/utils/code"
 import { useSerializer } from "@/utils/useSerializer"
 
 import InputLabel from "@/components/InputLabel.vue"
@@ -76,6 +77,7 @@ const setEditorValue = () => {
 		if (props.language === "json" || typeof value === "object") {
 			value = JSON5.stringify(value, { replacer: jsonReplacer, space: 2, quote: '"' })
 			value = unquoteFunctions(value)
+			value = unquoteDynamicExpressions(value)
 		}
 		code.value = value
 	} catch (e) {

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -29,7 +29,7 @@ import {
 	type CompletionContext,
 	type Completion,
 } from "@codemirror/autocomplete"
-import { LanguageSupport } from "@codemirror/language"
+import { LanguageSupport, indentService } from "@codemirror/language"
 import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
@@ -68,7 +68,7 @@ const props = withDefaults(
 	},
 )
 const emit = defineEmits(["update:modelValue", "save"])
-const { jsonReplacer, jsonToJs, parseObjectString } = useSerializer()
+const { jsonReplacer, jsToJson, jsonToJs, parseObjectString } = useSerializer()
 
 const code = ref<string>("")
 const setEditorValue = () => {
@@ -180,6 +180,33 @@ watch(code, () => {
 	}
 })
 
+const customIndent = indentService.of((context: any, pos: number) => {
+	/* helper to indent correctly inside objects because codemirror fails to do it for a bare object literal */
+	let node = context.state.tree.resolveInner(pos, -1)
+	const parentBlock = node.parent
+	const getIndent = () => context.lineIndent(node.from, -1) + context.unit
+
+	if (node.name === "{") {
+		if (
+			// Top-level ambiguous Block Statement
+			parentBlock?.name === "Block" ||
+			// Object Literal immediately inside an array or argument list
+			(parentBlock?.name === "ObjectExpression" &&
+				["ArrayExpression", "ArgList"].includes(parentBlock.parent?.name))
+		) {
+			// Treat it as a bare object literal at the top level
+			return getIndent()
+		}
+	} else if (node.name === "[") {
+		// indent inside an array
+		if (parentBlock?.name === "ArrayExpression") {
+			return getIndent()
+		}
+	}
+	// Fall back to the default indentation logic
+	return null
+})
+
 const extensions = computed(() => {
 	const baseExtensions = [
 		closeBrackets(),
@@ -235,6 +262,9 @@ const extensions = computed(() => {
 	if (customCompletionsExtension.value) {
 		baseExtensions.push(customCompletionsExtension.value)
 	}
+	if (isObjectLiteral.value) {
+		baseExtensions.push(customIndent)
+	}
 	const autocompletionOptions = {
 		activateOnTyping: true,
 		maxRenderedOptions: 10,
@@ -245,6 +275,10 @@ const extensions = computed(() => {
 	baseExtensions.push(autocompletion(autocompletionOptions))
 	return baseExtensions
 })
+
+const isObjectLiteral = computed(
+	() => props.language === "javascript" && typeof props.modelValue === "object",
+)
 
 defineExpose({
 	errorMessage,

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -34,7 +34,7 @@ import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import JSON5 from "json5"
-import { jsonToJs, isPrivateKey, jsonReplacer, jsonReviver } from "@/utils/helpers"
+import { jsonToJs, isPrivateKey, jsonReplacer, unquoteFunctions, parseObjectString } from "@/utils/helpers"
 
 import InputLabel from "@/components/InputLabel.vue"
 
@@ -73,6 +73,7 @@ const setEditorValue = () => {
 	try {
 		if (props.language === "json" || typeof value === "object") {
 			value = JSON5.stringify(value, { replacer: jsonReplacer, space: 2, quote: '"' })
+			value = unquoteFunctions(value)
 		}
 		code.value = value
 	} catch (e) {
@@ -101,13 +102,7 @@ const emitEditorValue = () => {
 			if (props.language === "json") {
 				value = jsonToJs(value)
 			} else if (props.language === "javascript" && isValidObjectString(value)) {
-				try {
-					// forgiving single-quoted/unquoted keys; trailing commas
-					value = JSON5.parse(value, jsonReviver)
-				} catch (e) {
-					// fallback to JSON parsing
-					value = jsonToJs(value)
-				}
+				value = parseObjectString(value)
 			}
 		}
 

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -34,7 +34,8 @@ import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import JSON5 from "json5"
-import { jsonToJs, isPrivateKey, jsonReplacer, unquoteFunctions, parseObjectString } from "@/utils/helpers"
+import { isPrivateKey, unquoteFunctions } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 
 import InputLabel from "@/components/InputLabel.vue"
 
@@ -66,6 +67,7 @@ const props = withDefaults(
 	},
 )
 const emit = defineEmits(["update:modelValue", "save"])
+const { jsonReplacer, jsonToJs, parseObjectString } = useSerializer()
 
 const code = ref<string>("")
 const setEditorValue = () => {
@@ -109,7 +111,7 @@ const emitEditorValue = () => {
 		if (!props.showSaveButton && !props.readonly) {
 			emit("update:modelValue", value)
 		}
-	} catch (e) {
+	} catch (e: any) {
 		console.error("Error while parsing JSON for editor", e)
 		errorMessage.value = `Invalid object/JSON: ${e.message}`
 	}

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -34,7 +34,7 @@ import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import JSON5 from "json5"
-import { jsonToJs, isPrivateKey } from "@/utils/helpers"
+import { jsonToJs, isPrivateKey, jsonReplacer, jsonReviver } from "@/utils/helpers"
 
 import InputLabel from "@/components/InputLabel.vue"
 
@@ -72,7 +72,7 @@ const setEditorValue = () => {
 	let value = props.modelValue ?? ""
 	try {
 		if (props.language === "json" || typeof value === "object") {
-			value = JSON5.stringify(value, { replacer: null, space: 2, quote: '"' })
+			value = JSON5.stringify(value, { replacer: jsonReplacer, space: 2, quote: '"' })
 		}
 		code.value = value
 	} catch (e) {
@@ -103,7 +103,7 @@ const emitEditorValue = () => {
 			} else if (props.language === "javascript" && isValidObjectString(value)) {
 				try {
 					// forgiving single-quoted/unquoted keys; trailing commas
-					value = JSON5.parse(value)
+					value = JSON5.parse(value, jsonReviver)
 				} catch (e) {
 					// fallback to JSON parsing
 					value = jsonToJs(value)

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -35,7 +35,7 @@ import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
 import JSON5 from "json5"
 import { isPrivateKey } from "@/utils/helpers"
-import { unquoteFunctions, unquoteDynamicExpressions } from "@/utils/code"
+import { normalizeCode } from "@/utils/code"
 import { useSerializer } from "@/utils/useSerializer"
 
 import InputLabel from "@/components/InputLabel.vue"
@@ -76,8 +76,7 @@ const setEditorValue = () => {
 	try {
 		if (props.language === "json" || typeof value === "object") {
 			value = JSON5.stringify(value, { replacer: jsonReplacer, space: 2, quote: '"' })
-			value = unquoteFunctions(value)
-			value = unquoteDynamicExpressions(value)
+			value = normalizeCode(value)
 		}
 		code.value = value
 	} catch (e) {

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -33,7 +33,8 @@ import { LanguageSupport } from "@codemirror/language"
 import { EditorView, keymap } from "@codemirror/view"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
-import { jsToJson, jsonToJs, isPrivateKey } from "@/utils/helpers"
+import JSON5 from "json5"
+import { jsonToJs, isPrivateKey } from "@/utils/helpers"
 
 import InputLabel from "@/components/InputLabel.vue"
 
@@ -71,7 +72,7 @@ const setEditorValue = () => {
 	let value = props.modelValue ?? ""
 	try {
 		if (props.language === "json" || typeof value === "object") {
-			value = jsToJson(value)
+			value = JSON5.stringify(value, { replacer: null, space: 2, quote: '"' })
 		}
 	} catch (e) {
 		console.log("Error while converting value to JSON", e)
@@ -91,13 +92,6 @@ const isValidObjectString = (text: string) => {
 	return false
 }
 
-const parseObjectString = (text: string) => {
-	if (!isValidObjectString(text)) {
-		throw new Error("Invalid object")
-	}
-	return new Function("return " + text)()
-}
-
 const errorMessage = ref("")
 const emitEditorValue = () => {
 	try {
@@ -109,7 +103,7 @@ const emitEditorValue = () => {
 			} else if (props.language === "javascript" && isValidObjectString(value)) {
 				try {
 					// forgiving single-quoted/unquoted keys; trailing commas
-					value = parseObjectString(value)
+					value = JSON5.parse(value)
 				} catch (e) {
 					// fallback to JSON parsing
 					value = jsonToJs(value)

--- a/frontend/src/components/ComponentContextMenu.vue
+++ b/frontend/src/components/ComponentContextMenu.vue
@@ -31,7 +31,8 @@ import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import useComponentEditorStore from "@/stores/componentEditorStore"
 import type { ContextMenuOption } from "@/types"
-import { getBlockCopy, getComponentBlock, isObjectEmpty } from "@/utils/helpers"
+import { isObjectEmpty } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import getBlockTemplate from "@/utils/blockTemplate"
 import FormDialog from "@/components/FormDialog.vue"
 import NewComponentDialog from "@/components/NewComponentDialog.vue"
@@ -63,6 +64,7 @@ const handleContextMenuSelect = (action: CallableFunction) => {
 	contextMenuVisible.value = false
 }
 
+const { getBlockCopy, getComponentBlock } = useSerializer()
 const contextMenuOptions: ContextMenuOption[] = [
 	{
 		label: "Wrap In Container",

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -74,7 +74,7 @@
 import { computed, ref, watch } from "vue"
 import { createResource, Dialog } from "frappe-ui"
 import Block from "@/utils/block"
-import { getComponentBlock } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import type { DocTypeField } from "@/types"
 import components from "@/data/components"
 import { Link } from "frappe-ui/frappe"
@@ -191,6 +191,7 @@ const getComponentForField = (arg?: DocTypeField | string) => {
 
 const addFields = () => {
 	if (!props.block) return
+	const { getComponentBlock } = useSerializer()
 
 	formMeta.value.fields.forEach((field: FormField) => {
 		const newBlock = getComponentBlock(field.componentName)

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -95,7 +95,7 @@ import FitScreenIcon from "@/components/Icons/FitScreenIcon.vue"
 
 import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
-import { getBlockCopy, getBlockInfo } from "@/utils/helpers"
+import { getBlockInfo } from "@/utils/helpers"
 import setPanAndZoom from "@/utils/panAndZoom"
 import Block from "@/utils/block"
 import { useCanvasDropZone } from "@/utils/useCanvasDropZone"
@@ -103,6 +103,7 @@ import { useCanvasUtils } from "@/utils/useCanvasUtils"
 import type { BreakpointConfig, CanvasHistory } from "@/types/StudioCanvas"
 import type { Slot } from "@/types"
 import { useCanvasEvents } from "@/utils/useCanvasEvents"
+import { useSerializer } from "@/utils/useSerializer"
 
 const props = defineProps({
 	componentTree: {
@@ -169,6 +170,8 @@ watch(
 		setScaleAndTranslate()
 	},
 )
+
+const { getBlockCopy } = useSerializer()
 
 // clone props.block into canvas data to avoid mutating them
 const rootComponent = ref(getBlockCopy(props.componentTree, true))

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -171,6 +171,30 @@ const evaluationContext = computed(() => {
 	}
 })
 
+const evaluateDynamicValues = (value: any): any => {
+	if (typeof value === "string") {
+		if (isDynamicValue(value)) {
+			const evaluated = codeStore.getDynamicValue(value, evaluationContext.value)
+			return evaluated
+		}
+		return value
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => evaluateDynamicValues(item))
+	}
+
+	if (value !== null && typeof value === "object") {
+		const result: Record<string, any> = {}
+		for (const [key, val] of Object.entries(value)) {
+			result[key] = evaluateDynamicValues(val)
+		}
+		return result
+	}
+
+	return value
+}
+
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
@@ -178,9 +202,7 @@ const getComponentProps = () => {
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {
-		if (isDynamicValue(config)) {
-			propValues[propName] = codeStore.getDynamicValue(config, evaluationContext.value)
-		}
+		propValues[propName] = evaluateDynamicValues(config)
 	})
 	return propValues
 }
@@ -199,17 +221,7 @@ const componentRef = ref<ComponentPublicInstance | null>(null)
 const showComponent = computed(() => {
 	if (props.block.visibilityCondition) {
 		const value = codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
-		// Handle different return types:
-		// - Boolean: return as-is
-		// - String "true"/"false": convert to boolean
-		// - Other values: check truthiness
-		if (typeof value === "boolean") {
-			return value
-		} else if (typeof value === "string" && (value === "true" || value === "false")) {
-			return value === "true"
-		} else {
-			return value
-		}
+		return value
 	}
 	return true
 })

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -107,7 +107,6 @@ import StudioComponentWrapper from "@/components/StudioComponentWrapper.vue"
 import ComponentEditor from "@/components/ComponentEditor.vue"
 
 import Block from "@/utils/block"
-import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import { getComponentRoot, isHTML } from "@/utils/helpers"
 import { isDynamicValue } from "@/utils/code"
@@ -131,7 +130,6 @@ defineOptions({
 	inheritAttrs: false,
 })
 
-const store = useStudioStore()
 const canvasStore = useCanvasStore()
 const codeStore = useCodeStore()
 

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -171,30 +171,6 @@ const evaluationContext = computed(() => {
 	}
 })
 
-const evaluateDynamicValues = (value: any): any => {
-	if (typeof value === "string") {
-		if (isDynamicValue(value)) {
-			const evaluated = codeStore.getDynamicValue(value, evaluationContext.value)
-			return evaluated
-		}
-		return value
-	}
-
-	if (Array.isArray(value)) {
-		return value.map((item) => evaluateDynamicValues(item))
-	}
-
-	if (value !== null && typeof value === "object") {
-		const result: Record<string, any> = {}
-		for (const [key, val] of Object.entries(value)) {
-			result[key] = evaluateDynamicValues(val)
-		}
-		return result
-	}
-
-	return value
-}
-
 const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
@@ -202,7 +178,7 @@ const getComponentProps = () => {
 	delete propValues.modelValue
 
 	Object.entries(propValues).forEach(([propName, config]) => {
-		propValues[propName] = evaluateDynamicValues(config)
+		propValues[propName] = codeStore.evaluateDynamicValues(config, evaluationContext.value)
 	})
 	return propValues
 }
@@ -220,8 +196,7 @@ const componentRef = ref<ComponentPublicInstance | null>(null)
 // visibility
 const showComponent = computed(() => {
 	if (props.block.visibilityCondition) {
-		const value = codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
-		return value
+		return codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
 	}
 	return true
 })

--- a/frontend/src/components/StudioComponentRenderer.vue
+++ b/frontend/src/components/StudioComponentRenderer.vue
@@ -9,7 +9,6 @@ import Block from "@/utils/block"
 import useComponentStore from "@/stores/componentStore"
 
 import useCodeStore from "@/stores/codeStore"
-import { isDynamicValue } from "@/utils/code"
 
 const props = defineProps<{
 	studioComponent: Block
@@ -28,9 +27,7 @@ const componentContext = computed(() => {
 			}
 
 			Object.entries(context).forEach(([inputName, value]) => {
-				if (isDynamicValue(value)) {
-					context[inputName] = codeStore.getDynamicValue(value, props.evaluationContext)
-				}
+				context[inputName] = codeStore.evaluateDynamicValues(value, props.evaluationContext)
 			})
 		})
 	}

--- a/frontend/src/components/StudioComponentWrapper.vue
+++ b/frontend/src/components/StudioComponentWrapper.vue
@@ -8,7 +8,6 @@ import StudioComponent from "@/components/StudioComponent.vue"
 import Block from "@/utils/block"
 import useComponentStore from "@/stores/componentStore"
 import useCodeStore from "@/stores/codeStore"
-import { isDynamicValue } from "@/utils/code"
 
 const props = defineProps<{
 	studioComponent: Block
@@ -28,9 +27,7 @@ const componentContext = computed(() => {
 			}
 
 			Object.entries(context).forEach(([inputName, value]) => {
-				if (isDynamicValue(value)) {
-					context[inputName] = codeStore.getDynamicValue(value, props.evaluationContext)
-				}
+				context[inputName] = codeStore.evaluateDynamicValues(value, props.evaluationContext)
 			})
 		})
 	}

--- a/frontend/src/data/components.ts
+++ b/frontend/src/data/components.ts
@@ -459,10 +459,10 @@ export const COMPONENTS: FrappeUIComponents = {
 					label: "Name",
 					key: "name",
 					width: 3,
-					getLabel: function ({ row }: { row: any }) {
+					getLabel: ({ row }: { row: any }) => {
 						return row.name
 					},
-					prefix: function ({ row }: { row: any }) {
+					prefix: ({ row }: { row: any }) => {
 						// @ts-ignore
 						return h(Avatar, {
 							shape: "circle",

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -7,7 +7,8 @@ import { watch, ref } from "vue"
 import { useRoute } from "vue-router"
 import { usePageMeta } from "frappe-ui"
 
-import { getBlockInstance, jsonToJs, findPageWithRoute } from "@/utils/helpers"
+import { findPageWithRoute } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import AppComponent from "@/components/AppComponent.vue"
 
 import useAppStore from "@/stores/appStore"
@@ -22,6 +23,8 @@ const codeStore = useCodeStore()
 const page = ref<StudioPage | null>(null)
 
 const rootBlock = ref<Block | null>(null)
+
+const { jsonToJs, getBlockInstance } = useSerializer()
 
 watch(
 	() => route.path,

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -92,9 +92,9 @@ import StudioCanvas from "@/components/StudioCanvas.vue"
 import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import { studioPages } from "@/data/studioPages"
-import { getRootBlock } from "@/utils/helpers"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import { useStudioEvents } from "@/utils/useStudioEvents"
+import { useSerializer } from "@/utils/useSerializer"
 
 const route = useRoute()
 const router = useRouter()
@@ -146,6 +146,7 @@ watch(
 	{ deep: true },
 )
 
+const { getRootBlock } = useSerializer()
 async function setPage() {
 	if (route.params.pageID === store.selectedPage) return
 

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia"
 import { ref, reactive, computed } from "vue"
 import type Block from "@/utils/block"
-import { getBlockCopy, getBlockInstance } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 
 import type StudioCanvas from "@/components/StudioCanvas.vue"
 import type { EditingMode, BlockOptions } from "@/types"
@@ -86,6 +86,8 @@ const useCanvasStore = defineStore("canvasStore", () => {
 	const showFragmentCanvas = computed(() => {
 		return editingMode.value === "fragment" || editingMode.value === "component" && fragmentData.value?.block
 	})
+
+	const { getBlockCopy, getBlockInstance } = useSerializer()
 
 	async function editOnCanvas(
 		block: Block,

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -407,6 +407,8 @@ const useCodeStore = defineStore("codeStore", () => {
 		// watchers
 		setPageWatchers,
 		// code execution
+		globalContext,
+		globalExecutionContext,
 		getDynamicValue,
 		executeUserScript,
 		handleSuccess,

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -5,7 +5,7 @@ import { studioPageResources } from "@/data/studioResources"
 import { studioVariables } from "@/data/studioVariables"
 import { studioWatchers } from "@/data/studioWatchers"
 import { getInitialVariableValue, getValueFromObject, setValueInObject } from "@/utils/helpers"
-import { isDynamicValue } from "@/utils/code"
+import { isDynamicValue, normalizeDynamicValue } from "@/utils/code"
 import type { Filters, Resource, DocumentResource, DataResult } from "@/types/Studio/StudioResource"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
@@ -136,6 +136,12 @@ const useCodeStore = defineStore("codeStore", () => {
 				// for proptype as object, return the evaluated object as is
 				// TODO: handle this more explicitly by checking the actual prop type
 				return dynamicValue || undefined
+			}
+
+			// If the whole value is a single dynamic expression, return the normalized evaluated value
+			// e.g. value === "{{ showTooltip }}" should return boolean true/false if appropriate
+			if (value.trim().match(/^\{\{.*\}\}$/)) {
+				return normalizeDynamicValue(dynamicValue)
 			}
 
 			// Append the static part of the string

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -157,6 +157,30 @@ const useCodeStore = defineStore("codeStore", () => {
 		return result || undefined
 	}
 
+	function evaluateDynamicValues(value: string | object | number, localContext: ExpressionEvaluationContext = {}): any {
+		/* recurse into arrays/objects and evaluate dynamic expressions */
+		if (typeof value === "string") {
+			if (isDynamicValue(value)) {
+				return getDynamicValue(value, localContext)
+			}
+			return value
+		}
+
+		if (Array.isArray(value)) {
+			return value.map((item) => evaluateDynamicValues(item, localContext))
+		}
+
+		if (value !== null && typeof value === "object") {
+			const result: Record<string, any> = {}
+			for (const [key, val] of Object.entries(value)) {
+				result[key] = evaluateDynamicValues(val, localContext)
+			}
+			return result
+		}
+
+		return value
+	}
+
 	function evaluateExpression(expression: string, localContext: ExpressionEvaluationContext) {
 		try {
 			const context = { ...globalContext.value, ...localContext }
@@ -416,6 +440,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		globalContext,
 		globalExecutionContext,
 		getDynamicValue,
+		evaluateDynamicValues,
 		executeUserScript,
 		handleSuccess,
 		handleError,

--- a/frontend/src/stores/componentEditorStore.ts
+++ b/frontend/src/stores/componentEditorStore.ts
@@ -1,8 +1,9 @@
 import { defineStore } from "pinia"
 import { ref } from "vue"
 import { studioComponents } from "@/data/studioComponents"
-import { getBlockObject, getBlockInstance, confirm, getComponentBlock } from "@/utils/helpers"
+import { confirm } from "@/utils/helpers"
 import getBlockTemplate from "@/utils/blockTemplate"
+import { useSerializer } from "@/utils/useSerializer"
 import Block from "@/utils/block"
 import useCanvasStore from "@/stores/canvasStore"
 import { toast } from "vue-sonner"
@@ -15,11 +16,12 @@ const useComponentEditorStore = defineStore("componentEditorStore", () => {
 	const studioComponentBlock = ref<Block | null>(null)
 	const componentInputs = ref<ComponentInput[]>([])
 	const componentStore = useComponentStore()
+	const { getBlockObjectCopy, getBlockInstance, getComponentBlock } = useSerializer()
 
 	async function createComponent(componentName: string, block?: Block | null) {
 		const component: any = { component_name: componentName }
 		if (block) {
-			component.block = getBlockObject(block)
+			component.block = getBlockObjectCopy(block)
 			if (component.block?.parentSlotName) {
 				// remove parentSlotName from the top-level block of the component
 				delete component.block.parentSlotName
@@ -43,7 +45,7 @@ const useComponentEditorStore = defineStore("componentEditorStore", () => {
 	function saveComponent(block: Block, componentName: string) {
 		const payload: any = {
 			name: componentName,
-			block: getBlockObject(block),
+			block: getBlockObjectCopy(block),
 		}
 
 		payload.inputs = componentInputs.value.map((input) => ({

--- a/frontend/src/stores/componentEditorStore.ts
+++ b/frontend/src/stores/componentEditorStore.ts
@@ -72,8 +72,8 @@ const useComponentEditorStore = defineStore("componentEditorStore", () => {
 	}
 
 	async function editComponent(componentId: string) {
-		const componentDoc = componentStore.getComponentDoc(componentId)
 		const componentBlock = await componentStore.getComponent(componentId)
+		const componentDoc = componentStore.getComponentDoc(componentId)
 		const block = componentBlock || getBlockInstance(getBlockTemplate("empty-component"))
 		studioComponentBlock.value = getComponentBlock(componentId, true)
 

--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -3,13 +3,15 @@ import { markRaw, reactive } from "vue"
 import { createDocumentResource } from "frappe-ui"
 import Block from "@/utils/block"
 import type { StudioComponent } from "@/types/Studio/StudioComponent"
-import { getBlockInstance, getBlockObject, isObjectEmpty } from "@/utils/helpers"
+import { isObjectEmpty } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import getBlockTemplate from "@/utils/blockTemplate"
 
 const useComponentStore = defineStore("componentStore", () => {
 	const componentMap = reactive<Map<string, Block>>(new Map())
 	const componentDocMap = reactive<Map<string, StudioComponent>>(new Map())
 	const fetchingComponent = reactive<Set<string>>(new Set())
+	const { getBlockInstance, getBlockObjectCopy } = useSerializer()
 
 	async function fetchComponent(componentName: string) {
 		const componentDoc = await createDocumentResource({
@@ -78,7 +80,7 @@ const useComponentStore = defineStore("componentStore", () => {
 		if (!component) {
 			return
 		}
-		const blockOptions = getBlockObject(component)
+		const blockOptions = getBlockObjectCopy(component)
 		const { baseStyles, mobileStyles, tabletStyles, rawStyles, visibilityCondition, classes, componentEvents } =
 			studioComponent
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -3,16 +3,12 @@ import router from "@/router/studio_router"
 import { defineStore } from "pinia"
 
 import {
-	getBlockInstance,
-	getRootBlock,
-	jsToJson,
-	getBlockCopyWithoutParent,
-	jsonToJs,
 	fetchApp,
 	fetchPage,
 	confirm,
 	getInitialVariableValue,
 } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import { studioPages } from "@/data/studioPages"
 import { studioApps } from "@/data/studioApps"
 import { studioVariables } from "@/data/studioVariables"
@@ -150,6 +146,8 @@ const useStudioStore = defineStore("store", () => {
 	const selectedPage = ref<string | null>(null)
 	const savingPage = ref(false)
 	const settingPage = ref(false)
+
+	const { getBlockInstance, getRootBlock, getBlockCopyWithoutParent, jsToJson, jsonToJs } = useSerializer()
 
 	async function setPage(pageName: string) {
 		settingPage.value = true

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -155,6 +155,7 @@ const useStudioStore = defineStore("store", () => {
 		settingPage.value = true
 		const page = await fetchPage(pageName)
 		activePage.value = page
+		await setPageData(page)
 
 		const blocks = jsonToJs(page.draft_blocks || page.blocks || "[]")
 		if (blocks.length === 0) {
@@ -163,7 +164,6 @@ const useStudioStore = defineStore("store", () => {
 			pageBlocks.value = [getBlockInstance(blocks[0])]
 		}
 		selectedPage.value = page.name
-		await setPageData(page)
 
 		const canvasStore = useCanvasStore()
 		canvasStore.editingMode = "page"

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -15,7 +15,6 @@ import type { StyleValue, FrappeUIComponents } from "@/types"
 import type { ComponentEvent } from "@/types/ComponentEvent"
 
 export type styleProperty = keyof CSSProperties | `__${string}`;
-const { copyObject, getBlockCopy, getComponentBlock } = useSerializer()
 class Block implements BlockOptions {
 	componentId: string
 	componentName: string
@@ -71,6 +70,7 @@ class Block implements BlockOptions {
 
 		// get component props
 		if (!options.componentProps) {
+			const { copyObject } = useSerializer()
 			this.componentProps = copyObject(Block.components?.[options.componentName]?.initialState)
 		} else {
 			this.componentProps = options.componentProps
@@ -519,6 +519,7 @@ class Block implements BlockOptions {
 		if (this.isRoot()) return
 
 		const canvasStore = useCanvasStore()
+		const { getBlockCopy } = useSerializer()
 		const blockCopy = getBlockCopy(this)
 		const parentBlock = this.getParentBlock()
 
@@ -730,6 +731,7 @@ class Block implements BlockOptions {
 
 	// studio components
 	extendFromComponent(componentName: string) {
+		const { getComponentBlock } = useSerializer()
 		let parentBlock = this.getParentBlock()
 		const newBlock = getComponentBlock(componentName, true)
 

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -1,6 +1,6 @@
 import type { BlockOptions, BlockStyleMap, CompletionSource, Slot } from "@/types"
 import { clamp } from "@vueuse/core"
-import { reactive, CSSProperties, nextTick, computed } from 'vue'
+import { reactive, CSSProperties, nextTick } from 'vue'
 
 import useCanvasStore from "@/stores/canvasStore"
 import useComponentStore from "@/stores/componentStore"
@@ -8,12 +8,14 @@ import LucideHash from "~icons/lucide/hash"
 import LucideAppWindow from "~icons/lucide/app-window"
 import LucideBox from "~icons/lucide/box"
 
-import { copyObject, generateId, getBlockCopy, getComponentBlock, isObjectEmpty, kebabToCamelCase, numberToPx } from "./helpers";
+import { generateId, isObjectEmpty, kebabToCamelCase, numberToPx } from "./helpers";
+import { useSerializer } from "@/utils/useSerializer"
 
 import type { StyleValue, FrappeUIComponents } from "@/types"
 import type { ComponentEvent } from "@/types/ComponentEvent"
 
 export type styleProperty = keyof CSSProperties | `__${string}`;
+const { copyObject, getBlockCopy, getComponentBlock } = useSerializer()
 class Block implements BlockOptions {
 	componentId: string
 	componentName: string

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,4 +1,4 @@
-import { FUNCTION_STRING_REGEX, DYNAMIC_EXPRESSION_REGEX } from "@/utils/constants"
+import { FUNCTION_STRING_REGEX, DYNAMIC_EXPRESSION_REGEX, QUOTED_STRING_CONTENT_REGEX } from "@/utils/constants"
 
 export function isDynamicValue(value: string) {
 	// Check if the prop value is a string and contains a dynamic expression
@@ -22,35 +22,31 @@ export function normalizeCode(json5String: string) {
 }
 
 export function unquoteFunctions(json5String: string) {
-	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
-		const unescaped = content
-			.replace(/\\n/g, '\n')
-			.replace(/\\t/g, '\t')
-			.replace(/\\"/g, '"')
-			.replace(/\\\\/g, '\\')
-			.trim()
-
+	return json5String.replace(QUOTED_STRING_CONTENT_REGEX, (match, content) => {
+		const unescaped = unescape(content)
 		if (FUNCTION_STRING_REGEX.test(unescaped)) {
 			return unescaped
 		}
 		return match
 	})
-	return json5String
 }
 
 export function unquoteDynamicExpressions(json5String: string) {
 	/* Unquote quoted strings that are exactly a single dynamic expression: "{{ ... }}" */
-	return json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
-		const unescaped = content
-			.replace(/\\n/g, '\n')
-			.replace(/\\t/g, '\t')
-			.replace(/\\"/g, '"')
-			.replace(/\\\\/g, '\\')
-			.trim()
-
+	return json5String.replace(QUOTED_STRING_CONTENT_REGEX, (match, content) => {
+		const unescaped = unescape(content)
 		if (DYNAMIC_EXPRESSION_REGEX.test(unescaped)) {
 			return unescaped
 		}
 		return match
 	})
+}
+
+function unescape(str: string) {
+	return str
+		.replace(/\\n/g, '\n')
+		.replace(/\\t/g, '\t')
+		.replace(/\\"/g, '"')
+		.replace(/\\\\/g, '\\')
+		.trim()
 }

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,4 +1,4 @@
-import { FUNCTION_STRING_REGEX } from "@/utils/constants"
+import { FUNCTION_STRING_REGEX, DYNAMIC_EXPRESSION_REGEX } from "@/utils/constants"
 
 export function isDynamicValue(value: string) {
 	// Check if the prop value is a string and contains a dynamic expression
@@ -14,6 +14,11 @@ export function normalizeDynamicValue(value: any) {
 		return value === "true"
 	}
 	return value
+}
+
+export function normalizeCode(json5String: string) {
+	/* Normalize code by unquoting dynamic expressions & functions making it more readable */
+	return unquoteDynamicExpressions(unquoteFunctions(json5String))
 }
 
 export function unquoteFunctions(json5String: string) {
@@ -43,8 +48,7 @@ export function unquoteDynamicExpressions(json5String: string) {
 			.replace(/\\\\/g, '\\')
 			.trim()
 
-		// match exactly {{ ... }} (allow whitespace inside)
-		if (/^\{\{[\s\S]*\}\}$/.test(unescaped)) {
+		if (DYNAMIC_EXPRESSION_REGEX.test(unescaped)) {
 			return unescaped
 		}
 		return match

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,3 +1,5 @@
+import { FUNCTION_STRING_REGEX } from "@/utils/constants"
+
 export function isDynamicValue(value: string) {
 	// Check if the prop value is a string and contains a dynamic expression
 	if (typeof value !== "string") return false
@@ -12,4 +14,39 @@ export function normalizeDynamicValue(value: any) {
 		return value === "true"
 	}
 	return value
+}
+
+export function unquoteFunctions(json5String: string) {
+	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
+		const unescaped = content
+			.replace(/\\n/g, '\n')
+			.replace(/\\t/g, '\t')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\')
+			.trim()
+
+		if (FUNCTION_STRING_REGEX.test(unescaped)) {
+			return unescaped
+		}
+		return match
+	})
+	return json5String
+}
+
+export function unquoteDynamicExpressions(json5String: string) {
+	/* Unquote quoted strings that are exactly a single dynamic expression: "{{ ... }}" */
+	return json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
+		const unescaped = content
+			.replace(/\\n/g, '\n')
+			.replace(/\\t/g, '\t')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\')
+			.trim()
+
+		// match exactly {{ ... }} (allow whitespace inside)
+		if (/^\{\{[\s\S]*\}\}$/.test(unescaped)) {
+			return unescaped
+		}
+		return match
+	})
 }

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -3,3 +3,13 @@ export function isDynamicValue(value: string) {
 	if (typeof value !== "string") return false
 	return value && value.includes("{{") && value.includes("}}")
 }
+
+export function normalizeDynamicValue(value: any) {
+	/** Normalize evaluated dynamic results. */
+	if (typeof value === "boolean") {
+		return value
+	} else if (typeof value === "string" && (value === "true" || value === "false")) {
+		return value === "true"
+	}
+	return value
+}

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -60,3 +60,8 @@ export const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z
 
 // Matches strings that are entirely wrapped in double curly braces, e.g., "{{ expression }}" (allows whitespace inside)
 export const DYNAMIC_EXPRESSION_REGEX = /^\{\{[\s\S]*\}\}$/
+
+// Match a double-quoted string and capture its inner content, including escaped chars.
+// This pattern safely captures the contents of a JSON-style double-quoted string,
+// preserving escaped sequences (e.g. \" or \\n) in the captured group.
+export const QUOTED_STRING_CONTENT_REGEX = /"((?:[^"\\]|\\.)*)"/g

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -57,3 +57,6 @@ export const STUDIO_COMPONENTS = [
 
 // Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
 export const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/
+
+// Matches strings that are entirely wrapped in double curly braces, e.g., "{{ expression }}" (allows whitespace inside)
+export const DYNAMIC_EXPRESSION_REGEX = /^\{\{[\s\S]*\}\}$/

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -54,3 +54,6 @@ export const STUDIO_COMPONENTS = [
 	"BottomTabs",
 	"MarkdownEditor",
 ]
+
+// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
+export const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -260,12 +260,15 @@ function jsToJson(obj: ObjectLiteral): string {
 	return JSON.stringify(obj, jsonReplacer, 2)
 }
 
+// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
+const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/
+
 const jsonReviver = (_key: string, value: any) => {
 	const registeredComponents = window.__APP_COMPONENTS__ || {}
 	if (typeof value === "string") {
 		const trimmed = value.trim()
 		// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
-		const isFunctionString = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/.test(trimmed)
+		const isFunctionString = FUNCTION_STRING_REGEX.test(trimmed)
 
 		if (isFunctionString) {
 			// provide access to render function & frappeUI lib for editing props
@@ -278,6 +281,33 @@ const jsonReviver = (_key: string, value: any) => {
 
 function jsonToJs(json: string): any {
 	return JSON.parse(json, jsonReviver)
+}
+
+function unquoteFunctions(json5String: string) {
+	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
+		const unescaped = content
+			.replace(/\\n/g, '\n')
+			.replace(/\\t/g, '\t')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\')
+			.trim()
+
+		if (FUNCTION_STRING_REGEX.test(unescaped)) {
+			return unescaped
+		}
+		return match
+	})
+	return json5String
+}
+
+function parseObjectString(jsString: string) {
+	const registeredComponents = window.__APP_COMPONENTS__ || {}
+	try {
+		const fn = new Function("h", ...Object.keys(registeredComponents), `return (${jsString})`)
+		return fn(h, ...Object.values(registeredComponents))
+	} catch (e) {
+		throw e
+	}
 }
 
 const mapToObject = (map: Map<any, any>) => Object.fromEntries(map.entries());
@@ -588,11 +618,15 @@ export {
 	getValueFromObject,
 	setValueInObject,
 	isPrivateKey,
+	// serialization/deserialization
 	isJSONString,
 	jsToJson,
 	jsonToJs,
 	jsonReplacer,
 	jsonReviver,
+	unquoteFunctions,
+	parseObjectString,
+	// maps
 	mapToObject,
 	replaceMapKey,
 	isTargetEditable,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,67 +1,11 @@
-import { reactive, toRaw, h, Ref } from "vue"
-import Block from "./block"
-import getBlockTemplate from "./blockTemplate"
+import { Ref } from "vue"
 import { createDocumentResource, createResource, confirmDialog } from "frappe-ui"
 import { toast } from "vue-sonner"
 
-import type { ObjectLiteral, BlockOptions, StyleValue, SelectOption, HashString, RGBString } from "@/types"
+import { FUNCTION_STRING_REGEX } from "@/utils/constants"
+import type { ObjectLiteral, StyleValue, SelectOption, HashString, RGBString } from "@/types"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
 import type { StudioApp } from "@/types/Studio/StudioApp"
-
-function getBlockString(block: BlockOptions | Block): string {
-	return jsToJson(getBlockCopyWithoutParent(block))
-}
-
-function getBlockObjectCopy(block: BlockOptions | Block): BlockOptions {
-	return jsonToJs(getBlockString(block))
-}
-
-function getBlockInstance(options: BlockOptions | string, retainId = true): Block {
-	if (typeof options === "string") {
-		options = jsonToJs(options) as BlockOptions
-	}
-	if (!retainId) {
-		const deleteComponentId = (block: BlockOptions) => {
-			delete block.componentId
-			for (let child of block.children || []) {
-				deleteComponentId(child)
-			}
-
-			// clear componentId of slot children
-			for (let slot of Object.values(block.componentSlots || {})) {
-				if (Array.isArray(slot.slotContent)) {
-					for (let child of slot.slotContent) {
-						deleteComponentId(child)
-					}
-				}
-			}
-		}
-
-		const deleteSlotId = (block: BlockOptions) => {
-			for (let slot of Object.values(block.componentSlots || {})) {
-				delete slot.slotId
-			}
-		}
-
-		deleteComponentId(options)
-		deleteSlotId(options)
-	}
-	return reactive(new Block(options))
-}
-
-function getComponentBlock(componentName: string, isStudioComponent: boolean = false) {
-	return getBlockInstance({ componentName: componentName, isStudioComponent: isStudioComponent, blockName: componentName })
-}
-
-function getRootBlock(): Block {
-	return getBlockInstance(getBlockTemplate("body"))
-}
-
-function getBlockCopy(block: BlockOptions | Block, retainId = false): Block {
-	// remove parent block reference as JSON doesn't accept circular references
-	const b = copyObject(getBlockCopyWithoutParent(block))
-	return getBlockInstance(b, retainId)
-}
 
 function deepCloneObject(obj: any, skipKeys: string[] | null = null): any {
 	if (!obj || typeof obj !== "object") {
@@ -83,23 +27,21 @@ function deepCloneObject(obj: any, skipKeys: string[] | null = null): any {
 	return clonedObj
 }
 
-function getBlockCopyWithoutParent(block: BlockOptions | Block) {
-	const rawBlock = toRaw(block)
-	const blockCopy = deepCloneObject(rawBlock, ["parentBlock"]) as BlockOptions
-	delete blockCopy.parentBlock
-	delete blockCopy.repeaterDataItem
-	delete blockCopy.componentContext
+function unquoteFunctions(json5String: string) {
+	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
+		const unescaped = content
+			.replace(/\\n/g, '\n')
+			.replace(/\\t/g, '\t')
+			.replace(/\\"/g, '"')
+			.replace(/\\\\/g, '\\')
+			.trim()
 
-	blockCopy.children = blockCopy.children?.map((child) => getBlockCopyWithoutParent(child))
-
-	// remove parentBlock reference for slot children
-	for (const slot of Object.values(blockCopy.componentSlots || {})) {
-		if (Array.isArray(slot.slotContent)) {
-			slot.slotContent = slot.slotContent.map((child) => getBlockCopyWithoutParent(child))
+		if (FUNCTION_STRING_REGEX.test(unescaped)) {
+			return unescaped
 		}
-	}
-
-	return blockCopy
+		return match
+	})
+	return json5String
 }
 
 type BlockInfo = {
@@ -164,11 +106,6 @@ function kebabToCamelCase(str: string) {
 	});
 }
 
-function copyObject<T>(obj: T) {
-	if (!obj) return {}
-	return jsonToJs(jsToJson(obj))
-}
-
 function areObjectsEqual(obj1: ObjectLiteral, obj2: ObjectLiteral): boolean {
 	const keys1 = Object.keys(obj1)
 	const keys2 = Object.keys(obj2)
@@ -228,86 +165,6 @@ function setValueInObject(obj: Record<string, any>, key: string, value: any) {
 
 function isPrivateKey(key: string) {
 	return key.startsWith("_") || key.startsWith("__")
-}
-
-function isJSONString(str: string) {
-	try {
-		jsonToJs(str)
-	} catch (e) {
-		return false
-	}
-	return true
-}
-
-const jsonReplacer = (_key: string, value: any) => {
-	// Preserve functions by converting them to strings
-	if (typeof value === "function") {
-		return value.toString()
-	}
-	// Handle circular references
-	if (typeof value === "object" && value !== null) {
-		if (value instanceof Set) {
-			return [...value]
-		}
-		if (value instanceof Map) {
-			return Object.fromEntries(value.entries())
-		}
-	}
-	return value
-}
-
-function jsToJson(obj: ObjectLiteral): string {
-	return JSON.stringify(obj, jsonReplacer, 2)
-}
-
-// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
-const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/
-
-const jsonReviver = (_key: string, value: any) => {
-	const registeredComponents = window.__APP_COMPONENTS__ || {}
-	if (typeof value === "string") {
-		const trimmed = value.trim()
-		// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
-		const isFunctionString = FUNCTION_STRING_REGEX.test(trimmed)
-
-		if (isFunctionString) {
-			// provide access to render function & frappeUI lib for editing props
-			const fn = new Function("h", ...Object.keys(registeredComponents), `return (${value})`)
-			return fn(h, ...Object.values(registeredComponents))
-		}
-	}
-	return value
-}
-
-function jsonToJs(json: string): any {
-	return JSON.parse(json, jsonReviver)
-}
-
-function unquoteFunctions(json5String: string) {
-	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
-		const unescaped = content
-			.replace(/\\n/g, '\n')
-			.replace(/\\t/g, '\t')
-			.replace(/\\"/g, '"')
-			.replace(/\\\\/g, '\\')
-			.trim()
-
-		if (FUNCTION_STRING_REGEX.test(unescaped)) {
-			return unescaped
-		}
-		return match
-	})
-	return json5String
-}
-
-function parseObjectString(jsString: string) {
-	const registeredComponents = window.__APP_COMPONENTS__ || {}
-	try {
-		const fn = new Function("h", ...Object.keys(registeredComponents), `return (${jsString})`)
-		return fn(h, ...Object.values(registeredComponents))
-	} catch (e) {
-		throw e
-	}
 }
 
 const mapToObject = (map: Map<any, any>) => Object.fromEntries(map.entries());
@@ -600,32 +457,18 @@ function scrub(txt: string | null | undefined) {
 }
 
 export {
-	getBlockString,
-	getBlockObjectCopy as getBlockObject,
-	getBlockInstance,
-	getComponentBlock,
-	getRootBlock,
-	getBlockCopy,
-	getBlockCopyWithoutParent,
+	deepCloneObject,
+	unquoteFunctions,
 	getBlockInfo,
 	getComponentRoot,
 	numberToPx,
 	pxToNumber,
 	kebabToCamelCase,
-	copyObject,
 	areObjectsEqual,
 	isObjectEmpty,
 	getValueFromObject,
 	setValueInObject,
 	isPrivateKey,
-	// serialization/deserialization
-	isJSONString,
-	jsToJson,
-	jsonToJs,
-	jsonReplacer,
-	jsonReviver,
-	unquoteFunctions,
-	parseObjectString,
 	// maps
 	mapToObject,
 	replaceMapKey,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -27,23 +27,6 @@ function deepCloneObject(obj: any, skipKeys: string[] | null = null): any {
 	return clonedObj
 }
 
-function unquoteFunctions(json5String: string) {
-	json5String = json5String.replace(/"((?:[^"\\]|\\.)*)"/g, (match, content) => {
-		const unescaped = content
-			.replace(/\\n/g, '\n')
-			.replace(/\\t/g, '\t')
-			.replace(/\\"/g, '"')
-			.replace(/\\\\/g, '\\')
-			.trim()
-
-		if (FUNCTION_STRING_REGEX.test(unescaped)) {
-			return unescaped
-		}
-		return match
-	})
-	return json5String
-}
-
 type BlockInfo = {
 	blockId: string
 	breakpoint: string
@@ -458,7 +441,6 @@ function scrub(txt: string | null | undefined) {
 
 export {
 	deepCloneObject,
-	unquoteFunctions,
 	getBlockInfo,
 	getComponentRoot,
 	numberToPx,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -239,38 +239,40 @@ function isJSONString(str: string) {
 	return true
 }
 
-function jsToJson(obj: ObjectLiteral): string {
-	const replacer = (_key: string, value: any) => {
-		// Preserve functions by converting them to strings
-		if (typeof value === "function") {
-			return value.toString()
-		}
-		// Handle circular references
-		if (typeof value === "object" && value !== null) {
-			if (value instanceof Set) {
-			return [...value]
-			}
-			if (value instanceof Map) {
-			return Object.fromEntries(value.entries())
-			}
-		}
-		return value
+const jsonReplacer = (_key: string, value: any) => {
+	// Preserve functions by converting them to strings
+	if (typeof value === "function") {
+		return value.toString()
 	}
-	return JSON.stringify(obj, replacer, 2)
+	// Handle circular references
+	if (typeof value === "object" && value !== null) {
+		if (value instanceof Set) {
+			return [...value]
+		}
+		if (value instanceof Map) {
+			return Object.fromEntries(value.entries())
+		}
+	}
+	return value
+}
+
+function jsToJson(obj: ObjectLiteral): string {
+	return JSON.stringify(obj, jsonReplacer, 2)
+}
+
+const jsonReviver = (_key: string, value: any) => {
+	const registeredComponents = window.__APP_COMPONENTS__ || {}
+	// Convert functions back to functions
+	if (typeof value === "string" && value.startsWith("function")) {
+		// provide access to render function & frappeUI lib for editing props
+		const newFunc = new Function("scope", `with(scope) { return ${value}; }`)
+		return newFunc({"h": h, ...registeredComponents})
+	}
+	return value
 }
 
 function jsonToJs(json: string): any {
-	const registeredComponents = window.__APP_COMPONENTS__ || {}
-	const reviver = (_key: string, value: any) => {
-		// Convert functions back to functions
-		if (typeof value === "string" && value.startsWith("function")) {
-			// provide access to render function & frappeUI lib for editing props
-			const newFunc = new Function("scope", `with(scope) { return ${value}; }`)
-			return newFunc({"h": h, ...registeredComponents})
-		}
-		return value
-	}
-	return JSON.parse(json, reviver)
+	return JSON.parse(json, jsonReviver)
 }
 
 const mapToObject = (map: Map<any, any>) => Object.fromEntries(map.entries());
@@ -584,6 +586,8 @@ export {
 	isJSONString,
 	jsToJson,
 	jsonToJs,
+	jsonReplacer,
+	jsonReviver,
 	mapToObject,
 	replaceMapKey,
 	isTargetEditable,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -262,11 +262,16 @@ function jsToJson(obj: ObjectLiteral): string {
 
 const jsonReviver = (_key: string, value: any) => {
 	const registeredComponents = window.__APP_COMPONENTS__ || {}
-	// Convert functions back to functions
-	if (typeof value === "string" && value.startsWith("function")) {
-		// provide access to render function & frappeUI lib for editing props
-		const newFunc = new Function("scope", `with(scope) { return ${value}; }`)
-		return newFunc({"h": h, ...registeredComponents})
+	if (typeof value === "string") {
+		const trimmed = value.trim()
+		// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
+		const isFunctionString = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/.test(trimmed)
+
+		if (isFunctionString) {
+			// provide access to render function & frappeUI lib for editing props
+			const fn = new Function("h", ...Object.keys(registeredComponents), `return (${value})`)
+			return fn(h, ...Object.values(registeredComponents))
+		}
 	}
 	return value
 }

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -1,6 +1,6 @@
 import useCanvasStore from "@/stores/canvasStore"
 import Block from "@/utils/block"
-import { getComponentBlock } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import { useDropZone } from "@vueuse/core"
 import { Ref } from "vue"
 
@@ -12,6 +12,7 @@ export function useCanvasDropZone(
 	block: Ref<Block | null>,
 	findBlock: (id: string) => Block | null,
 ) {
+	const { getComponentBlock } = useSerializer()
 	const { isOverDropZone } = useDropZone(canvasContainer, {
 		onDrop: async (_files, ev) => {
 			const { parentComponent, index, slotName } = canvasStore.dropTarget

--- a/frontend/src/utils/useCanvasHistory.ts
+++ b/frontend/src/utils/useCanvasHistory.ts
@@ -1,6 +1,7 @@
 import { ref, Ref } from "vue";
 import Block from "@/utils/block";
-import { generateId, getBlockInstance, getBlockString } from "@/utils/helpers";
+import { generateId } from "@/utils/helpers";
+import { useSerializer } from "@/utils/useSerializer"
 import { debounceFilter, pausableFilter, watchIgnorable } from "@vueuse/core";
 
 type CanvasState = {
@@ -65,6 +66,7 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 	}
 
 	function createHistoryRecord() {
+		const { getBlockString } = useSerializer();
 		return {
 			block: getBlockString(source.value),
 			selectedBlockIds: selectedBlockIds.value,
@@ -72,6 +74,7 @@ export function useCanvasHistory(source: Ref<Block>, selectedBlockIds: Ref<Set<s
 	}
 
 	function setSource(value: CanvasState) {
+		const { getBlockInstance } = useSerializer();
 		ignorePrevAsyncBlockUpdates();
 		ignoreBlockUpdates(() => {
 			source.value = getBlockInstance(value.block);

--- a/frontend/src/utils/useSerializer.ts
+++ b/frontend/src/utils/useSerializer.ts
@@ -76,16 +76,24 @@ export const useSerializer = () => {
 		const codeStore = useCodeStore()
 		const registeredComponents = window.__APP_COMPONENTS__ || {}
 		try {
+			// Quote dynamic values before parsing
+			const processedString = quoteDynamicValues(jsString)
 			const fn = new Function(
 				"h",
 				...Object.keys(registeredComponents),
 				...Object.keys(codeStore.globalExecutionContext),
-				`return (${jsString})`
+				`return (${processedString})`
 			)
 			return fn(h, ...Object.values(registeredComponents), ...Object.values(codeStore.globalExecutionContext))
 		} catch (e) {
 			throw e
 		}
+	}
+
+	function quoteDynamicValues(str: string): string {
+		// Match {{ ... }} that is not already quoted (not preceded by " or ')
+		// This regex looks for {{ ... }} patterns that are not surrounded by quotes
+		return str.replace(/:\s*({{[^}]+}})\s*([,}\n\r])/g, ': "$1"$2')
 	}
 
 	function getBlockString(block: BlockOptions | Block): string {
@@ -170,6 +178,7 @@ export const useSerializer = () => {
 		jsonReviver,
 		copyObject,
 		parseObjectString,
+		quoteDynamicValues,
 		// block serialization/deserialization
 		getBlockString,
 		getBlockObjectCopy,

--- a/frontend/src/utils/useSerializer.ts
+++ b/frontend/src/utils/useSerializer.ts
@@ -1,0 +1,177 @@
+import { reactive, toRaw, h } from "vue"
+import Block from "./block"
+import getBlockTemplate from "@/utils/blockTemplate"
+import { deepCloneObject } from "@/utils/helpers"
+import { FUNCTION_STRING_REGEX } from "@/utils/constants"
+
+import type { ObjectLiteral, BlockOptions } from "@/types"
+
+/**
+ * Serialization and Deserialization utilities for Blocks and Objects
+*/
+export const useSerializer = () => {
+	function isJSONString(str: string) {
+		try {
+			jsonToJs(str)
+		} catch (e) {
+			return false
+		}
+		return true
+	}
+
+	const jsonReplacer = (_key: string, value: any) => {
+		// Preserve functions by converting them to strings
+		if (typeof value === "function") {
+			return value.toString()
+		}
+		// Handle circular references
+		if (typeof value === "object" && value !== null) {
+			if (value instanceof Set) {
+				return [...value]
+			}
+			if (value instanceof Map) {
+				return Object.fromEntries(value.entries())
+			}
+		}
+		return value
+	}
+
+	function jsToJson(obj: ObjectLiteral): string {
+		return JSON.stringify(obj, jsonReplacer, 2)
+	}
+
+	const jsonReviver = (_key: string, value: any) => {
+		const registeredComponents = window.__APP_COMPONENTS__ || {}
+		if (typeof value === "string") {
+			const trimmed = value.trim()
+			const isFunctionString = FUNCTION_STRING_REGEX.test(trimmed)
+
+
+			if (isFunctionString) {
+				// provide access to render function & frappeUI lib for editing props
+				const fn = new Function(
+					"h",
+					...Object.keys(registeredComponents),
+					`return (${value})`
+				)
+				return fn(h, ...Object.values(registeredComponents))
+			}
+		}
+		return value
+	}
+
+	function jsonToJs(json: string): any {
+		return JSON.parse(json, jsonReviver)
+	}
+
+	function copyObject<T>(obj: T) {
+		if (!obj) return {}
+		return jsonToJs(jsToJson(obj))
+	}
+
+	function parseObjectString(jsString: string) {
+		const registeredComponents = window.__APP_COMPONENTS__ || {}
+		try {
+			const fn = new Function(
+				"h",
+				...Object.keys(registeredComponents),
+				`return (${jsString})`
+			)
+			return fn(h, ...Object.values(registeredComponents))
+		} catch (e) {
+			throw e
+		}
+	}
+
+	function getBlockString(block: BlockOptions | Block): string {
+		return jsToJson(getBlockCopyWithoutParent(block))
+	}
+
+	function getBlockObjectCopy(block: BlockOptions | Block): BlockOptions {
+		return jsonToJs(getBlockString(block))
+	}
+
+	function getBlockInstance(options: BlockOptions | string, retainId = true): Block {
+		if (typeof options === "string") {
+			options = jsonToJs(options) as BlockOptions
+		}
+		if (!retainId) {
+			const deleteComponentId = (block: BlockOptions) => {
+				delete block.componentId
+				for (let child of block.children || []) {
+					deleteComponentId(child)
+				}
+
+				// clear componentId of slot children
+				for (let slot of Object.values(block.componentSlots || {})) {
+					if (Array.isArray(slot.slotContent)) {
+						for (let child of slot.slotContent) {
+							deleteComponentId(child)
+						}
+					}
+				}
+			}
+
+			const deleteSlotId = (block: BlockOptions) => {
+				for (let slot of Object.values(block.componentSlots || {})) {
+					delete slot.slotId
+				}
+			}
+
+			deleteComponentId(options)
+			deleteSlotId(options)
+		}
+		return reactive(new Block(options))
+	}
+
+	function getComponentBlock(componentName: string, isStudioComponent: boolean = false) {
+		return getBlockInstance({ componentName: componentName, isStudioComponent: isStudioComponent, blockName: componentName })
+	}
+
+	function getRootBlock(): Block {
+		return getBlockInstance(getBlockTemplate("body"))
+	}
+
+	function getBlockCopy(block: BlockOptions | Block, retainId = false): Block {
+		// remove parent block reference as JSON doesn't accept circular references
+		const b = copyObject(getBlockCopyWithoutParent(block))
+		return getBlockInstance(b, retainId)
+	}
+
+	function getBlockCopyWithoutParent(block: BlockOptions | Block) {
+		const rawBlock = toRaw(block)
+		const blockCopy = deepCloneObject(rawBlock, ["parentBlock"]) as BlockOptions
+		delete blockCopy.parentBlock
+		delete blockCopy.repeaterDataItem
+		delete blockCopy.componentContext
+
+		blockCopy.children = blockCopy.children?.map((child) => getBlockCopyWithoutParent(child))
+
+		// remove parentBlock reference for slot children
+		for (const slot of Object.values(blockCopy.componentSlots || {})) {
+			if (Array.isArray(slot.slotContent)) {
+				slot.slotContent = slot.slotContent.map((child) => getBlockCopyWithoutParent(child))
+			}
+		}
+
+		return blockCopy
+	}
+
+	return {
+		isJSONString,
+		jsToJson,
+		jsonReplacer,
+		jsonToJs,
+		jsonReviver,
+		copyObject,
+		parseObjectString,
+		// block serialization/deserialization
+		getBlockString,
+		getBlockObjectCopy,
+		getBlockInstance,
+		getComponentBlock,
+		getRootBlock,
+		getBlockCopy,
+		getBlockCopyWithoutParent,
+	}
+}

--- a/frontend/src/utils/useSerializer.ts
+++ b/frontend/src/utils/useSerializer.ts
@@ -5,6 +5,7 @@ import { deepCloneObject } from "@/utils/helpers"
 import { FUNCTION_STRING_REGEX } from "@/utils/constants"
 
 import type { ObjectLiteral, BlockOptions } from "@/types"
+import useCodeStore from "@/stores/codeStore"
 
 /**
  * Serialization and Deserialization utilities for Blocks and Objects
@@ -41,6 +42,7 @@ export const useSerializer = () => {
 	}
 
 	const jsonReviver = (_key: string, value: any) => {
+		const codeStore = useCodeStore()
 		const registeredComponents = window.__APP_COMPONENTS__ || {}
 		if (typeof value === "string") {
 			const trimmed = value.trim()
@@ -52,9 +54,10 @@ export const useSerializer = () => {
 				const fn = new Function(
 					"h",
 					...Object.keys(registeredComponents),
+					...Object.keys(codeStore.globalExecutionContext),
 					`return (${value})`
 				)
-				return fn(h, ...Object.values(registeredComponents))
+				return fn(h, ...Object.values(registeredComponents), ...Object.values(codeStore.globalExecutionContext))
 			}
 		}
 		return value
@@ -70,14 +73,16 @@ export const useSerializer = () => {
 	}
 
 	function parseObjectString(jsString: string) {
+		const codeStore = useCodeStore()
 		const registeredComponents = window.__APP_COMPONENTS__ || {}
 		try {
 			const fn = new Function(
 				"h",
 				...Object.keys(registeredComponents),
+				...Object.keys(codeStore.globalExecutionContext),
 				`return (${jsString})`
 			)
-			return fn(h, ...Object.values(registeredComponents))
+			return fn(h, ...Object.values(registeredComponents), ...Object.values(codeStore.globalExecutionContext))
 		} catch (e) {
 			throw e
 		}

--- a/frontend/src/utils/useStudioEvents.ts
+++ b/frontend/src/utils/useStudioEvents.ts
@@ -5,11 +5,9 @@ import blockController from "@/utils/blockController"
 import {
 	isCtrlOrCmd,
 	isTargetEditable,
-	isJSONString,
-	getBlockCopy,
-	getBlockCopyWithoutParent,
 	setClipboardData,
 } from "@/utils/helpers"
+import { useSerializer } from "@/utils/useSerializer"
 import Block from "@/utils/block"
 import type { BlockOptions } from "@/types"
 
@@ -38,6 +36,8 @@ export function useStudioEvents() {
 
 		const data = e.clipboardData?.getData("studio-copied-blocks") as string
 		// paste blocks directly
+		const { isJSONString, getBlockCopy } = useSerializer()
+
 		if (data && isJSONString(data)) {
 			const dataObj = JSON.parse(data) as { blocks: Block[] }
 
@@ -156,6 +156,7 @@ const copySelectedBlocksToClipboard = (e: ClipboardEvent) => {
 	if (canvasStore.activeCanvas?.selectedBlocks.length) {
 		e.preventDefault()
 
+		const { getBlockCopyWithoutParent } = useSerializer()
 		const blocksToCopy = canvasStore.activeCanvas?.selectedBlocks.map((block) => {
 			return getBlockCopyWithoutParent(block)
 		})


### PR DESCRIPTION
### Before:

<img width="1624" height="1056" alt="object-editing-before" src="https://github.com/user-attachments/assets/8659889c-5176-40cb-83da-9f3074e96084" />

### After:

<img width="1624" height="1056" alt="object-editing-after" src="https://github.com/user-attachments/assets/55320c6b-c712-47af-82f8-a3acce2fb351" />

### Changes

1. Easier object editing: Although [this PR](https://github.com/frappe/studio/pull/91) made editing objects easier, display for objects was still not JS friendly: keys were always double-quoted. Use [JSON5](https://json5.org/) for human-friendly display & editing in code fields. Closes https://github.com/frappe/studio/issues/135
2. Support arrow functions/async functions in block props
3. Allow reading/referencing variables & resources in functions inside props
4. Evaluate dynamic values inside object props
5. Unquote functions & dynamic values inside code editor for easier editing in code fields
6. Refactor: Moved all block/object serialization code to `useSerializer` composable from `helpers.ts`
7. Fix: set page data before setting page blocks dependent on data
8. Fix: Edit component action failing for components not used on the page -> load component before fetching component doc map
9. Fix: indentation for object literals in code fields - codemirror fails to identify and indent bare object literals

<details>
<summary>Indentation Fixes</summary>
<b>Before:</b>

https://github.com/user-attachments/assets/e64c54f4-a29e-4af8-bfd6-2dcff0c02290

<b>After: </b>

https://github.com/user-attachments/assets/f02cf05a-3470-45e1-89d5-07549d68db72

</details>