### PR TITLE
feat: add auto load option to Data Source

### DIFF
--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -15,6 +15,10 @@
 					v-model="newResource.resource_name"
 					autocomplete="off"
 				/>
+				<div class="flex w-full flex-row items-center gap-1.5">
+					<FormControl size="sm" type="checkbox" v-model="newResource.auto" />
+					<InputLabel class="max-w-full">Fetch data automatically on load</InputLabel>
+				</div>
 				<div class="flex w-full flex-row gap-2">
 					<FormControl
 						label="Type"
@@ -229,6 +233,7 @@ const emptyResource: Resource = {
 	transform: null,
 	on_success: "",
 	on_error: "",
+	auto: true,
 }
 
 const newResource = ref<Resource>({ ...emptyResource })

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -17,7 +17,7 @@
 				/>
 				<div class="flex w-full flex-row items-center gap-1.5">
 					<FormControl size="sm" type="checkbox" v-model="newResource.auto" />
-					<InputLabel class="max-w-full">Fetch data automatically on load</InputLabel>
+					<InputLabel class="max-w-full">Auto fetch data on load</InputLabel>
 				</div>
 				<div class="flex w-full flex-row gap-2">
 					<FormControl

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -15,10 +15,6 @@
 					v-model="newResource.resource_name"
 					autocomplete="off"
 				/>
-				<div class="flex w-full flex-row items-center gap-1.5">
-					<FormControl size="sm" type="checkbox" v-model="newResource.auto" />
-					<InputLabel class="max-w-full">Auto fetch data on load</InputLabel>
-				</div>
 				<div class="flex w-full flex-row gap-2">
 					<FormControl
 						label="Type"
@@ -139,6 +135,11 @@
 						:multiple="true"
 					/>
 				</template>
+
+				<div class="flex w-full flex-row items-center gap-1.5">
+					<FormControl size="sm" type="checkbox" v-model="newResource.auto" />
+					<InputLabel class="max-w-full">Auto fetch data on load</InputLabel>
+				</div>
 
 				<!-- Transform Results for any Resource Type -->
 				<ScriptSection

--- a/frontend/src/data/studioResources.ts
+++ b/frontend/src/data/studioResources.ts
@@ -6,6 +6,7 @@ export const studioPageResources = createListResource({
 	fields: [
 		"resource_type",
 		"resource_name",
+		"auto",
 		"fields",
 		"filters",
 		"limit",

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -327,7 +327,7 @@ const useCodeStore = defineStore("codeStore", () => {
 					fields: fields.length ? fields : "*",
 					filters: getEvaluatedFilters(resource.filters, context),
 					pageLength: resource.limit,
-					auto: true,
+					auto: resource.auto,
 					...getTransforms(resource),
 					...getSuccessErrorHandlers(resource),
 				}
@@ -340,7 +340,7 @@ const useCodeStore = defineStore("codeStore", () => {
 					url: resource.url,
 					method: resource.method,
 					params: getAPIParams(resource.params, context),
-					auto: true,
+					auto: resource.auto,
 					...getTransforms(resource),
 					...getSuccessErrorHandlers(resource),
 				})
@@ -375,7 +375,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		return createDocumentResource({
 			doctype: resource.document_type,
 			name: docname,
-			auto: true,
+			auto: resource.auto,
 			...getTransforms(resource),
 			...getSuccessErrorHandlers(resource),
 			...getWhitelistedMethods(resource),

--- a/frontend/src/types/Studio/StudioResource.ts
+++ b/frontend/src/types/Studio/StudioResource.ts
@@ -7,6 +7,8 @@ interface BaseResource {
 	resource_id: string
 	resource_name: string
 	resource_type: ResourceType
+	/** Whether to automatically fetch data on first load */
+	auto?: boolean
 	transform?: string | null
 	on_success?: string
 	on_error?: string

--- a/studio/patches.txt
+++ b/studio/patches.txt
@@ -8,3 +8,5 @@ studio.studio.doctype.studio_page.patches.replace_frappeUI_namespace_references
 studio.studio.doctype.studio_app.patches.rename_studio_app_based_on_app_title
 studio.studio.doctype.studio_page.patches.migrate_studio_resource_to_studio_page_resource_child_table
 studio.studio.doctype.studio_page.patches.move_text_block_style_props_to_classes
+studio.studio.doctype.studio_page.patches.set_auto_to_true_in_studio_page_resources
+

--- a/studio/studio/doctype/studio_page/patches/set_auto_to_true_in_studio_page_resources.py
+++ b/studio/studio/doctype/studio_page/patches/set_auto_to_true_in_studio_page_resources.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.qb.update("Studio Page Resource").set("auto", 1).run()

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.json
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.json
@@ -172,14 +172,14 @@
    "fieldname": "auto",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Auto Load?"
+   "label": "Auto fetch data on load"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-24 14:58:58.388282",
+ "modified": "2026-03-24 15:56:00.919209",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Resource",

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.json
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.json
@@ -13,6 +13,7 @@
   "limit",
   "sort_field",
   "sort_order",
+  "auto",
   "document_resource_section",
   "document_type",
   "column_break_mkdu",
@@ -165,13 +166,20 @@
   {
    "fieldname": "on_success_error_section",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "auto",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Auto Load?"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-11 09:53:04.647639",
+ "modified": "2026-03-24 14:58:58.388282",
  "modified_by": "Administrator",
  "module": "Studio",
  "name": "Studio Page Resource",

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.py
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.py
@@ -14,6 +14,7 @@ class StudioPageResource(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		auto: DF.Check
 		document_name: DF.Data | None
 		document_type: DF.Link | None
 		fetch_document_using_filters: DF.Check


### PR DESCRIPTION
Added option to disable auto loading of data sources. Enabled by default. Useful for disabling auto loading when a data source is dependent on another

<img width="1134" height="673" alt="auto" src="https://github.com/user-attachments/assets/c8fcb26c-2315-4308-8b14-6c7c1877d21a" />