### PR TITLE
feat(Utility): register `studio.call` for direct API calls

### DIFF
--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -1,6 +1,7 @@
 import app_router from "@/router/app_router"
 import { toast } from "vue-sonner"
 import type { RouteLocationRaw } from "vue-router"
+import { call } from "frappe-ui"
 
 declare global {
 	interface Window {
@@ -37,6 +38,7 @@ const utils = {
 				return toast(toastMessage, { description })
 		}
 	},
+	call: call,
 }
 
 Object.assign(window.studio, utils)

--- a/frontend/src/utils/appUtilsRenderer.ts
+++ b/frontend/src/utils/appUtilsRenderer.ts
@@ -1,6 +1,7 @@
 import studio_router from "@/router/studio_router"
 import { toast } from "vue-sonner"
 import type { RouteLocationRaw } from "vue-router"
+import { call } from "frappe-ui"
 
 declare global {
 	interface Window {
@@ -37,6 +38,7 @@ const utils = {
 				return toast(toastMessage, { description })
 		}
 	},
+	call: call,
 }
 
 Object.assign(window.studio, utils)


### PR DESCRIPTION
`studio.call` utility function for direct API calls:

<img width="1624" height="1056" alt="studio call" src="https://github.com/user-attachments/assets/9cc67d5e-47e9-4279-89e6-7228416da746" />

**Execution**:

https://github.com/user-attachments/assets/1b75b016-703f-44f9-a9d0-6902dae6a0d9

> [!NOTE]
> 1. Its recommended to use data sources (resources) instead of studio.call to keep reactivity intact. Eg: if you want to perform CRUD operations on some document and you are also displaying it in UI, its better to create a Document List data source and do:
> `campaigns.insert.submit`, `campaigns.delete.submit`, `campaigns.setValue.submit` to keep the UI updated whenever these changes happen. If you use the `call` function here, you will have to explicitly reload the data source (document.reload()) to keep the UI in sync with backend changes.
> 2. `studio.call` should be used when you want to call different APIs in scripts that are not directly dependent on the UI or you can take care of them by reloading existing data sources. Eg: fetching some setting to map data before inserting/updating document, API calls for pre/post processing after CRUD operations (ideally that should happen on the server-side)

Partially closes https://github.com/frappe/studio/issues/68
