### PR TITLE
feat: Provide access to event args in event action scripts

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -166,10 +166,11 @@ const componentEvents = computed(() => {
 					router.push(event.page)
 				}
 			} else if (event.action === "Call API") {
-				return () => {
+				return (...eventArgs: any[]) => {
 					const path: string[] = event.api_endpoint.split(".")
 					// get resource
 					const resource = codeStore.resources[path[0]]
+					event.eventArgs = eventArgs
 
 					if (resource) {
 						// access and call whitelisted method
@@ -185,11 +186,12 @@ const componentEvents = computed(() => {
 					}
 				}
 			} else if (event.action === "Insert a Document") {
-				return () => {
+				return (...eventArgs: any[]) => {
 					const fields: Record<string, any> = {}
 					event.fields.forEach((field: Field) => {
-						fields[field.field] = codeStore.getValueFromVariable(field.value)
+						fields[field.field] = codeStore.getValueFromVariable(field.value, evaluationContext.value)
 					})
+					event.eventArgs = eventArgs
 					createResource({
 						url: "frappe.client.insert",
 						method: "POST",
@@ -204,8 +206,8 @@ const componentEvents = computed(() => {
 					}).submit()
 				}
 			} else if (event.action === "Run Script") {
-				return (...args: any[]) => {
-					codeStore.executeUserScript(event.script, repeaterContext, componentContext?.value, args)
+				return (...eventArgs: any[]) => {
+					codeStore.executeUserScript(event.script, repeaterContext, componentContext?.value, eventArgs)
 				}
 			}
 		}
@@ -217,7 +219,13 @@ const componentEvents = computed(() => {
 
 const handleSuccess = (event: any) => (data: DataResult) => {
 	if (event.on_success === "script" && event.on_success_script) {
-		return codeStore.handleSuccess(event.on_success_script, data, repeaterContext, componentContext?.value)
+		return codeStore.handleSuccess(
+			event.on_success_script,
+			data,
+			repeaterContext,
+			componentContext?.value,
+			event.eventArgs,
+		)
 	} else {
 		if (event.action === "Insert a Document") {
 			toast.success(event.success_message || `${event.doctype} created successfully`)
@@ -229,7 +237,13 @@ const handleSuccess = (event: any) => (data: DataResult) => {
 
 const handleError = (event: any) => (error: any) => {
 	if (event.on_error === "script" && event.on_error_script) {
-		return codeStore.handleError(event.on_error_script, error, repeaterContext, componentContext?.value)
+		return codeStore.handleError(
+			event.on_error_script,
+			error,
+			repeaterContext,
+			componentContext?.value,
+			event.eventArgs,
+		)
 	} else {
 		if (event.action === "Insert a Document") {
 			toast.error(event.error_message || `Error creating ${event.doctype}`)

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -204,8 +204,14 @@ const componentEvents = computed(() => {
 					}).submit()
 				}
 			} else if (event.action === "Run Script") {
-				return () => {
-					codeStore.executeUserScript(event.script, repeaterContext, componentContext?.value)
+				return (...args: any[]) => {
+					codeStore.executeUserScript(
+						event.script,
+						repeaterContext,
+						componentContext?.value,
+						args,
+						event.additionalScope,
+					)
 				}
 			}
 		}

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -205,13 +205,7 @@ const componentEvents = computed(() => {
 				}
 			} else if (event.action === "Run Script") {
 				return (...args: any[]) => {
-					codeStore.executeUserScript(
-						event.script,
-						repeaterContext,
-						componentContext?.value,
-						args,
-						event.additionalScope,
-					)
+					codeStore.executeUserScript(event.script, repeaterContext, componentContext?.value, args)
 				}
 			}
 		}

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -24,6 +24,7 @@
 			@blur="syncToParent"
 		/>
 
+		<span class="text-p-xs text-ink-gray-6" v-show="description" v-html="description"></span>
 		<Button v-if="showSaveButton" variant="solid" @click="emit('save', code)" class="mt-3 w-full text-base">
 			Save
 		</Button>
@@ -65,6 +66,7 @@ const props = withDefaults(
 		showLineNumbers?: boolean
 		completions?: Function | null
 		label?: string
+		description?: string
 		required?: boolean
 		readonly?: boolean
 		borderless?: boolean

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -133,6 +133,11 @@
 									@update:modelValue="(val: string) => (newEvent.on_error_script = val)"
 								/>
 							</div>
+
+							<span
+								class="mt-1 text-p-xs text-ink-gray-6"
+								v-html="getScriptDescription(newEvent.event)"
+							></span>
 						</template>
 					</div>
 				</template>

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -548,8 +548,9 @@ function getScriptDescription(eventName: string): string {
 		const componentSlug = props.block.componentName.toLowerCase()
 		docsLink = `https://ui.frappe.io/docs/components/${componentSlug}#emit-events`
 	}
-	return `You can access event arguments in your script using the ${getCodeBlock("eventArgs")} array<br>
-		<b>Example:</b> ${getCodeBlock("varName.value = eventArgs[0]")} ${docsLink ? `<br>Refer to the <a class="underline" href="${docsLink}" target="_blank">component documentation</a> to check what arguments are passed in the emitted event` : ""}
+	return `You can access event arguments using the ${getCodeBlock("eventArgs")} array: ${getCodeBlock("eventArgs[index]")}<br><br>
+		<b>Example:</b> A ${getCodeBlock("change")} event on TextEditor emits the editor content, which can be accessed as:<br>
+		${getCodeBlock("const editorContent = eventArgs[0]")} ${docsLink ? `<br><br>Refer to the <a class="underline" href="${docsLink}" target="_blank">${[props.block?.componentName]} documentation</a> to see what arguments are emitted for ${eventName} event` : ""}
 		`
 }
 

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -191,6 +191,7 @@ const emptyEvent: ComponentEvent = {
 	on_error_script: "",
 	// run script
 	script: "",
+	additionalScope: [],
 }
 const newEvent = ref<ComponentEvent>({ ...emptyEvent })
 
@@ -254,6 +255,24 @@ watch(
 
 const actions: ActionConfigurations = {
 	"Run Script": [
+		{
+			component: FormControl,
+			getProps: () => {
+				return {
+					label: "Additional Scope Variables (comma separated)",
+					modelValue: newEvent.value.additionalScope?.join(", ") || "",
+					autocomplete: "off",
+				}
+			},
+			events: {
+				"update:modelValue": (val: string) => {
+					newEvent.value.additionalScope = val
+						.split(",")
+						.map((s) => s.trim())
+						.filter((s) => s.length > 0)
+				},
+			},
+		},
 		{
 			component: Code,
 			getProps: () => {
@@ -440,6 +459,7 @@ function getEvent(event: ComponentEvent): ComponentEvent {
 	}
 	if (event.action === "Run Script") {
 		_event.script = event.script || ""
+		_event.additionalScope = event.additionalScope || []
 	} else if (event.action === "Call API") {
 		_event.api_endpoint = event.api_endpoint
 		setEventCallbackFields(_event, event)

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -548,10 +548,20 @@ function getScriptDescription(eventName: string): string {
 		const componentSlug = props.block.componentName.toLowerCase()
 		docsLink = `https://ui.frappe.io/docs/components/${componentSlug}#emit-events`
 	}
-	return `You can access event arguments using the ${getCodeBlock("eventArgs")} array: ${getCodeBlock("eventArgs[index]")}<br><br>
-		<b>Example:</b> A ${getCodeBlock("change")} event on TextEditor emits the editor content, which can be accessed as:<br>
-		${getCodeBlock("const editorContent = eventArgs[0]")} ${docsLink ? `<br><br>Refer to the <a class="underline" href="${docsLink}" target="_blank">${[props.block?.componentName]} documentation</a> to see what arguments are emitted for ${eventName} event` : ""}
+	let docs = `You can access event arguments using the ${getCodeBlock("eventArgs")} array: ${getCodeBlock("eventArgs[index]")}<br><br>`
+
+	if (docsLink) {
+		docs += `
+			<b>Example:</b> The ${getCodeBlock("change")} event on DatePicker emits the selected date, which can be accessed as:<br>
+			${getCodeBlock("const date = eventArgs[0]")} <br><br>Refer to the <a class="underline" href="${docsLink}" target="_blank">${[props.block?.componentName]} documentation</a> to see what arguments are emitted for ${eventName} event
 		`
+	} else {
+		docs += `
+			<b>Example:</b> For a ${getCodeBlock("click")} event, you can access the MouseEvent object as:<br>
+			${getCodeBlock("const mouseEvent = eventArgs[0]")}
+		`
+	}
+	return docs
 }
 
 function getCodeBlock(string: string): string {

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -191,7 +191,6 @@ const emptyEvent: ComponentEvent = {
 	on_error_script: "",
 	// run script
 	script: "",
-	additionalScope: [],
 }
 const newEvent = ref<ComponentEvent>({ ...emptyEvent })
 
@@ -255,24 +254,6 @@ watch(
 
 const actions: ActionConfigurations = {
 	"Run Script": [
-		{
-			component: FormControl,
-			getProps: () => {
-				return {
-					label: "Additional Scope Variables (comma separated)",
-					modelValue: newEvent.value.additionalScope?.join(", ") || "",
-					autocomplete: "off",
-				}
-			},
-			events: {
-				"update:modelValue": (val: string) => {
-					newEvent.value.additionalScope = val
-						.split(",")
-						.map((s) => s.trim())
-						.filter((s) => s.length > 0)
-				},
-			},
-		},
 		{
 			component: Code,
 			getProps: () => {
@@ -459,7 +440,6 @@ function getEvent(event: ComponentEvent): ComponentEvent {
 	}
 	if (event.action === "Run Script") {
 		_event.script = event.script || ""
-		_event.additionalScope = event.additionalScope || []
 	} else if (event.action === "Call API") {
 		_event.api_endpoint = event.api_endpoint
 		setEventCallbackFields(_event, event)

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -197,7 +197,6 @@ const newEvent = ref<ComponentEvent>({ ...emptyEvent })
 const eventOptions = computed(() => {
 	if (!props.block || props.block.isRoot()) return []
 	return [
-		...getComponentEvents(props.block?.componentName),
 		"click",
 		"change",
 		"focus",
@@ -206,16 +205,18 @@ const eventOptions = computed(() => {
 		"keydown",
 		"keyup",
 		"keypress",
+		...componentEvents.value,
 	]
 })
 
-function getComponentEvents(name: string) {
-	const component = resolveComponent(name)
+const componentEvents = computed(() => {
+	if (!props.block?.componentName) return []
+	const component = resolveComponent(props.block?.componentName)
 	if (typeof component === "string" || !component) {
 		return []
 	}
 	return component?.emits || []
-}
+})
 
 const doctypeFields = ref<{ label: string; value: string }[]>([])
 watch(
@@ -264,6 +265,7 @@ const actions: ActionConfigurations = {
 					height: "400px",
 					maxHeight: "400px",
 					emitOnChange: true,
+					description: getScriptDescription(newEvent.value.event),
 					completions: (context: CompletionContext) =>
 						getEditorCompletions(context, props.block?.getCompletions()),
 				}
@@ -533,5 +535,20 @@ const getEventMenu = (event: ComponentEvent) => {
 			onClick: () => deleteEvent(event),
 		},
 	]
+}
+
+function getScriptDescription(eventName: string): string {
+	let docsLink = ""
+	if (props.block && componentEvents.value.includes(eventName)) {
+		const componentSlug = props.block.componentName.toLowerCase()
+		docsLink = `https://ui.frappe.io/docs/components/${componentSlug}#emit-events`
+	}
+	return `You can access event arguments in your script using the ${getCodeBlock("eventArgs")} array<br>
+		<b>Example:</b> ${getCodeBlock("varName.value = eventArgs[0]")} ${docsLink ? `<br>Refer to the <a class="underline" href="${docsLink}" target="_blank">component documentation</a> to check what arguments are passed in the emitted event` : ""}
+		`
+}
+
+function getCodeBlock(string: string): string {
+	return `<span class="font-mono font-medium">${string}</span>`
 }
 </script>

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -18,7 +18,7 @@
 			<Dialog
 				v-model="showAddEventDialog"
 				:options="{
-					title: newEvent.isEditing ? 'Edit Event' : 'Add Event',
+					title: (newEvent.isEditing ? 'Edit Event' : 'Add Event') + ' - ' + block.getBlockDescription(),
 					size: '3xl',
 					actions: [
 						{

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -239,7 +239,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		eventArgs?: Record<string, any>,
 	) {
 		try {
-			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, args: eventArgs }
+			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, eventArgs }
 
 			const scriptToExecute = `
 				with (context) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -237,20 +237,9 @@ const useCodeStore = defineStore("codeStore", () => {
 		repeaterContext?: Record<string, any>,
 		componentContext?: Record<string, any>,
 		eventArgs?: Record<string, any>,
-		additionalScope?: string[],
 	) {
 		try {
-			// Map event arguments to named parameters
-			const namedEventArgs: Record<string, any> = {}
-			if (eventArgs && additionalScope) {
-				additionalScope.forEach((paramName, index) => {
-					if (paramName && index < eventArgs.length) {
-						namedEventArgs[paramName] = eventArgs[index]
-					}
-				})
-			}
-
-			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, ...namedEventArgs }
+			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, args: eventArgs }
 
 			const scriptToExecute = `
 				with (context) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -236,9 +236,21 @@ const useCodeStore = defineStore("codeStore", () => {
 		script: string,
 		repeaterContext?: Record<string, any>,
 		componentContext?: Record<string, any>,
+		eventArgs?: Record<string, any>,
+		additionalScope?: string[],
 	) {
 		try {
-			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext }
+			// Map event arguments to named parameters
+			const namedEventArgs: Record<string, any> = {}
+			if (eventArgs && additionalScope) {
+				additionalScope.forEach((paramName, index) => {
+					if (paramName && index < eventArgs.length) {
+						namedEventArgs[paramName] = eventArgs[index]
+					}
+				})
+			}
+
+			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, ...namedEventArgs }
 
 			const scriptToExecute = `
 				with (context) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -258,12 +258,14 @@ const useCodeStore = defineStore("codeStore", () => {
 		data: DataResult,
 		repeaterContext?: Record<string, any>,
 		componentContext?: Record<string, any>,
+		eventArgs?: string[],
 	) {
 		try {
 			const context = {
 				...globalExecutionContext.value,
 				...repeaterContext,
 				...componentContext,
+				eventArgs,
 				data,
 			}
 			const successFn = new Function(
@@ -284,12 +286,14 @@ const useCodeStore = defineStore("codeStore", () => {
 		error: any,
 		repeaterContext?: Record<string, any>,
 		componentContext?: Record<string, any>,
+		eventArgs?: string[],
 	) {
 		try {
 			const context = {
 				...globalExecutionContext.value,
 				...repeaterContext,
 				...componentContext,
+				eventArgs,
 				error,
 			}
 			const errorFn = new Function(

--- a/frontend/src/types/ComponentEvent.ts
+++ b/frontend/src/types/ComponentEvent.ts
@@ -33,6 +33,7 @@ export type ComponentEvent = {
 	on_error_script?: string,
 	/** action = 'Run Script' */
 	script?: string
+	additionalScope?: string[]
 	// for editing
 	isEditing?: boolean
 	oldEvent?: Events | string

--- a/frontend/src/types/ComponentEvent.ts
+++ b/frontend/src/types/ComponentEvent.ts
@@ -33,7 +33,6 @@ export type ComponentEvent = {
 	on_error_script?: string,
 	/** action = 'Run Script' */
 	script?: string
-	additionalScope?: string[]
 	// for editing
 	isEditing?: boolean
 	oldEvent?: Events | string


### PR DESCRIPTION
There was no way to access event arguments passed when event occurs

Its now available with `eventArgs` array

<img width="1624" height="1056" alt="args" src="https://github.com/user-attachments/assets/02f2a3a7-ccac-42c3-b17a-61b1ec2e9f02" />

