### PR TITLE
fix: save fragment without exiting fragment mode

### DIFF
--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -204,12 +204,6 @@ async function saveFragmentMode() {
 		canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
 		hasSavedFragment = true
 	}
-
-	const pageRootBlock = pageCanvas.value?.getRootBlock()
-	if (pageRootBlock) {
-		store.savingPage = true
-		store.savePage(pageRootBlock)
-	}
 }
 
 watch(() => canvasStore.editingMode, () => {
@@ -222,13 +216,16 @@ watch(
 	() => {
 		if (
 			store.selectedPage &&
-			canvasStore.editingMode === "page" &&
 			!pageCanvas.value?.canvasProps?.settingCanvas &&
 			!store.settingPage &&
 			!store.savingPage
 		) {
 			store.savingPage = true
-			debouncedPageSave()
+			if (canvasStore.editingMode === "page") {
+				debouncedPageSave()
+			} else {
+				store.savePage(pageCanvas.value?.getRootBlock())
+			}
 		}
 	},
 	{ deep: true },

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -48,7 +48,8 @@
 								@click.prevent="store.studioLayout.rightPanelActiveTab = 'Interface'"
 							></Button>
 							<Button variant="subtle" class="text-xs" @click="canvasStore.exitFragmentMode">
-								Close
+								<template #prefix><FeatherIcon name="chevron-left" class="!h-3 !w-3" /></template>
+								Page
 							</Button>
 							<Button variant="solid" class="text-xs" @click="saveFragmentMode">
 								{{ canvasStore.fragmentData.saveActionLabel || "Save" }}
@@ -169,6 +170,7 @@ import type { StudioPage } from "@/types/Studio/StudioPage"
 import { useStudioEvents } from "@/utils/useStudioEvents"
 import { getRootBlock } from "@/utils/serializer"
 import { useStudioCompletions } from "@/utils/useStudioCompletions"
+import { toast } from "vue-sonner"
 
 const route = useRoute()
 const router = useRouter()
@@ -204,6 +206,7 @@ async function saveFragmentMode() {
 		canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
 		hasSavedFragment = true
 	}
+	toast.success(`${canvasStore.fragmentData.fragmentName} saved successfully`)
 }
 
 watch(() => canvasStore.editingMode, () => {

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -47,7 +47,10 @@
 								icon="settings"
 								@click.prevent="store.studioLayout.rightPanelActiveTab = 'Interface'"
 							></Button>
-							<Button variant="solid" class="text-xs" @click="saveAndExitFragmentMode">
+							<Button variant="subtle" class="text-xs" @click="canvasStore.exitFragmentMode">
+								Close
+							</Button>
+							<Button variant="solid" class="text-xs" @click="saveFragmentMode">
 								{{ canvasStore.fragmentData.saveActionLabel || "Save" }}
 							</Button>
 						</div>
@@ -195,10 +198,23 @@ watchEffect(() => {
 	}
 })
 
-async function saveAndExitFragmentMode(e: Event) {
-	canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
-	canvasStore.exitFragmentMode(e)
+let hasSavedFragment = false
+async function saveFragmentMode() {
+	if (!hasSavedFragment) {
+		canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
+		hasSavedFragment = true
+	}
+
+	const pageRootBlock = pageCanvas.value?.getRootBlock()
+	if (pageRootBlock) {
+		store.savingPage = true
+		store.savePage(pageRootBlock)
+	}
 }
+
+watch(() => canvasStore.editingMode, () => {
+	hasSavedFragment = false
+})
 
 const debouncedPageSave = useDebounceFn(store.savePage, 300)
 watch(

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -200,18 +200,10 @@ watchEffect(() => {
 	}
 })
 
-let hasSavedFragment = false
 async function saveFragmentMode() {
-	if (!hasSavedFragment) {
-		canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
-		hasSavedFragment = true
-	}
+	canvasStore.fragmentData.saveAction?.(fragmentCanvas.value?.getRootBlock())
 	toast.success(`${canvasStore.fragmentData.fragmentName} saved successfully`)
 }
-
-watch(() => canvasStore.editingMode, () => {
-	hasSavedFragment = false
-})
 
 const debouncedPageSave = useDebounceFn(store.savePage, 300)
 watch(

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -32,7 +32,7 @@ const useStudioStore = defineStore("store", () => {
 		showLeftPanel: true,
 		showRightPanel: true,
 		leftPanelActiveTab: <LeftPanelOptions>"Add Component",
-		leftPanelComponentTab: <leftPanelComponentTabOptions> "Standard",
+		leftPanelComponentTab: <leftPanelComponentTabOptions>"Standard",
 		rightPanelActiveTab: <RightPanelOptions>"Properties",
 	})
 	const mode = ref<StudioMode>("select")
@@ -74,7 +74,7 @@ const useStudioStore = defineStore("store", () => {
 		if (!appName) {
 			return
 		}
-		studioPages.filters = { studio_app : appName }
+		studioPages.filters = { studio_app: appName }
 		await studioPages.reload()
 		appPages.value = {}
 
@@ -173,10 +173,14 @@ const useStudioStore = defineStore("store", () => {
 		})
 	}
 
-	function savePage() {
-		const canvasStore = useCanvasStore()
-		if (canvasStore?.activeCanvas) {
-			pageBlocks.value = [canvasStore.activeCanvas.getRootBlock()]
+	function savePage(rootBlock?: Block) {
+		if (rootBlock) {
+			pageBlocks.value = [rootBlock]
+		} else {
+			const canvasStore = useCanvasStore()
+			if (canvasStore?.activeCanvas) {
+				pageBlocks.value = [canvasStore.activeCanvas.getRootBlock()]
+			}
 		}
 		const pageData = jsToJson(pageBlocks.value.map((block) => getBlockCopyWithoutParent(block)))
 

--- a/frontend/src/utils/useCanvasDropZone.ts
+++ b/frontend/src/utils/useCanvasDropZone.ts
@@ -22,22 +22,18 @@ export function useCanvasDropZone(
 			if (!componentName) return
 			let newBlock = getComponentBlock(componentName, isStudioComponent)
 
-			function saveBlock(block: Block) {
-				if (slotName) {
-					parentComponent?.updateSlot(slotName, block)
-				} else {
-					parentComponent?.addChild(block, index)
-				}
+			if (slotName) {
+				parentComponent?.updateSlot(slotName, newBlock)
+			} else {
+				parentComponent?.addChild(newBlock, index)
 			}
 
 			if (newBlock.editInFragmentMode()) {
 				canvasStore.editOnCanvas(
 					newBlock,
-					(editedBlock: Block) => saveBlock(editedBlock),
+					(editedBlock: Block) => parentComponent?.replaceChild(newBlock, editedBlock),
 					`Save ${componentName}`
 				)
-			} else {
-				saveBlock(newBlock)
 			}
 		},
 		onOver: (_files, ev) => {


### PR DESCRIPTION
**Before**:

Fragment mode used to exit everytime on save. This was annoying at times when testing changes frequently. Example: a typical workflow:
Edit a dialog script > click "Save Dialog" > saves and goes back to page > click on Preview > come back to page > search for dialog > open it to edit > edit the script > hit save > again thrown back to page

**After:**

Now the fragment mode saves the changes without exiting it. There is a separate button to go back to page
Also changed the logic to save dialog/fragment components immediately on drop, just like other components. The dialog not getting added to the page unless you explicitly hit save might be counter-intuitive as other components get saved immediately on dropping on the canvas