### PR TITLE
feat(Watcher)!: Debounced and Deep options

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -48,6 +48,7 @@ declare module 'vue' {
     Filters: typeof import('./src/components/Filters.vue')['default']
     FitContainer: typeof import('./src/components/AppLayout/FitContainer.vue')['default']
     FitScreenIcon: typeof import('./src/components/Icons/FitScreenIcon.vue')['default']
+    FormDescription: typeof import('./src/components/FormDescription.vue')['default']
     FormDialog: typeof import('./src/components/FormDialog.vue')['default']
     Grid: typeof import('./src/components/Grid.vue')['default']
     Header: typeof import('./src/components/AppLayout/Header.vue')['default']

--- a/frontend/src/components/CodePanel.vue
+++ b/frontend/src/components/CodePanel.vue
@@ -57,6 +57,13 @@
 							:completions="getCompletions"
 							@save="editPageWatcher(pageWatcher)"
 						/>
+						<FormControl
+							type="number"
+							label="Debounce (ms)"
+							placeholder="300"
+							v-model="pageWatcher.debounce"
+							description="Delay the execution until the set time has passed since the last change"
+						/>
 						<div class="flex flex-col space-y-1">
 							<FormControl type="checkbox" label="Run Immediately?" v-model="pageWatcher.immediate" />
 							<FormDescription
@@ -111,7 +118,7 @@ const studioPageWatchers = createListResource({
 	filters: {
 		parent: props.page.name,
 	},
-	fields: ["name", "source", "script", "immediate", "deep", "parent"],
+	fields: ["name", "source", "script", "immediate", "deep", "debounce", "parent"],
 	orderBy: "modified desc",
 	pageLength: 50,
 	auto: true,
@@ -123,6 +130,7 @@ const pageWatcher = ref<StudioPageWatcher>({
 	script: "",
 	immediate: false,
 	deep: false,
+	debounce: 0,
 	parent: "",
 	name: "",
 })
@@ -151,6 +159,7 @@ const addPageWatcher = (watcher: StudioPageWatcher) => {
 			script: watcher.script,
 			immediate: watcher.immediate,
 			deep: watcher.deep,
+			debounce: watcher.debounce,
 			parent: props.page.name,
 			parenttype: "Studio Page",
 			parentfield: "watchers",
@@ -176,6 +185,7 @@ const editPageWatcher = (watcher: StudioPageWatcher) => {
 			script: watcher.script,
 			immediate: watcher.immediate,
 			deep: watcher.deep,
+			debounce: watcher.debounce,
 		})
 		.then(async () => {
 			// setValue didn't update the list, so reloading explicitly

--- a/frontend/src/components/CodePanel.vue
+++ b/frontend/src/components/CodePanel.vue
@@ -57,18 +57,18 @@
 							:completions="getCompletions"
 							@save="editPageWatcher(pageWatcher)"
 						/>
-						<FormControl
-							type="checkbox"
-							label="Run Immediately?"
-							description="By default, this script won't run unless the source value changes. Enable this to run the script immediately."
-							v-model="pageWatcher.immediate"
-						/>
-						<FormControl
-							type="checkbox"
-							label="Deep"
-							description="Trigger the script when any nested property inside the source changes, not just the source."
-							v-model="pageWatcher.deep"
-						/>
+						<div class="flex flex-col space-y-1">
+							<FormControl type="checkbox" label="Run Immediately?" v-model="pageWatcher.immediate" />
+							<FormDescription
+								description="By default, this script won't run unless the source value changes. Enable this to run the script immediately"
+							/>
+						</div>
+						<div class="flex flex-col space-y-1">
+							<FormControl type="checkbox" label="Deep" v-model="pageWatcher.deep" />
+							<FormDescription
+								description="Trigger the script when any nested property inside the source changes, not just the source"
+							/>
+						</div>
 					</div>
 				</template>
 				<template #actions>
@@ -97,6 +97,7 @@ import { toast } from "vue-sonner"
 import { confirm } from "@/utils/helpers"
 import { useStudioCompletions } from "@/utils/useStudioCompletions"
 import ItemActions from "@/components/ItemActions.vue"
+import FormDescription from "@/components/FormDescription.vue"
 
 const props = defineProps<{
 	page: StudioPage

--- a/frontend/src/components/CodePanel.vue
+++ b/frontend/src/components/CodePanel.vue
@@ -110,7 +110,7 @@ const studioPageWatchers = createListResource({
 	filters: {
 		parent: props.page.name,
 	},
-	fields: ["name", "source", "script", "immediate", "parent"],
+	fields: ["name", "source", "script", "immediate", "deep", "parent"],
 	orderBy: "modified desc",
 	pageLength: 50,
 	auto: true,

--- a/frontend/src/components/CodePanel.vue
+++ b/frontend/src/components/CodePanel.vue
@@ -29,6 +29,7 @@
 							source: '',
 							script: '',
 							immediate: false,
+							deep: false,
 							parent: '',
 							name: '',
 						}
@@ -39,16 +40,12 @@
 				<template #body-content>
 					<div class="flex flex-col space-y-4">
 						<FormControl
-							type="autocomplete"
+							type="combobox"
 							:options="store.variableOptions"
 							label="Source"
 							placeholder="Select variable"
-							:modelValue="pageWatcher.source"
-							@update:modelValue="
-								(selectedOption: SelectOption) => {
-									pageWatcher.source = selectedOption.value
-								}
-							"
+							:openOnFocus="true"
+							v-model="pageWatcher.source"
 						/>
 						<Code
 							label="Script"
@@ -65,6 +62,12 @@
 							label="Run Immediately?"
 							description="By default, this script won't run unless the source value changes. Enable this to run the script immediately."
 							v-model="pageWatcher.immediate"
+						/>
+						<FormControl
+							type="checkbox"
+							label="Deep"
+							description="Trigger the script when any nested property inside the source changes, not just the source."
+							v-model="pageWatcher.deep"
 						/>
 					</div>
 				</template>
@@ -88,7 +91,6 @@ import EmptyState from "@/components/EmptyState.vue"
 import CollapsibleSection from "@/components/CollapsibleSection.vue"
 import Code from "@/components/Code.vue"
 import type { StudioPage } from "@/types/Studio/StudioPage"
-import type { SelectOption } from "@/types"
 import type { StudioPageWatcher } from "@/types/Studio/StudioPageWatcher"
 import useStudioStore from "@/stores/studioStore"
 import { toast } from "vue-sonner"
@@ -119,6 +121,7 @@ const pageWatcher = ref<StudioPageWatcher>({
 	source: "",
 	script: "",
 	immediate: false,
+	deep: false,
 	parent: "",
 	name: "",
 })
@@ -146,6 +149,7 @@ const addPageWatcher = (watcher: StudioPageWatcher) => {
 			source: watcher.source,
 			script: watcher.script,
 			immediate: watcher.immediate,
+			deep: watcher.deep,
 			parent: props.page.name,
 			parenttype: "Studio Page",
 			parentfield: "watchers",
@@ -170,6 +174,7 @@ const editPageWatcher = (watcher: StudioPageWatcher) => {
 			source: watcher.source,
 			script: watcher.script,
 			immediate: watcher.immediate,
+			deep: watcher.deep,
 		})
 		.then(async () => {
 			// setValue didn't update the list, so reloading explicitly

--- a/frontend/src/components/CodePanel.vue
+++ b/frontend/src/components/CodePanel.vue
@@ -65,15 +65,17 @@
 							description="Delay the execution until the set time has passed since the last change"
 						/>
 						<div class="flex flex-col space-y-1">
-							<FormControl type="checkbox" label="Run Immediately?" v-model="pageWatcher.immediate" />
-							<FormDescription
-								description="By default, this script won't run unless the source value changes. Enable this to run the script immediately"
+							<FormControl
+								type="checkbox"
+								label="Immediate: Run on page load"
+								v-model="pageWatcher.immediate"
 							/>
+							<FormDescription description="Trigger when the page loads, not just when the source changes" />
 						</div>
 						<div class="flex flex-col space-y-1">
-							<FormControl type="checkbox" label="Deep" v-model="pageWatcher.deep" />
+							<FormControl type="checkbox" label="Deep: Watch nested properties" v-model="pageWatcher.deep" />
 							<FormDescription
-								description="Trigger the script when any nested property inside the source changes, not just the source"
+								description="Trigger when nested properties within the source change, in addition to the source itself"
 							/>
 						</div>
 					</div>

--- a/frontend/src/components/FormDescription.vue
+++ b/frontend/src/components/FormDescription.vue
@@ -1,0 +1,9 @@
+<template>
+	<p v-if="description" class="text-xs text-ink-gray-5">{{ description }}</p>
+</template>
+
+<script lang="ts" setup>
+defineProps<{
+	description?: string
+}>()
+</script>

--- a/frontend/src/components/FormDescription.vue
+++ b/frontend/src/components/FormDescription.vue
@@ -1,5 +1,5 @@
 <template>
-	<p v-if="description" class="text-xs text-ink-gray-5">{{ description }}</p>
+	<p v-if="description" class="text-xs leading-4 text-ink-gray-5">{{ description }}</p>
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/data/components.ts
+++ b/frontend/src/data/components.ts
@@ -358,7 +358,6 @@ export const COMPONENTS: FrappeUIComponents = {
 		icon: LucideAppWindowMac,
 		initialState: {
 			modelValue: false,
-			disableOutsideClickToClose: true,
 			options: {
 				title: "Confirm",
 				message: "Are you sure you want to confirm this action?",

--- a/frontend/src/data/studioWatchers.ts
+++ b/frontend/src/data/studioWatchers.ts
@@ -3,7 +3,7 @@ import { createListResource } from "frappe-ui"
 const studioWatchers = createListResource({
 	doctype: "Studio Page Watcher",
 	parent: "Studio Page",
-	fields: ["name", "source", "script", "immediate", "parent"],
+	fields: ["name", "source", "script", "immediate", "deep", "parent"],
 	orderBy: "modified desc",
 	pageLength: 50,
 })

--- a/frontend/src/data/studioWatchers.ts
+++ b/frontend/src/data/studioWatchers.ts
@@ -3,7 +3,7 @@ import { createListResource } from "frappe-ui"
 const studioWatchers = createListResource({
 	doctype: "Studio Page Watcher",
 	parent: "Studio Page",
-	fields: ["name", "source", "script", "immediate", "deep", "parent"],
+	fields: ["name", "source", "script", "immediate", "deep", "debounce", "parent"],
 	orderBy: "modified desc",
 	pageLength: 50,
 })

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -90,12 +90,10 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	function setupWatcher(watcher: StudioPageWatcher) {
-		const currentValue = getValueFromVariable(watcher.source)
-		const isDeep = typeof currentValue === "object"
 		const watcherFn = watch(
 			() => getValueFromVariable(watcher.source),
 			() => executeUserScript(watcher.script),
-			{ deep: isDeep, immediate: watcher.immediate }
+			{ deep: watcher.deep, immediate: watcher.immediate }
 		)
 		activeWatchers.value[watcher.name || watcher.source] = watcherFn
 	}

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -90,8 +90,9 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	function setupWatcher(watcher: StudioPageWatcher) {
-		const watcherFn = watch(
-			() => getValueFromVariable(watcher.source),
+		const sourceValue = computed(() => getValueFromVariable(watcher.source))
+
+		const watcherFn = watch(sourceValue,
 			() => executeUserScript(watcher.script),
 			{ deep: watcher.deep, immediate: watcher.immediate }
 		)

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia"
 import { ref, computed, watch, type WatchStopHandle, ComputedRef, toRefs, unref } from "vue"
+import { watchDebounced } from "@vueuse/core"
 import { createDocumentResource, createListResource, createResource, call } from "frappe-ui"
 import { studioPageResources } from "@/data/studioResources"
 import { studioVariables } from "@/data/studioVariables"
@@ -91,11 +92,19 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	function setupWatcher(watcher: StudioPageWatcher) {
 		const sourceValue = computed(() => getValueFromVariable(watcher.source))
+		let watcherFn
 
-		const watcherFn = watch(sourceValue,
-			() => executeUserScript(watcher.script),
-			{ deep: watcher.deep, immediate: watcher.immediate }
-		)
+		if (watcher.debounce && watcher.debounce > 0) {
+			watcherFn = watchDebounced(sourceValue,
+				() => executeUserScript(watcher.script),
+				{ debounce: watcher.debounce, deep: watcher.deep, immediate: watcher.immediate }
+			)
+		} else {
+			watcherFn = watch(sourceValue,
+				() => executeUserScript(watcher.script),
+				{ deep: watcher.deep, immediate: watcher.immediate }
+			)
+		}
 		activeWatchers.value[watcher.name || watcher.source] = watcherFn
 	}
 

--- a/frontend/src/types/Studio/StudioPageWatcher.ts
+++ b/frontend/src/types/Studio/StudioPageWatcher.ts
@@ -3,6 +3,7 @@ export type StudioPageWatcher = {
 	script: string,
 	immediate: boolean,
 	deep: boolean,
+	debounce?: number,
 	parent?: string,
 	name?: string,
 }

--- a/frontend/src/types/Studio/StudioPageWatcher.ts
+++ b/frontend/src/types/Studio/StudioPageWatcher.ts
@@ -2,6 +2,7 @@ export type StudioPageWatcher = {
 	source: string,
 	script: string,
 	immediate: boolean,
+	deep: boolean,
 	parent?: string,
 	name?: string,
 }

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
@@ -7,7 +7,7 @@
  "field_order": [
   "source",
   "script",
-  "debounce_ms",
+  "debounce",
   "immediate",
   "deep"
  ],
@@ -28,24 +28,29 @@
    "reqd": 1
   },
   {
+   "columns": 1,
    "default": "0",
-   "description": "By default, this script won't run unless the source value changes. Enable this to run the script immediately.",
+   "description": "By default, this script won't run unless the source value changes. Enable this to run the script immediately",
    "fieldname": "immediate",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Run Immediately?"
   },
   {
+   "columns": 1,
    "default": "0",
-   "description": "Trigger the script when any nested property inside the source changes, not just the source.\n<br>\nEg: watching user object will fire the script if user.name changes.",
+   "description": "Trigger the script when any nested property inside the source changes, not just the source.\n<br>\nEg: watching user object will fire the script if user.name changes",
    "fieldname": "deep",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Deep"
   },
   {
-   "fieldname": "debounce_ms",
+   "columns": 2,
+   "description": "Delay the execution until the set time has passed since the last change",
+   "fieldname": "debounce",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Debounce (ms)"
   }
  ],
@@ -53,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-14 13:50:08.152225",
+ "modified": "2026-01-14 16:22:40.933558",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Watcher",

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
@@ -3,13 +3,16 @@
  "allow_rename": 1,
  "creation": "2025-04-01 09:31:00.594704",
  "doctype": "DocType",
+ "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "source",
   "script",
-  "debounce",
+  "section_break_ktei",
   "immediate",
-  "deep"
+  "deep",
+  "column_break_uxbo",
+  "debounce"
  ],
  "fields": [
   {
@@ -28,37 +31,42 @@
    "reqd": 1
   },
   {
-   "columns": 1,
    "default": "0",
-   "description": "By default, this script won't run unless the source value changes. Enable this to run the script immediately",
+   "description": "Trigger when the page loads, not just when the source changes",
    "fieldname": "immediate",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Run Immediately?"
+   "label": "Immediate: Run on page load"
   },
   {
-   "columns": 1,
    "default": "0",
-   "description": "Trigger the script when any nested property inside the source changes, not just the source.\n<br>\nEg: watching user object will fire the script if user.name changes",
+   "description": "Trigger when nested properties within the source change, in addition to the source itself\n<br>\nEg: watching user object will fire the script if user.name changes",
    "fieldname": "deep",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Deep"
+   "label": "Deep: Watch nested properties"
   },
   {
-   "columns": 2,
    "description": "Delay the execution until the set time has passed since the last change",
    "fieldname": "debounce",
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Debounce (ms)"
+  },
+  {
+   "fieldname": "section_break_ktei",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_uxbo",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-14 16:22:40.933558",
+ "modified": "2026-01-15 10:47:33.087699",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Watcher",

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
@@ -7,7 +7,9 @@
  "field_order": [
   "source",
   "script",
-  "immediate"
+  "debounce_ms",
+  "immediate",
+  "deep"
  ],
  "fields": [
   {
@@ -27,18 +29,30 @@
   },
   {
    "default": "0",
-   "description": "By default, this script won't run unless the Source value changes. Enable this to run the script immediately.",
+   "description": "By default, this script won't run unless the source value changes. Enable this to run the script immediately.",
    "fieldname": "immediate",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Run Immediately?"
+  },
+  {
+   "default": "0",
+   "description": "Trigger the script when any nested property inside the source changes, not just the source.\n<br>\nEg: watching user object will fire the script if user.name changes.",
+   "fieldname": "deep",
+   "fieldtype": "Check",
+   "label": "Deep"
+  },
+  {
+   "fieldname": "debounce_ms",
+   "fieldtype": "Int",
+   "label": "Debounce (ms)"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-04-01 13:57:15.006423",
+ "modified": "2026-01-14 11:21:01.144556",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Watcher",

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.json
@@ -40,6 +40,7 @@
    "description": "Trigger the script when any nested property inside the source changes, not just the source.\n<br>\nEg: watching user object will fire the script if user.name changes.",
    "fieldname": "deep",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Deep"
   },
   {
@@ -52,7 +53,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-14 11:21:01.144556",
+ "modified": "2026-01-14 13:50:08.152225",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Watcher",

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.py
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.py
@@ -14,6 +14,8 @@ class StudioPageWatcher(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		debounce_ms: DF.Int
+		deep: DF.Check
 		immediate: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data

--- a/studio/studio/doctype/studio_page_watcher/studio_page_watcher.py
+++ b/studio/studio/doctype/studio_page_watcher/studio_page_watcher.py
@@ -14,7 +14,7 @@ class StudioPageWatcher(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		debounce_ms: DF.Int
+		debounce: DF.Int
 		deep: DF.Check
 		immediate: DF.Check
 		parent: DF.Data


### PR DESCRIPTION
**Before**:
Watchers on object type Variables were implicitly deeply reactive. No control on opting out of it.

**After:**

> [!IMPORTANT]
>  **BREAKING CHANGE**
> Watchers on object/array variables will have to be marked deep explicitly

- Explicit option to make watchers **deep** (watch nested properties)
- Also added option to configure debounce to set **debounced** watcher
- Changed label for immediate config as the previous one was confusing. What does immediately mean?: 
   Run **Immediately**? > Run on page load

<img width="1624" height="1056" alt="watcher-adv-settings" src="https://github.com/user-attachments/assets/580c0e26-7286-4e57-9f59-6d40089e7743" />

<hr>

Also related fix:

Watcher didn't work on nested variables eg: if user is an object variable then watcher on user.name didn't work. 
[This commit]( https://github.com/frappe/studio/commit/3332d116cfef96fb6e292a96b8f83f342bbaa7ab) fixed it. 

**Problem**: But due to this change, there was another issue: deep watcher was executing on any variable change, not just source
**Fix**: Convert source to computed property; else, watcher ends up tracking entire variables.value because of the getter function.
