### PR TITLE
fix: deserialization failing for functions followed by other code

### DIFF
--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -55,8 +55,11 @@ export const STUDIO_COMPONENTS = [
 	"MarkdownEditor",
 ]
 
-// Matches: "function", "async function", "() =>", "(x) =>", "x =>", "({ x }) =>", "async () =>", etc.
-export const FUNCTION_STRING_REGEX = /^(async\s+)?(function\b|(\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>)/
+// Matches a single complete function (function declaration or arrow function), nothing before or after
+// - Function declaration: (async)? function name?(...) {...}
+// - Arrow function: (async)? (...) => expr or (...) => {...}
+export const FUNCTION_STRING_REGEX =
+	/^\s*(?:async\s+)?(?:(?:function\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{(?:[^{}]|\{[^{}]*\})*\})|(?:(?:\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>\s*(?:\{(?:[^{}]|\{[^{}]*\})*\}|[^,;{}]+)))\s*$/
 
 // Matches strings that are entirely wrapped in double curly braces, e.g., "{{ expression }}" (allows whitespace inside)
 export const DYNAMIC_EXPRESSION_REGEX = /^\{\{[\s\S]*\}\}$/

--- a/frontend/src/utils/useSerializer.ts
+++ b/frontend/src/utils/useSerializer.ts
@@ -48,16 +48,19 @@ export const useSerializer = () => {
 			const trimmed = value.trim()
 			const isFunctionString = FUNCTION_STRING_REGEX.test(trimmed)
 
-
 			if (isFunctionString) {
-				// provide access to render function & frappeUI lib for editing props
-				const fn = new Function(
-					"h",
-					...Object.keys(registeredComponents),
-					...Object.keys(codeStore.globalExecutionContext),
-					`return (${value})`
-				)
-				return fn(h, ...Object.values(registeredComponents), ...Object.values(codeStore.globalExecutionContext))
+				try {
+					// provide access to render function & frappeUI lib for editing props
+					const fn = new Function(
+						"h",
+						...Object.keys(registeredComponents),
+						...Object.keys(codeStore.globalExecutionContext),
+						`return (${value})`
+					)
+					return fn(h, ...Object.values(registeredComponents), ...Object.values(codeStore.globalExecutionContext))
+				} catch (e) {
+					return value
+				}
 			}
 		}
 		return value


### PR DESCRIPTION
**Bug**:
Scripts like these fail during block deserialization:

<img width="837" height="764" alt="image" src="https://github.com/user-attachments/assets/9714baaf-f340-4133-896d-d0402489c8a3" />

```javascript
VM13502:8 Uncaught (in promise) SyntaxError: Unexpected identifier 'callAPI'
    at new Function (<anonymous>)
    at Object.jsonReviver (useSerializer.ts:54:16)
    at JSON.parse (<anonymous>)
    at jsonToJs (useSerializer.ts:67:15)
    at Proxy.setPage (studioStore.ts:158:18)
    at async setPage (StudioPage.vue:167:3)
    at async watch.immediate (StudioPage.vue:187:3)
```
The deserialization is trying to convert this function string into an actual function but this is actually not just a function, its followed by the call.

**Fix**:
- regex for fn string should match & ensure it's a single function before attempting to create a function from the string
- return value as is on running into errors while creating function

Fixes for https://github.com/frappe/studio/pull/134