### PR TITLE
feat!: combine & standardise global utilities

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,12 @@
 <template>
 	<div class="h-full">
-		<router-view v-slot="{ Component }">
-			<keep-alive>
-				<component :is="Component" />
-			</keep-alive>
-		</router-view>
+		<FrappeUIProvider>
+			<router-view v-slot="{ Component }">
+				<keep-alive>
+					<component :is="Component" />
+				</keep-alive>
+			</router-view>
+		</FrappeUIProvider>
 
 		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
 		<Dialogs></Dialogs>
@@ -12,6 +14,6 @@
 </template>
 
 <script setup lang="ts">
-import { Dialogs } from "frappe-ui"
+import { Dialogs, FrappeUIProvider } from "frappe-ui"
 import { Toaster } from "vue-sonner"
 </script>

--- a/frontend/src/AppRenderer.vue
+++ b/frontend/src/AppRenderer.vue
@@ -1,12 +1,14 @@
 <template>
 	<div class="h-full">
-		<router-view />
 		<Toaster :visible-toasts="2" position="bottom-right" richColors closeButton />
+		<FrappeUIProvider>
+			<router-view />
+		</FrappeUIProvider>
 		<Dialogs></Dialogs>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { Dialogs } from "frappe-ui"
+import { Dialogs, FrappeUIProvider } from "frappe-ui"
 import { Toaster } from "vue-sonner"
 </script>

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -12,6 +12,7 @@ const useAppStore = defineStore("appStore", () => {
 	const routeObject = computed(() => app_router.currentRoute.value)
 	const codeStore = useCodeStore()
 	codeStore.setRouteObject(routeObject)
+	codeStore.setRouterObject(app_router)
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -14,15 +14,21 @@ import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
 import type { StudioPageWatcher } from "@/types/Studio/StudioPageWatcher"
 import type { ExpressionEvaluationContext } from "@/types"
+import type { Router } from "vue-router"
 
 const useCodeStore = defineStore("codeStore", () => {
 	const resources = ref<Record<string, Resource>>({})
 	const variables = ref<Record<string, any>>({})
 	const activeWatchers = ref<Record<string, WatchStopHandle>>({})
 	const routeObject = ref<ComputedRef>()
+	const routerObject = ref<Router>()
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
+	}
+
+	function setRouterObject(router: Router) {
+		routerObject.value = router
 	}
 
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
@@ -34,6 +40,7 @@ const useCodeStore = defineStore("codeStore", () => {
 			const newResource = await getNewResource(resource, {
 				...variables.value,
 				route: unref(routeObject.value),
+				router: routerObject.value,
 			})
 			return {
 				resource_name: resource.resource_name,
@@ -121,6 +128,7 @@ const useCodeStore = defineStore("codeStore", () => {
 			...resources.value,
 			...globalUtils,
 			route: unref(routeObject.value),
+			router: routerObject.value,
 		}
 	})
 
@@ -133,6 +141,7 @@ const useCodeStore = defineStore("codeStore", () => {
 			...resources.value,
 			...globalUtils,
 			route: unref(routeObject.value),
+			router: routerObject.value,
 		}
 	})
 
@@ -479,7 +488,9 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	return {
 		setRouteObject,
+		setRouterObject,
 		routeObject,
+		routerObject,
 		// resources
 		resources,
 		setPageResources,

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -21,13 +21,13 @@ const useCodeStore = defineStore("codeStore", () => {
 	const variables = ref<Record<string, any>>({})
 	const activeWatchers = ref<Record<string, WatchStopHandle>>({})
 	const routeObject = ref<ComputedRef>()
-	const routerObject = ref<Router>()
+	const routerObject = ref<Router | Readonly<Router>>()
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
 	}
 
-	function setRouterObject(router: Router) {
+	function setRouterObject(router: Router | Readonly<Router>) {
 		routerObject.value = router
 	}
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, nextTick, computed, toRaw, unref } from "vue"
+import { ref, reactive, nextTick, computed, toRaw, readonly } from "vue"
 import router from "@/router/studio_router"
 import { defineStore } from "pinia"
 
@@ -383,7 +383,7 @@ const useStudioStore = defineStore("store", () => {
 
 	const codeStore = useCodeStore()
 	codeStore.setRouteObject(routeObject)
-	codeStore.setRouterObject(unref(router))
+	codeStore.setRouterObject(readonly(router))
 
 	async function setPageData(page: StudioPage) {
 		await codeStore.setPageVariables(page)

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, nextTick, computed, toRaw } from "vue"
+import { ref, reactive, nextTick, computed, toRaw, unref } from "vue"
 import router from "@/router/studio_router"
 import { defineStore } from "pinia"
 
@@ -383,6 +383,7 @@ const useStudioStore = defineStore("store", () => {
 
 	const codeStore = useCodeStore()
 	codeStore.setRouteObject(routeObject)
+	codeStore.setRouterObject(unref(router))
 
 	async function setPageData(page: StudioPage) {
 		await codeStore.setPageVariables(page)

--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -1,7 +1,4 @@
-import app_router from "@/router/app_router"
 import { toast } from "vue-sonner"
-import type { RouteLocationRaw } from "vue-router"
-import { call } from "frappe-ui"
 
 declare global {
 	interface Window {

--- a/frontend/src/utils/appUtils.ts
+++ b/frontend/src/utils/appUtils.ts
@@ -14,9 +14,6 @@ if (typeof window.studio === 'undefined') {
 }
 
 const utils = {
-	navigate: (to: RouteLocationRaw) => {
-		return app_router.push(to)
-	},
 	showToast: ({ title, message, type }: {
 		title?: string
 		message: string
@@ -38,7 +35,6 @@ const utils = {
 				return toast(toastMessage, { description })
 		}
 	},
-	call: call,
 }
 
 Object.assign(window.studio, utils)

--- a/frontend/src/utils/appUtilsRenderer.ts
+++ b/frontend/src/utils/appUtilsRenderer.ts
@@ -1,7 +1,4 @@
-import studio_router from "@/router/studio_router"
 import { toast } from "vue-sonner"
-import type { RouteLocationRaw } from "vue-router"
-import { call } from "frappe-ui"
 
 declare global {
 	interface Window {

--- a/frontend/src/utils/appUtilsRenderer.ts
+++ b/frontend/src/utils/appUtilsRenderer.ts
@@ -14,9 +14,6 @@ if (typeof window.studio === 'undefined') {
 }
 
 const utils = {
-	navigate: (to: RouteLocationRaw) => {
-		return studio_router.push(to)
-	},
 	showToast: ({ title, message, type }: {
 		title?: string
 		message: string
@@ -38,7 +35,6 @@ const utils = {
 				return toast(toastMessage, { description })
 		}
 	},
-	call: call,
 }
 
 Object.assign(window.studio, utils)

--- a/frontend/src/utils/globalUtils.ts
+++ b/frontend/src/utils/globalUtils.ts
@@ -1,9 +1,9 @@
 import { h } from "vue"
-import { toast } from "frappe-ui"
+import { toast, call } from "frappe-ui"
 import { Icon } from "frappe-ui/icons"
 
 function getIcon(name: string) {
 	return h(Icon, { name })
 }
 
-export { getIcon, toast }
+export { getIcon, toast, call }

--- a/frontend/src/utils/globalUtils.ts
+++ b/frontend/src/utils/globalUtils.ts
@@ -1,8 +1,9 @@
 import { h } from "vue"
+import { toast } from "frappe-ui"
 import { Icon } from "frappe-ui/icons"
 
 function getIcon(name: string) {
 	return h(Icon, { name })
 }
 
-export { getIcon }
+export { getIcon, toast }

--- a/frontend/src/utils/useStudioCompletions.ts
+++ b/frontend/src/utils/useStudioCompletions.ts
@@ -50,6 +50,15 @@ export const useStudioCompletions = (canEditValues: boolean = false) => {
 			}
 		})
 
+		sources.push({
+			item: codeStore.routerObject,
+			completion: {
+				label: "router",
+				type: "variable",
+				detail: "Vue Router Object",
+			}
+		})
+
 		if (window.studio) {
 			Object.entries(window.studio).forEach(([funcName, func]) => {
 				if (isPrivateKey(funcName)) {

--- a/frontend/src/utils/useStudioCompletions.ts
+++ b/frontend/src/utils/useStudioCompletions.ts
@@ -4,6 +4,7 @@ import type { CompletionSource } from "@/types"
 import { isPrivateKey } from "@/utils/helpers"
 import { getCompletions } from "./autocompletions"
 import type { CompletionContext } from "@codemirror/autocomplete"
+import * as globalUtils from "@/utils/globalUtils"
 
 export const useStudioCompletions = (canEditValues: boolean = false) => {
 	const codeStore = useCodeStore()
@@ -72,6 +73,28 @@ export const useStudioCompletions = (canEditValues: boolean = false) => {
 				})
 			})
 		}
+
+		Object.entries(globalUtils).forEach(([funcName, func]) => {
+			if (isPrivateKey(funcName)) {
+				return
+			}
+
+			sources.push({
+				item: func,
+				completion: {
+					label: funcName,
+					type: "function",
+					detail: "Utility Function",
+					apply(view, completion, from, to) {
+						let insertText = `${completion.label}()`
+						view.dispatch({
+							changes: { from, to, insert: insertText },
+							selection: { anchor: from + insertText.length - 1 } // Place cursor inside the parentheses
+						})
+					}
+				}
+			})
+		})
 
 		return sources
 	})

--- a/frontend/src/utils/useStudioCompletions.ts
+++ b/frontend/src/utils/useStudioCompletions.ts
@@ -95,10 +95,12 @@ export const useStudioCompletions = (canEditValues: boolean = false) => {
 					type: "function",
 					detail: "Utility Function",
 					apply(view, completion, from, to) {
-						let insertText = `${completion.label}()`
+						let insertText = typeof func === "function" ? `${completion.label}()` : `${completion.label}`
+						// Place cursor inside the parentheses if function
+						let cursorPos = typeof func === "function" ? from + insertText.length - 1 : from + insertText.length
 						view.dispatch({
 							changes: { from, to, insert: insertText },
-							selection: { anchor: from + insertText.length - 1 } // Place cursor inside the parentheses
+							selection: { anchor: cursorPos }
 						})
 					}
 				}

--- a/studio/patches.txt
+++ b/studio/patches.txt
@@ -9,4 +9,4 @@ studio.studio.doctype.studio_app.patches.rename_studio_app_based_on_app_title
 studio.studio.doctype.studio_page.patches.migrate_studio_resource_to_studio_page_resource_child_table
 studio.studio.doctype.studio_page.patches.move_text_block_style_props_to_classes
 studio.studio.doctype.studio_page.patches.set_auto_to_true_in_studio_page_resources
-
+studio.studio.doctype.studio_page.patches.update_old_global_utility_usage

--- a/studio/studio/doctype/studio_page/patches/update_old_global_utility_usage.py
+++ b/studio/studio/doctype/studio_page/patches/update_old_global_utility_usage.py
@@ -1,0 +1,33 @@
+import frappe
+
+
+def execute():
+	"""update global utility usage"""
+	StudioPage = frappe.qb.DocType("Studio Page")
+	pages = (
+		frappe.qb.from_(StudioPage)
+		.select(StudioPage.name, StudioPage.blocks, StudioPage.draft_blocks)
+		.where(
+			(StudioPage.blocks.like("%studio.call%"))
+			| (StudioPage.draft_blocks.like("%studio.call%"))
+			| (StudioPage.blocks.like("%studio.navigate%"))
+			| (StudioPage.draft_blocks.like("%studio.navigate%"))
+		)
+	).run(as_dict=True)
+
+	for page in pages:
+		updates = {}
+		blocks = page.get("blocks")
+		draft_blocks = page.get("draft_blocks")
+
+		if blocks:
+			updates["blocks"] = blocks.replace("studio.call", "call").replace(
+				"studio.navigate", "router.push"
+			)
+
+		if draft_blocks:
+			updates["draft_blocks"] = draft_blocks.replace("studio.call", "call").replace(
+				"studio.navigate", "router.push"
+			)
+
+		frappe.db.set_value("Studio Page", page.name, updates, update_modified=False)


### PR DESCRIPTION
Global utility functions were previously added under the "studio" namespace in https://github.com/frappe/studio/pull/96 and https://github.com/frappe/studio/pull/141

But as we move more towards files and extensibility ([ref](https://github.com/frappe/studio/pull/171)), we can't have 2 versions of the same API. Hence directly exposing global utilities instead of namespacing them

<table>
<tr>
 <th>Before
 <th>Now
<tr>
<tr>
 <td><b>studio.call</b> (used frappe ui's call function internally)
 <td> <b>call</b> (from Frappe UI)
<tr>
 <td> <b>studio.navigate</b> (used router.push internally)
 <td> <b>router</b> (vue-router object exposed directly)
<tr>
 <td> <b>studio.showToast</b> (used vue-sonner's toast API)
 <td> <b>toast.create, toast.promise</b>, etc. <br> (<a href="https://ui.frappe.io/docs/components/toast">from Frappe UI</a>)
</table>

> [!IMPORTANT]
> BREAKING CHANGE
> Removed `studio.call`, `studio.navigate` in favour of `call` and `router`. Retaining `studio.showToast` (vue-sonner) until frappe-ui supports title in toasts