### PR TITLE
fix: router links breaking on canvas

### DIFF
--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -334,6 +334,10 @@ watch(
 
 const error = ref<Error | null>(null)
 onErrorCaptured((err, _instance, info) => {
+	const isRouterError = err.message.includes("No match for")
+	if (isRouterError) {
+		return false
+	}
 	console.error(
 		`Error while rendering StudioComponent ${props.block.componentName} ${props.block.componentId}:\n`,
 		`source: ${info}\n`,

--- a/frontend/src/pages/NotFound.vue
+++ b/frontend/src/pages/NotFound.vue
@@ -1,10 +1,8 @@
 <template>
 	<div class="flex h-screen w-full items-center justify-center bg-gray-50">
 		<div class="flex flex-col items-center justify-center">
-			<h1 class="mt-1 text-2xl font-semibold text-gray-600">403: Permission Denied</h1>
-			<div class="mt-2 text-base text-gray-500">
-				You don't have permission to access this page. Make sure you have the right roles & permissions.
-			</div>
+			<h1 class="mt-1 text-2xl font-semibold text-gray-600">404</h1>
+			<div class="mt-2 text-base text-gray-500">The page you are looking for does not exist.</div>
 			<a href="/desk" class="mt-4 text-base text-gray-600 underline">Back to Home</a>
 		</div>
 	</div>

--- a/frontend/src/router/studio_router.ts
+++ b/frontend/src/router/studio_router.ts
@@ -25,6 +25,11 @@ const routes = [
 		path: "/not-permitted",
 		name: "NotPermitted",
 		component: () => import("@/pages/NotPermitted.vue"),
+	},
+	{
+		path: "/:catchAll(.*)",
+		name: "NotFound",
+		component: () => import("@/pages/NotFound.vue"),
 	}
 ]
 
@@ -46,5 +51,16 @@ router.beforeEach(async (to, _, next) => {
 	}
 	return next()
 })
+
+// Patch router to resolve unmatched routes to NotFound page
+// This ensures router-link renders correctly for the app being edited in studio
+const resolve = router.resolve
+// @ts-ignore
+router.resolve = (to, currentLocation) => {
+	if (!to.matched?.length) {
+		to = "/not-found"
+	}
+	return resolve(to, currentLocation)
+}
 
 export default router


### PR DESCRIPTION
**Problem**

`<router-link>` inside components like Breadcrumbs fails because the Studio editor's Vue router doesn't have the app's routes registered. When router-link tries to resolve a route like `{ name: "Campaigns" }` where Campaigns is an app page, it throws "No match for..." error, and the component does not render.

This only breaks for named routes ({ name: "Campaigns" }) not path routes ("/campaigns") because vue router's useLink tries to resolve named routes passed to it even before rendering the component. 

<img width="1186" height="497" alt="image" src="https://github.com/user-attachments/assets/8c29ff55-8780-44c2-a4cf-373875342556" />

But this will always be the case because studio's router would not resolve routes for the app that's being edited in edit mode

**Fix 1:**

Catch & ignore router errors in Studio Component renderer. App routes are not in the context of studio router so route resolution errors should not stop the component from rendering. 

This only renders the path routes, not the named routes (that are invalid)

<img width="1186" height="497" alt="image" src="https://github.com/user-attachments/assets/674010c9-d8b0-471f-ba37-54ed2e447bff" />
<br>

**Fix 2:**

patch router.resolve to resolve unmatched routes to the "Not Found" page. This ensures router-link renders correctly for the app being edited in studio

<img width="1186" height="497" alt="image" src="https://github.com/user-attachments/assets/896dd062-34ec-4444-ad65-7315a6459d91" /><br>

**Why patch router.resolve and not use beforeResolve hook instead?**

The issue is that <router-link> resolves the route during its setup (when it calls useLink()), which happens before any navigation occurs. `beforeResolve` runs only on actual navigation, not when router-link resolves.