### PR TITLE
fix: `update:modelValue` event overwrites event listener from v-model

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -10,7 +10,7 @@
 			v-if="showComponent"
 			:is="componentName"
 			v-bind="componentProps"
-			v-on="{ ...vModelListeners, ...componentEvents }"
+			v-on="mergedListeners"
 			:data-component-id="block.componentId"
 			:style="styles"
 			:class="classes"
@@ -43,7 +43,7 @@
 			v-if="showComponent"
 			:is="componentName"
 			v-bind="componentProps"
-			v-on="{ ...vModelListeners, ...componentEvents }"
+			v-on="mergedListeners"
 			:data-component-id="block.componentId"
 			:style="styles"
 			:class="classes"
@@ -221,6 +221,25 @@ const componentEvents = computed(() => {
 	})
 
 	return events
+})
+
+const mergedListeners = computed(() => {
+	const merged: Record<string, Function | Array<Function> | undefined> = { ...vModelListeners.value }
+
+	Object.entries(componentEvents.value).forEach(([eventName, handler]) => {
+		if (merged[eventName] && handler) {
+			const existingHandler = merged[eventName]
+			if (Array.isArray(existingHandler)) {
+				merged[eventName] = [...existingHandler, handler]
+			} else {
+				merged[eventName] = [existingHandler, handler]
+			}
+		} else {
+			merged[eventName] = handler
+		}
+	})
+
+	return merged
 })
 
 const handleSuccess = (event: any) => (data: DataResult) => {


### PR DESCRIPTION
**Problem:**
`update:modelValue` event overwrites event listener from v-model because they're spread into the same v-on binding

<img width="1186" height="631" alt="link-sync" src="https://github.com/user-attachments/assets/d4cd5b82-e51a-46c7-aad2-94fc7ab2e597" />

<img width="1186" height="631" alt="image" src="https://github.com/user-attachments/assets/0db2705a-bde8-4263-a8f4-4940e767fac6" />

Only the script works in this case, but the Link field's value isn't retained (sync with variable fails)

**Fix:**
Construct an array of event handlers for the same event and bind that to the component