### PR TITLE
feat(two-way binding): Sync any prop with variable, not just modelValue

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -121,7 +121,7 @@ const boundValue = computed({
 	get() {
 		const modelValue = props.block.componentProps.modelValue
 		if (modelValue?.$type === "variable") {
-			return codeStore.getValueFromVariable(modelValue.name)
+			return codeStore.getValueFromVariable(modelValue.name, evaluationContext.value)
 		} else if (isDynamicValue(modelValue)) {
 			return codeStore.getDynamicValue(modelValue, evaluationContext.value)
 		}
@@ -130,7 +130,7 @@ const boundValue = computed({
 	set(newValue) {
 		const modelValue = props.block.componentProps.modelValue
 		if (modelValue?.$type === "variable") {
-			codeStore.setValueInVariable(modelValue.name, newValue)
+			codeStore.setValueInVariable(modelValue.name, newValue, evaluationContext.value)
 		} else {
 			// update the prop directly if not bound to a variable
 			props.block.setProp("modelValue", newValue)

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -10,11 +10,10 @@
 		v-show="showComponent"
 		:is="componentName"
 		v-bind="componentProps"
-		v-model="boundValue"
+		v-on="{ ...vModelListeners, ...componentEvents }"
 		:data-component-id="block.componentId"
 		:style="styles"
 		:class="classes"
-		v-on="componentEvents"
 	>
 		<!-- Dynamically render named slots -->
 		<template v-for="(slot, slotName) in block.componentSlots" :key="slotName" v-slot:[slotName]>
@@ -35,7 +34,7 @@
 
 <script setup lang="ts">
 import Block from "@/utils/block"
-import { computed, onMounted, ref, useAttrs, inject, type ComputedRef, toRefs } from "vue"
+import { computed, onMounted, ref, useAttrs, inject, type ComputedRef } from "vue"
 import type { ComponentPublicInstance } from "vue"
 import { useRouter } from "vue-router"
 import { createResource } from "frappe-ui"
@@ -92,13 +91,33 @@ const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
 	const propValues = props.block.getPropsAndAttributes()
-	delete propValues.modelValue
-
-	Object.entries(propValues).forEach(([propName, config]) => {
-		propValues[propName] = codeStore.evaluateDynamicValues(config, evaluationContext.value)
+	Object.entries(propValues).forEach(([propName, propValue]) => {
+		if (propValue?.$type === "variable") {
+			propValues[propName] = codeStore.getValueFromVariable(propValue.name, evaluationContext.value)
+		} else if (isDynamicValue(propValue)) {
+			propValues[propName] = codeStore.evaluateDynamicValues(propValue, evaluationContext.value)
+		}
 	})
 	return propValues
 }
+
+// 2-way binding
+const vModelListeners = computed(() => {
+	if (!props.block || props.block.isRoot()) return {}
+
+	const listeners: Record<string, Function> = {}
+	const propValues = props.block.getPropsAndAttributes()
+
+	Object.entries(propValues).forEach(([propName, propValue]) => {
+		if (propValue?.$type === "variable") {
+			const eventName = `update:${propName}`
+			listeners[eventName] = (newValue: any) => {
+				codeStore.setValueInVariable(propValue.name, newValue, evaluationContext.value)
+			}
+		}
+	})
+	return listeners
+})
 
 const attrs = useAttrs()
 const componentProps = computed(() => {
@@ -114,28 +133,6 @@ const showComponent = computed(() => {
 		return codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
 	}
 	return true
-})
-
-// modelValue binding
-const boundValue = computed({
-	get() {
-		const modelValue = props.block.componentProps.modelValue
-		if (modelValue?.$type === "variable") {
-			return codeStore.getValueFromVariable(modelValue.name, evaluationContext.value)
-		} else if (isDynamicValue(modelValue)) {
-			return codeStore.getDynamicValue(modelValue, evaluationContext.value)
-		}
-		return modelValue
-	},
-	set(newValue) {
-		const modelValue = props.block.componentProps.modelValue
-		if (modelValue?.$type === "variable") {
-			codeStore.setValueInVariable(modelValue.name, newValue, evaluationContext.value)
-		} else {
-			// update the prop directly if not bound to a variable
-			props.block.setProp("modelValue", newValue)
-		}
-	},
 })
 
 // events

--- a/frontend/src/components/AppLayout/Repeater.vue
+++ b/frontend/src/components/AppLayout/Repeater.vue
@@ -6,7 +6,7 @@
 		>
 			{{ emptyStateMessage || "No data" }}
 		</div>
-		<template v-else v-for="(dataItem, dataIndex) in data" :key="dataItem?.[dataKey]">
+		<template v-else v-for="(dataItem, dataIndex) in data" :key="dataItem?.[dataKey] || dataIndex">
 			<RepeaterContextProvider :dataItem="dataItem" :dataIndex="dataIndex" :dataKey="dataKey">
 				<slot v-bind="{ dataItem, dataKey, dataIndex }"></slot>
 			</RepeaterContextProvider>

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -61,7 +61,6 @@ const emit = defineEmits<{
 }>()
 const bindVariable = ref(!!props.isVariableBound)
 
-// Watch for external changes to isVariableBound prop
 watch(
 	() => props.isVariableBound,
 	(newValue) => {

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -8,15 +8,23 @@
 		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value, bindVariable)"
 	>
 		<template #target="{ togglePopover }">
-			<slot name="target" v-if="$slots.target" v-bind="{ togglePopover }"></slot>
-			<Tooltip v-else text="Click to set dynamic value" placement="bottom">
-				<FeatherIcon
-					ref="dropdownTrigger"
-					name="plus-circle"
-					class="mr-1 h-3 w-4 cursor-pointer select-none text-ink-gray-5 outline-none hover:text-ink-gray-9"
-					@click="togglePopover"
-				/>
-			</Tooltip>
+			<IconButton
+				v-if="bindVariable"
+				:icon="Link2"
+				label="Synced with variable. Click to change."
+				placement="bottom"
+				class="mr-1"
+				@click="togglePopover"
+			/>
+			<IconButton
+				v-else
+				icon="plus-circle"
+				label="Click to set dynamic value"
+				placement="bottom"
+				class="mr-1"
+				size="sm"
+				@click="togglePopover"
+			/>
 		</template>
 
 		<template #item-suffix="{ option }">
@@ -25,7 +33,7 @@
 		<template #footer>
 			<div class="p-1" @mousedown.prevent>
 				<Switch
-					modelValue="bindVariable"
+					v-model="bindVariable"
 					label="Sync with variable"
 					description="Changing the selected variable value will change the prop value and vice versa"
 				/>
@@ -35,8 +43,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue"
-import { Autocomplete, Tooltip, Switch } from "frappe-ui"
+import { computed, ref, watch } from "vue"
+import { Autocomplete, Switch } from "frappe-ui"
+import IconButton from "@/components/IconButton.vue"
 import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import useComponentEditorStore from "@/stores/componentEditorStore"
@@ -45,14 +54,26 @@ import type { VariableOption } from "@/types/Studio/StudioPageVariable"
 import type { ComponentInput } from "@/types/Studio/StudioComponent"
 import { isObjectEmpty } from "@/utils/helpers"
 import useCodeStore from "@/stores/codeStore"
+import Link2 from "~icons/lucide/link-2"
 
-const props = withDefaults(defineProps<{ block?: Block; formatValuesAsTemplate?: boolean }>(), {
-	formatValuesAsTemplate: true,
-})
+const props = withDefaults(
+	defineProps<{ block?: Block; isVariableBound?: string | null; formatValuesAsTemplate?: boolean }>(),
+	{
+		formatValuesAsTemplate: true,
+	},
+)
 const emit = defineEmits<{
 	(event: "update:modelValue", value: string, bindVariable: boolean): void
 }>()
-const bindVariable = ref(false)
+const bindVariable = ref(!!props.isVariableBound)
+
+// Watch for external changes to isVariableBound prop
+watch(
+	() => props.isVariableBound,
+	(newValue) => {
+		bindVariable.value = !!newValue
+	},
+)
 
 const store = useStudioStore()
 const canvasStore = useCanvasStore()

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -31,12 +31,11 @@
 			<span class="text-ink-gray-4">{{ option.type?.toLowerCase() }}</span>
 		</template>
 		<template #footer>
-			<div class="p-1" @mousedown.prevent>
-				<Switch
-					v-model="bindVariable"
-					label="Sync with variable"
-					description="Changing the selected variable value will change the prop value and vice versa"
-				/>
+			<div class="flex items-center p-2" @mousedown.prevent>
+				<Tooltip text="Changing the selected variable value will change the prop value and vice versa">
+					<FeatherIcon name="info" class="size-3 text-ink-gray-5" />
+				</Tooltip>
+				<Switch v-model="bindVariable" label="Sync with variable" class="w-full" />
 			</div>
 		</template>
 	</Autocomplete>
@@ -44,7 +43,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue"
-import { Autocomplete, Switch } from "frappe-ui"
+import { Autocomplete, Switch, Tooltip } from "frappe-ui"
 import IconButton from "@/components/IconButton.vue"
 import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -56,12 +56,7 @@ import { isObjectEmpty } from "@/utils/helpers"
 import useCodeStore from "@/stores/codeStore"
 import Link2 from "~icons/lucide/link-2"
 
-const props = withDefaults(
-	defineProps<{ block?: Block; isVariableBound?: string | null; formatValuesAsTemplate?: boolean }>(),
-	{
-		formatValuesAsTemplate: true,
-	},
-)
+const props = defineProps<{ block?: Block; isVariableBound?: string | null }>()
 const emit = defineEmits<{
 	(event: "update:modelValue", value: string, bindVariable: boolean): void
 }>()
@@ -79,13 +74,6 @@ const store = useStudioStore()
 const canvasStore = useCanvasStore()
 const codeStore = useCodeStore()
 
-const formatValue = (value: string) => {
-	if (props.formatValuesAsTemplate) {
-		return `{{ ${value} }}`
-	}
-	return value
-}
-
 const dynamicValueOptions = computed(() => {
 	const groups = []
 
@@ -96,7 +84,7 @@ const dynamicValueOptions = computed(() => {
 			const componentContext: VariableOption[] = []
 			componentInputs.map?.((input: ComponentInput) => {
 				componentContext.push({
-					value: formatValue(`inputs.${input.input_name}`),
+					value: `inputs.${input.input_name}`,
 					label: `inputs.${input.input_name}`,
 					type: input.type,
 				})
@@ -111,10 +99,7 @@ const dynamicValueOptions = computed(() => {
 		if (store.variableOptions.length > 0) {
 			groups.push({
 				group: "Variables",
-				items: store.variableOptions.map((option) => ({
-					...option,
-					value: formatValue(option.value),
-				})),
+				items: store.variableOptions,
 			})
 		}
 		// Data Sources group
@@ -124,7 +109,7 @@ const dynamicValueOptions = computed(() => {
 					? `${resourceName}.doc`
 					: `${resourceName}.data`
 			return {
-				value: formatValue(completion),
+				value: completion,
 				label: resourceName,
 				type: "array",
 			}
@@ -141,7 +126,7 @@ const dynamicValueOptions = computed(() => {
 	const repeaterContext = props.block?.repeaterDataItem
 	if (!isObjectEmpty(repeaterContext)) {
 		const repeaterOptions = Object.keys(repeaterContext!).map((key) => ({
-			value: formatValue(`dataItem.${key}`),
+			value: `dataItem.${key}`,
 			label: `dataItem.${key}`,
 			type: typeof repeaterContext![key],
 		}))

--- a/frontend/src/components/DynamicValueSelector.vue
+++ b/frontend/src/components/DynamicValueSelector.vue
@@ -3,8 +3,9 @@
 		size="sm"
 		:options="dynamicValueOptions"
 		class="!w-auto"
+		placement="left-start"
 		modelValue=""
-		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value)"
+		@update:modelValue="(option: VariableOption) => emit('update:modelValue', option.value, bindVariable)"
 	>
 		<template #target="{ togglePopover }">
 			<slot name="target" v-if="$slots.target" v-bind="{ togglePopover }"></slot>
@@ -21,12 +22,21 @@
 		<template #item-suffix="{ option }">
 			<span class="text-ink-gray-4">{{ option.type?.toLowerCase() }}</span>
 		</template>
+		<template #footer>
+			<div class="p-1" @mousedown.prevent>
+				<Switch
+					modelValue="bindVariable"
+					label="Sync with variable"
+					description="Changing the selected variable value will change the prop value and vice versa"
+				/>
+			</div>
+		</template>
 	</Autocomplete>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue"
-import { Autocomplete, Tooltip } from "frappe-ui"
+import { computed, ref } from "vue"
+import { Autocomplete, Tooltip, Switch } from "frappe-ui"
 import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import useComponentEditorStore from "@/stores/componentEditorStore"
@@ -40,8 +50,10 @@ const props = withDefaults(defineProps<{ block?: Block; formatValuesAsTemplate?:
 	formatValuesAsTemplate: true,
 })
 const emit = defineEmits<{
-	(event: "update:modelValue", value: string): void
+	(event: "update:modelValue", value: string, bindVariable: boolean): void
 }>()
+const bindVariable = ref(false)
+
 const store = useStudioStore()
 const canvasStore = useCanvasStore()
 const codeStore = useCodeStore()

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -10,7 +10,7 @@
 				:block="block"
 				@update:modelValue="(value, bindVariable) => setDynamicValue(propName, value, bindVariable)"
 				:class="{ 'mt-1 self-start': isCodeField(config.inputType) }"
-				:formatValuesAsTemplate="false"
+				:formatValuesAsTemplate="isVariableBound(config.modelValue) ? false : true"
 				:isVariableBound="isVariableBound(config.modelValue)"
 			/>
 
@@ -18,8 +18,8 @@
 				v-if="config.inputType === 'html'"
 				:label="propName"
 				language="html"
-				:modelValue="config.modelValue"
-				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
+				:modelValue="getFormattedValue(propName)"
+				@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 				:required="config.required"
 				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 				:showLineNumbers="false"
@@ -38,30 +38,21 @@
 				v-else-if="config.inputType === 'code'"
 				:label="propName"
 				language="javascript"
-				:modelValue="config.modelValue"
-				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
+				:modelValue="getFormattedValue(propName)"
+				@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 				:required="config.required"
 				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 				:showLineNumbers="false"
 				class="overflow-hidden"
 			/>
 			<InlineInput
-				v-else-if="propName !== 'modelValue'"
+				v-else
 				:label="propName"
 				:type="config.inputType"
 				:options="config.options"
 				:required="config.required"
-				:modelValue="config.modelValue"
-				@update:modelValue="(newValue) => props.block?.setProp(propName, newValue)"
-				class="flex-1"
-			/>
-			<InlineInput
-				v-else-if="propName === 'modelValue'"
-				:label="propName"
-				:type="config.inputType"
-				:options="config.options"
-				:required="config.required"
-				v-model="boundValue"
+				:modelValue="getFormattedValue(propName)"
+				@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 				class="flex-1"
 			/>
 		</div>
@@ -182,19 +173,17 @@ function setDynamicValue(propName: string, varName: string, bindVariable: boolea
 	}
 }
 
-// variable binding
-const boundValue = computed({
-	get() {
-		const modelValue = props.block?.componentProps.modelValue
-		if (modelValue?.$type === "variable") {
-			return `{{ ${modelValue.name} }}`
-		}
-		return modelValue
-	},
-	set(newValue) {
-		props.block?.setProp("modelValue", newValue)
-	},
-})
+const getFormattedValue = (propName: string) => {
+	const value = props.block?.componentProps[propName]
+	if (value?.$type === "variable") {
+		return `{{ ${value.name} }}`
+	}
+	return value
+}
+
+const handlePropUpdate = (propName: string, newValue: any) => {
+	props.block?.setProp(propName, newValue)
+}
 
 const isVariableBound = (value: any) => {
 	return value?.$type === "variable" ? value.name : null

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -10,7 +10,6 @@
 				:block="block"
 				@update:modelValue="(value, bindVariable) => setDynamicValue(propName, value, bindVariable)"
 				:class="{ 'mt-1 self-start': isCodeField(config.inputType) }"
-				:formatValuesAsTemplate="isVariableBound(config.modelValue) ? false : true"
 				:isVariableBound="isVariableBound(config.modelValue)"
 			/>
 
@@ -169,7 +168,7 @@ function setDynamicValue(propName: string, varName: string, bindVariable: boolea
 	if (bindVariable) {
 		props.block?.setProp(propName, { $type: "variable", name: varName })
 	} else {
-		props.block?.setProp(propName, varName)
+		props.block?.setProp(propName, `{{ ${varName} }}`)
 	}
 }
 

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -6,36 +6,12 @@
 	<div v-else class="mt-3 flex flex-col gap-3">
 		<div v-for="(config, propName) in componentProps" :key="propName" class="group flex w-full items-center">
 			<DynamicValueSelector
-				v-if="propName === 'modelValue'"
+				v-if="!isTestingComponent"
 				:block="block"
-				@update:modelValue="(value) => bindVariable(propName, value)"
+				@update:modelValue="(value, bindVariable) => setDynamicValue(propName, value, bindVariable)"
 				:class="{ 'mt-1 self-start': isCodeField(config.inputType) }"
 				:formatValuesAsTemplate="false"
-			>
-				<template #target="{ togglePopover }">
-					<IconButton
-						:icon="isVariableBound(config.modelValue) ? Link2Off : Link2"
-						:label="isVariableBound(config.modelValue) ? 'Disable sync with variable' : 'Sync with variable'"
-						placement="bottom"
-						class="mr-1"
-						@click="
-							() => {
-								if (isVariableBound(config.modelValue)) {
-									unbindVariable(propName)
-								} else {
-									togglePopover()
-								}
-							}
-						"
-					/>
-				</template>
-			</DynamicValueSelector>
-
-			<DynamicValueSelector
-				v-else-if="!isTestingComponent"
-				:block="block"
-				:class="{ 'mt-1 self-start': isCodeField(config.inputType) }"
-				@update:modelValue="(value) => props.block?.setProp(propName, value)"
+				:isVariableBound="isVariableBound(config.modelValue)"
 			/>
 
 			<Code
@@ -99,9 +75,6 @@ import Block from "@/utils/block"
 
 import InlineInput from "@/components/InlineInput.vue"
 import { isObjectEmpty } from "@/utils/helpers"
-import IconButton from "@/components/IconButton.vue"
-import Link2 from "~icons/lucide/link-2"
-import Link2Off from "~icons/lucide/link-2-off"
 import Code from "@/components/Code.vue"
 import { useStudioCompletions } from "@/utils/useStudioCompletions"
 import type { CompletionContext } from "@codemirror/autocomplete"
@@ -201,6 +174,14 @@ const isCodeField = (inputType: string) => {
 	return ["code", "html"].includes(inputType)
 }
 
+function setDynamicValue(propName: string, varName: string, bindVariable: boolean) {
+	if (bindVariable) {
+		props.block?.setProp(propName, { $type: "variable", name: varName })
+	} else {
+		props.block?.setProp(propName, varName)
+	}
+}
+
 // variable binding
 const boundValue = computed({
 	get() {
@@ -217,13 +198,5 @@ const boundValue = computed({
 
 const isVariableBound = (value: any) => {
 	return value?.$type === "variable" ? value.name : null
-}
-
-const bindVariable = (propName: string, varName: string) => {
-	props.block?.setProp(propName, { $type: "variable", name: varName })
-}
-
-const unbindVariable = (propName: string) => {
-	props.block?.setProp(propName, "")
 }
 </script>

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -16,7 +16,7 @@
 		v-show="showComponent"
 		:is="componentName"
 		v-bind="componentProps"
-		v-model="boundValue"
+		v-on="vModelListeners"
 		:data-component-id="block.componentId"
 		:data-breakpoint="breakpoint"
 		:style="styles"
@@ -76,7 +76,7 @@
 		:is="block.componentName"
 		v-show="showComponent"
 		v-bind="componentProps"
-		v-model="boundValue"
+		v-on="vModelListeners"
 		:data-component-id="block.componentId"
 		:data-breakpoint="breakpoint"
 		:style="styles"
@@ -176,13 +176,34 @@ const getComponentProps = () => {
 	if (!props.block || props.block.isRoot()) return []
 
 	const propValues = props.block.getPropsAndAttributes()
-	delete propValues.modelValue
-
-	Object.entries(propValues).forEach(([propName, config]) => {
-		propValues[propName] = codeStore.evaluateDynamicValues(config, evaluationContext.value)
+	Object.entries(propValues).forEach(([propName, propValue]) => {
+		if (propValue?.$type === "variable") {
+			propValues[propName] = codeStore.getValueFromVariable(propValue.name, evaluationContext.value)
+		} else if (isDynamicValue(propValue)) {
+			propValues[propName] = codeStore.evaluateDynamicValues(propValue, evaluationContext.value)
+		}
+		return propValue
 	})
 	return propValues
 }
+
+// 2-way binding
+const vModelListeners = computed(() => {
+	if (!props.block || props.block.isRoot()) return {}
+
+	const listeners: Record<string, Function> = {}
+	const propValues = props.block.getPropsAndAttributes()
+
+	Object.entries(propValues).forEach(([propName, propValue]) => {
+		if (propValue?.$type === "variable") {
+			const eventName = `update:${propName}`
+			listeners[eventName] = (newValue: any) => {
+				codeStore.setValueInVariable(propValue.name, newValue, evaluationContext.value)
+			}
+		}
+	})
+	return listeners
+})
 
 const attrs = useAttrs()
 const componentProps = computed(() => {
@@ -200,29 +221,6 @@ const showComponent = computed(() => {
 		return codeStore.getDynamicValue(props.block.visibilityCondition, evaluationContext.value)
 	}
 	return true
-})
-
-// modelValue binding
-const boundValue = computed({
-	get() {
-		const modelValue = props.block.componentProps.modelValue
-		if (modelValue?.$type === "variable") {
-			return codeStore.getValueFromVariable(modelValue.name, evaluationContext.value)
-		} else if (isDynamicValue(modelValue)) {
-			return codeStore.getDynamicValue(modelValue, evaluationContext.value)
-		}
-		return modelValue
-	},
-	set(newValue) {
-		const modelValue = props.block.componentProps.modelValue
-		if (modelValue?.$type === "variable") {
-			// update the variable in the store
-			codeStore.setValueInVariable(modelValue.name, newValue, evaluationContext.value)
-		} else {
-			// update the prop directly if not bound to a variable
-			props.block.setProp("modelValue", newValue)
-		}
-	},
 })
 
 // block hovering and selection

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -182,7 +182,6 @@ const getComponentProps = () => {
 		} else if (isDynamicValue(propValue)) {
 			propValues[propName] = codeStore.evaluateDynamicValues(propValue, evaluationContext.value)
 		}
-		return propValue
 	})
 	return propValues
 }

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -207,7 +207,7 @@ const boundValue = computed({
 	get() {
 		const modelValue = props.block.componentProps.modelValue
 		if (modelValue?.$type === "variable") {
-			return codeStore.getValueFromVariable(modelValue.name)
+			return codeStore.getValueFromVariable(modelValue.name, evaluationContext.value)
 		} else if (isDynamicValue(modelValue)) {
 			return codeStore.getDynamicValue(modelValue, evaluationContext.value)
 		}
@@ -217,7 +217,7 @@ const boundValue = computed({
 		const modelValue = props.block.componentProps.modelValue
 		if (modelValue?.$type === "variable") {
 			// update the variable in the store
-			codeStore.setValueInVariable(modelValue.name, newValue)
+			codeStore.setValueInVariable(modelValue.name, newValue, evaluationContext.value)
 		} else {
 			// update the prop directly if not bound to a variable
 			props.block.setProp("modelValue", newValue)

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -62,11 +62,20 @@ const useCodeStore = defineStore("codeStore", () => {
 		})
 	}
 
-	function getValueFromVariable(variablePath: string) {
-		return getValueFromObject(variables.value, variablePath)
+	function getValueFromVariable(variablePath: string, localContext?: ExpressionEvaluationContext) {
+		const context = localContext ? { ...variables.value, ...localContext } : variables.value
+		return getValueFromObject(context, variablePath)
 	}
 
-	function setValueInVariable(variablePath: string, value: any) {
+	function setValueInVariable(variablePath: string, value: any, localContext?: ExpressionEvaluationContext) {
+		if (localContext) {
+			const pathParts = variablePath.split(".")
+			const rootKey = pathParts[0]
+			if (localContext[rootKey] !== undefined) {
+				setValueInObject(localContext, variablePath, value)
+				return
+			}
+		}
 		setValueInObject(variables.value, variablePath, value)
 	}
 

--- a/frontend/src/types/studio_components/HTML.ts
+++ b/frontend/src/types/studio_components/HTML.ts
@@ -1,3 +1,3 @@
 export interface HTMLProps {
-	html: string
+	html?: string
 }

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -139,13 +139,8 @@ class StudioApp(WebsiteGenerator):
 		if not frappe.has_permission("Studio App", ptype="write"):
 			frappe.throw("You do not have permission to generate the app build", frappe.PermissionError)
 
-		# check if build is required
-		draft_components = get_app_components(self.name, "draft_blocks")
-		components = get_app_components(self.name)
-		if not draft_components.symmetric_difference(components):
-			return
-
 		try:
+			components = get_app_components(self.name)
 			command = f"yarn build-studio-app {self.name} --components {','.join(list(components))}"
 			studio_app_path = frappe.get_app_source_path("studio")
 			popen(command, cwd=studio_app_path, raise_err=True)

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -17,7 +17,10 @@ class StudioPage(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-		from studio.studio.doctype.studio_page_client_script.studio_page_client_script import StudioPageClientScript
+
+		from studio.studio.doctype.studio_page_client_script.studio_page_client_script import (
+			StudioPageClientScript,
+		)
 		from studio.studio.doctype.studio_page_resource.studio_page_resource import StudioPageResource
 		from studio.studio.doctype.studio_page_variable.studio_page_variable import StudioPageVariable
 		from studio.studio.doctype.studio_page_watcher.studio_page_watcher import StudioPageWatcher


### PR DESCRIPTION
Sync with variable option was only available for modelValue prop

To understand what two-way binding is: Here, basically, whenever you check “Fetch members from multiple sources” it will set `newAudience.fetch_from_other_doctypes` variable to `true`. Moreover, if you set `newAudience.fetch_from_other_doctypes` to false anywhere in your code, the “Fetch members from multiple sources” checkbox will be unchecked. So this “sync” is now available for any prop, not just modelValue.

<img width="3024" height="1710" alt="image" src="https://github.com/user-attachments/assets/bd82362d-b9ea-4a4f-b2eb-b49ef1022659" />

<img width="1686" height="668" alt="image" src="https://github.com/user-attachments/assets/25cff79a-a947-4428-b1ce-f9848c2dd462" />

<hr>

Also fixed an issue where [sync with variable didn't work for repeater context/component context](https://github.com/frappe/studio/pull/149/commits/4800ebe5a8221ce790ec2a68cc17d9c1377e52e7) 
[4800ebe](https://github.com/frappe/studio/pull/149/commits/4800ebe5a8221ce790ec2a68cc17d9c1377e52e7)

So here, the value of the Link field inside a repeater can be synced with the data item at that index

<img width="1243" height="737" alt="repeater-modelValue" src="https://github.com/user-attachments/assets/5cef1b9e-efab-4954-bf9c-7fd54eed19c3" />
