### PR TITLE
feat: Layer Panel Enhancements

### DIFF
--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -291,18 +291,11 @@ const resetDropIndicators = () => {
 	canvasStore.layerDraggingOverBlock = null
 }
 
-const collapseBlockElement = (draggedElementID: string) => {
-	if (draggedElementID && expandedLayers.value.has(draggedElementID)) {
-		expandedLayers.value.delete(draggedElementID)
-	}
-}
-
 const checkMove = () => false // Prevent automatic reordering
 
 const onDragStart = (event: any) => {
 	canvasStore.isDragging = true
 	resetDropIndicators()
-	collapseBlockElement(event.item.dataset.componentLayerId)
 	dragState.draggedElement = event.item
 	document.addEventListener("mousemove", onMouseMove)
 }

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -55,7 +55,7 @@
 							}"
 						/>
 						<span
-							class="min-h-[1em] min-w-[2em] max-w-64 truncate"
+							class="layer-label min-h-[1em] min-w-[2em] max-w-64 truncate"
 							:class="{
 								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
 									element.isStudioComponent,
@@ -82,7 +82,7 @@
 							<FeatherIcon
 								v-if="!element.isRoot() && !isParentHidden"
 								:name="element.isVisible() ? 'eye' : 'eye-off'"
-								class="mr-2 hidden h-3 w-3 cursor-pointer group-hover:block"
+								class="invisible mr-2 h-3 w-3 cursor-pointer group-hover:visible"
 								@click.stop="element.toggleVisibility()"
 							/>
 						</div>

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -363,9 +363,8 @@ const onMouseMove = (event: MouseEvent) => {
 
 const removeFromParent = (block: Block) => {
 	const parent = block.getParentBlock()
-	if (parent?.children) {
-		const index = parent.children.indexOf(block)
-		if (index > -1) parent.children.splice(index, 1)
+	if (parent) {
+		parent.removeChild(block)
 	}
 }
 
@@ -374,17 +373,28 @@ const moveBlockInside = (draggedBlock: Block, targetBlock: Block) => {
 	if (!targetBlock.children) targetBlock.children = []
 	targetBlock.children.push(draggedBlock)
 	draggedBlock.parentBlock = targetBlock
+	delete draggedBlock.parentSlotName
 }
 
 const moveBlockAdjacent = (draggedBlock: Block, targetBlock: Block, position: "before" | "after") => {
 	const targetParent = targetBlock.getParentBlock()
-	if (!targetParent?.children) return
+	if (!targetParent) return
 
 	removeFromParent(draggedBlock)
-	const targetIndex = targetParent.children.indexOf(targetBlock)
+	const targetIndex = targetParent.getChildIndex(targetBlock)
 	const insertIndex = position === "before" ? targetIndex : targetIndex + 1
-	targetParent.children.splice(insertIndex, 0, draggedBlock)
+
 	draggedBlock.parentBlock = targetParent
+	if (targetBlock.isSlotBlock()) {
+		draggedBlock.parentSlotName = targetBlock.parentSlotName
+		let slotContent = targetParent.getSlotContent(targetBlock.parentSlotName!)
+		if (Array.isArray(slotContent)) {
+			slotContent.splice(insertIndex, 0, draggedBlock)
+		}
+	} else {
+		delete draggedBlock.parentSlotName
+		targetParent.children.splice(insertIndex, 0, draggedBlock)
+	}
 }
 
 const onDragEnd = (e: DragEvent) => {

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -22,7 +22,7 @@
 					:data-component-layer-id="element.componentId"
 					:data-indent="indent"
 					:title="element.componentId"
-					class="component-layer-item min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
+					class="component-layer-item relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
 					:class="{
 						'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
 							canvasStore.layerDraggingOverBlock === element.componentId,
@@ -105,7 +105,7 @@
 							:key="slot.slotId"
 							:data-slot-layer-id="slot.slotId"
 							:title="slot.slotName"
-							class="min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
+							class="relative min-w-24 cursor-pointer select-none rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
 							@click.stop="canvasStore.activeCanvas?.selectSlot(slot)"
 						>
 							<div

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -441,18 +441,22 @@ watch(
 		if (canvasStore.activeCanvas?.selectedBlocks.length) {
 			canvasStore.activeCanvas?.selectedBlocks.forEach((block: Block) => {
 				if (block) {
-					let parentBlock = block.getParentBlock()
+					let currentBlock = block
 					// open all parent blocks and slots
-					while (parentBlock && !parentBlock.isRoot()) {
-						let slotName = parentBlock.parentSlotName
-						expandedLayers.value.add(parentBlock?.componentId)
-						parentBlock = parentBlock.getParentBlock()
+					while (currentBlock && !currentBlock.isRoot()) {
+						const parentBlock = currentBlock.getParentBlock()
+						if (!parentBlock) break
+						expandedLayers.value.add(parentBlock.componentId)
+
+						const slotName = currentBlock.parentSlotName
 						if (slotName) {
-							const slotId = parentBlock?.getSlot(slotName)?.slotId
+							const slotId = parentBlock.getSlot(slotName)?.slotId
 							if (slotId) {
 								expandedSlots.value.add(slotId)
 							}
 						}
+
+						currentBlock = parentBlock
 					}
 				}
 			})

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -322,7 +322,7 @@ const onMouseMove = (event: MouseEvent) => {
 	const target = document.elementFromPoint(event.clientX, event.clientY)
 	const layerItem = target?.closest(".component-layer-item") as HTMLElement | null
 
-	if (!layerItem || layerItem === draggedElement) {
+	if (!layerItem || layerItem === draggedElement || draggedElement.contains(layerItem)) {
 		resetDropIndicators()
 		return
 	}
@@ -331,13 +331,6 @@ const onMouseMove = (event: MouseEvent) => {
 	const block = canvasStore.activeCanvas?.findBlock(componentId!)
 
 	if (!block) {
-		resetDropIndicators()
-		return
-	}
-
-	// Prevent dropping a block into its own descendants
-	const draggedBlock = canvasStore.activeCanvas?.findBlock(draggedElement.dataset.componentLayerId!)
-	if (draggedBlock && block.isDescendantOf(draggedBlock)) {
 		resetDropIndicators()
 		return
 	}
@@ -403,7 +396,7 @@ const onDragEnd = (e: DragEvent) => {
 	document.removeEventListener("mousemove", onMouseMove)
 
 	const { draggedElement, hoverTarget, hoverPosition } = dragState
-	if (!draggedElement || !hoverTarget || !hoverPosition) {
+	if (!draggedElement || !hoverTarget || !hoverPosition || draggedElement.contains(hoverTarget)) {
 		Object.assign(dragState, { draggedElement: null, hoverTarget: null, hoverPosition: null })
 		return
 	}
@@ -411,12 +404,7 @@ const onDragEnd = (e: DragEvent) => {
 	const draggedBlock = canvasStore.activeCanvas?.findBlock(draggedElement.dataset.componentLayerId!)
 	const targetBlock = canvasStore.activeCanvas?.findBlock(hoverTarget.dataset.componentLayerId!)
 
-	if (
-		draggedBlock &&
-		targetBlock &&
-		draggedBlock !== targetBlock &&
-		!targetBlock.isDescendantOf(draggedBlock)
-	) {
+	if (draggedBlock && targetBlock && draggedBlock !== targetBlock) {
 		if (hoverPosition === "inside") {
 			moveBlockInside(draggedBlock, targetBlock)
 		} else {

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -177,7 +177,7 @@ const canShowChildLayer = (block: Block) => {
 }
 
 const isExpandable = (block: Block) => {
-	return block.hasChildren() || (block.hasComponentSlots() && !block.isRoot())
+	return (block.hasChildren() || block.hasComponentSlots()) && !block.isRoot()
 }
 
 // slots

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -37,7 +37,7 @@
 						class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
 						:style="{ paddingLeft: `${indent}px` }"
 						:class="{
-							'!opacity-50': !element.isVisible(),
+							'!opacity-50': !element.isVisible() || isParentHidden,
 						}"
 					>
 						<FeatherIcon
@@ -80,7 +80,7 @@
 								<FeatherIcon :name="element.visibilityCondition ? 'zap' : 'zap-off'" class="h-3 w-3" />
 							</div>
 							<FeatherIcon
-								v-if="!element.isRoot()"
+								v-if="!element.isRoot() && !isParentHidden"
 								:name="element.isVisible() ? 'eye' : 'eye-off'"
 								class="mr-2 hidden h-3 w-3 cursor-pointer group-hover:block"
 								@click.stop="element.toggleVisibility()"
@@ -91,7 +91,12 @@
 						</span>
 					</span>
 					<div v-show="canShowChildLayer(element)">
-						<ComponentLayers :blocks="element.children" :ref="childLayer" :indent="childIndent" />
+						<ComponentLayers
+							:blocks="element.children"
+							:is-parent-hidden="isParentHidden || !element.isVisible()"
+							:ref="childLayer"
+							:indent="childIndent"
+						/>
 					</div>
 
 					<div v-show="canShowSlotLayer(element)">
@@ -156,10 +161,12 @@ const props = withDefaults(
 	defineProps<{
 		blocks: Block[]
 		indent?: number
+		isParentHidden?: boolean
 	}>(),
 	{
 		blocks: () => [],
 		indent: 10,
+		isParentHidden: false,
 	},
 )
 

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -74,7 +74,7 @@
 							<div
 								v-if="element.hasVisibilityCondition()"
 								title="Toggle visibility condition"
-								class="hidden cursor-pointer group-hover:block"
+								class="invisible cursor-pointer group-hover:visible"
 								@click.stop="element.toggleVisibilityCondition()"
 							>
 								<FeatherIcon :name="element.visibilityCondition ? 'zap' : 'zap-off'" class="h-3 w-3" />

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -1,117 +1,140 @@
 <template>
-	<div>
+	<div ref="rootContainer" class="relative">
 		<Draggable
 			class="component-tree"
 			:list="blocks"
 			item-key="componentId"
-			:group="{ name: 'component-tree' }"
+			:group="{ name: 'component-tree', pull: 'clone', put: true }"
 			@add="updateParent"
 			:disabled="blocks.length && blocks[0].isRoot()"
-			ghost-class="opacity-50"
+			:force-fallback="true"
+			:fallback-class="'!hidden'"
+			:fallback-on-body="false"
+			:delay="100"
+			:delay-on-touch-only="false"
+			:sort="false"
+			:move="checkMove"
+			@start="onDragStart"
+			@end="onDragEnd"
 		>
 			<template #item="{ element }">
-				<div>
-					<div
-						:data-component-layer-id="element.componentId"
-						:title="element.componentId"
-						class="min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
-						@click.stop="openBlockEditor(element, $event)"
-						@mouseover.stop="canvasStore.activeCanvas?.setHoveredBlock(element.componentId)"
-						@mouseleave="canvasStore.activeCanvas?.setHoveredBlock(null)"
+				<div
+					:data-component-layer-id="element.componentId"
+					:data-indent="indent"
+					:title="element.componentId"
+					class="component-layer-item min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
+					:class="{
+						'border-blue-500 !bg-blue-100 dark:!bg-blue-900':
+							canvasStore.layerDraggingOverBlock === element.componentId,
+					}"
+					@click.stop="openBlockEditor(element, $event)"
+					@mouseover.stop="
+						!canvasStore.isDragging && canvasStore.activeCanvas?.setHoveredBlock(element.componentId)
+					"
+					@mouseleave.stop="!canvasStore.isDragging && canvasStore.activeCanvas?.setHoveredBlock(null)"
+				>
+					<span
+						class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
+						:style="{ paddingLeft: `${indent}px` }"
+						:class="{
+							'!opacity-50': !element.isVisible(),
+						}"
 					>
-						<span
-							class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
-							:style="{ paddingLeft: `${indent}px` }"
+						<FeatherIcon
+							v-if="isExpandable(element)"
+							:name="isExpanded(element) ? 'chevron-down' : 'chevron-right'"
+							class="h-3 w-3"
+							@click.stop="toggleExpanded(element)"
+						/>
+						<component
+							:is="element.getIcon()"
+							class="h-3 w-3"
 							:class="{
-								'!opacity-50': !element.isVisible(),
+								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
+									element.isStudioComponent,
 							}"
+						/>
+						<span
+							class="min-h-[1em] min-w-[2em] max-w-64 truncate"
+							:class="{
+								'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
+									element.isStudioComponent,
+							}"
+							:contenteditable="element.editable"
+							:title="element.blockId"
+							@dblclick="element.editable = true"
+							@keydown.enter.stop.prevent="element.editable = false"
+							@blur="setBlockName($event, element)"
 						>
-							<FeatherIcon
-								v-if="isExpandable(element)"
-								:name="isExpanded(element) ? 'chevron-down' : 'chevron-right'"
-								class="h-3 w-3"
-								@click.stop="toggleExpanded(element)"
-							/>
-							<component
-								:is="element.getIcon()"
-								class="h-3 w-3"
-								:class="{
-									'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
-										element.isStudioComponent,
-								}"
-							/>
-							<span
-								class="min-h-[1em] min-w-[2em] truncate"
-								:class="{
-									'text-purple-500 opacity-80 dark:opacity-100 dark:brightness-125 dark:saturate-[0.3]':
-										element.isStudioComponent,
-								}"
-								:contenteditable="element.editable"
-								:title="element.blockId"
-								@dblclick="element.editable = true"
-								@keydown.enter.stop.prevent="element.editable = false"
-								@blur="setBlockName($event, element)"
-							>
-								{{ element.getBlockDescription() }}
-							</span>
-
-							<!-- toggle visibility -->
-							<div class="ml-auto flex items-center gap-2">
-								<div
-									v-if="element.hasVisibilityCondition()"
-									title="Toggle visibility condition"
-									class="hidden cursor-pointer group-hover:block"
-									@click.stop="element.toggleVisibilityCondition()"
-								>
-									<FeatherIcon :name="element.visibilityCondition ? 'zap' : 'zap-off'" class="h-3 w-3" />
-								</div>
-								<FeatherIcon
-									v-if="!element.isRoot()"
-									:name="element.isVisible() ? 'eye' : 'eye-off'"
-									class="mr-2 hidden h-3 w-3 cursor-pointer group-hover:block"
-									@click.stop="element.toggleVisibility()"
-								/>
-							</div>
-							<span v-if="element.isRoot()" class="ml-auto mr-2 text-sm capitalize text-gray-500">
-								{{ canvasStore.activeCanvas?.activeBreakpoint }}
-							</span>
+							{{ element.getBlockDescription() }}
 						</span>
-						<div v-show="canShowChildLayer(element)">
-							<ComponentLayers :blocks="element.children" ref="childLayer" :indent="childIndent" />
-						</div>
 
-						<div v-show="canShowSlotLayer(element)">
+						<!-- toggle visibility -->
+						<div class="ml-auto flex items-center gap-2">
 							<div
-								v-for="(slot, slotName) in element.componentSlots"
-								:key="slot.slotId"
-								:data-slot-layer-id="slot.slotId"
-								:title="slot.slotName"
-								class="min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
-								@click.stop="canvasStore.activeCanvas?.selectSlot(slot)"
+								v-if="element.hasVisibilityCondition()"
+								title="Toggle visibility condition"
+								class="hidden cursor-pointer group-hover:block"
+								@click.stop="element.toggleVisibilityCondition()"
 							>
-								<div
-									class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
-									:style="{ paddingLeft: `${childIndent}px` }"
-								>
-									<FeatherIcon
-										v-if="isSlotExpandable(slot, element)"
-										:name="isSlotExpanded(slot) ? 'chevron-down' : 'chevron-right'"
-										class="h-3 w-3"
-										@click.stop="toggleSlotExpanded(slot)"
-									/>
-									<SlotIcon class="h-3 w-3" />
-									<span class="min-h-[1em] min-w-[2em] truncate" :title="slot.slotName">#{{ slotName }}</span>
-								</div>
+								<FeatherIcon :name="element.visibilityCondition ? 'zap' : 'zap-off'" class="h-3 w-3" />
+							</div>
+							<FeatherIcon
+								v-if="!element.isRoot()"
+								:name="element.isVisible() ? 'eye' : 'eye-off'"
+								class="mr-2 hidden h-3 w-3 cursor-pointer group-hover:block"
+								@click.stop="element.toggleVisibility()"
+							/>
+						</div>
+						<span v-if="element.isRoot()" class="ml-auto mr-2 text-sm capitalize text-gray-500">
+							{{ canvasStore.activeCanvas?.activeBreakpoint }}
+						</span>
+					</span>
+					<div v-show="canShowChildLayer(element)">
+						<ComponentLayers :blocks="element.children" :ref="childLayer" :indent="childIndent" />
+					</div>
 
-								<div v-if="Array.isArray(slot.slotContent) && isSlotExpanded(slot)">
-									<ComponentLayers :blocks="slot.slotContent" ref="slotLayer" :indent="slotIndent" />
-								</div>
+					<div v-show="canShowSlotLayer(element)">
+						<div
+							v-for="(slot, slotName) in element.componentSlots"
+							:key="slot.slotId"
+							:data-slot-layer-id="slot.slotId"
+							:title="slot.slotName"
+							class="min-w-24 cursor-pointer overflow-hidden rounded border border-transparent bg-white bg-opacity-50 text-base text-gray-700"
+							@click.stop="canvasStore.activeCanvas?.selectSlot(slot)"
+						>
+							<div
+								class="group my-[7px] flex items-center gap-1.5 pr-[2px] font-medium"
+								:style="{ paddingLeft: `${childIndent}px` }"
+							>
+								<FeatherIcon
+									v-if="isSlotExpandable(slot, element)"
+									:name="isSlotExpanded(slot) ? 'chevron-down' : 'chevron-right'"
+									class="h-3 w-3"
+									@click.stop="toggleSlotExpanded(slot)"
+								/>
+								<SlotIcon class="h-3 w-3" />
+								<span class="min-h-[1em] min-w-[2em] truncate" :title="slot.slotName">#{{ slotName }}</span>
+							</div>
+
+							<div v-if="Array.isArray(slot.slotContent) && isSlotExpanded(slot)">
+								<ComponentLayers :blocks="slot.slotContent" ref="slotLayer" :indent="slotIndent" />
 							</div>
 						</div>
 					</div>
 				</div>
 			</template>
 		</Draggable>
+		<!-- Drop indicator line -->
+		<div
+			v-if="showDropIndicator"
+			class="pointer-events-none absolute h-0.5 bg-blue-500 transition-none"
+			:style="{
+				top: dropIndicatorTop + 'px',
+				left: dropIndicatorLeft + 'px',
+				width: 'calc(100% - ' + dropIndicatorLeft + 'px)',
+			}"
+		></div>
 	</div>
 </template>
 
@@ -127,6 +150,8 @@ import Block from "@/utils/block"
 import SlotIcon from "@/components/Icons/SlotIcon.vue"
 import type { Slot } from "@/types"
 
+type LayerInstance = InstanceType<typeof ComponentLayers>
+
 const props = withDefaults(
 	defineProps<{
 		blocks: Block[]
@@ -139,7 +164,13 @@ const props = withDefaults(
 )
 
 const canvasStore = useCanvasStore()
-const childLayer = ref<InstanceType<typeof ComponentLayers> | null>(null)
+const rootContainer = ref<HTMLElement | null>(null)
+const childLayers = ref<LayerInstance[]>([])
+const childLayer = (el: LayerInstance) => {
+	if (el) {
+		childLayers.value.push(el)
+	}
+}
 
 interface LayerBlock extends Block {
 	editable: boolean
@@ -160,16 +191,36 @@ const isExpanded = (block: Block) => {
 }
 
 const toggleExpanded = (block: Block) => {
-	const blockIndex = props.blocks.findIndex((b) => b.componentId === block.componentId)
-	if (blockIndex === -1) {
-		childLayer.value?.toggleExpanded(block)
+	if (block.isRoot()) {
 		return
 	}
-	if (isExpanded(block) && !block.isRoot()) {
+	if (!blockExists(block)) {
+		const child = childLayers.value.find((layer) => layer.blockExistsInTree(block)) as LayerInstance
+		if (child) {
+			child.toggleExpanded(block)
+		}
+	}
+	if (isExpanded(block)) {
 		expandedLayers.value.delete(block.componentId)
 	} else {
 		expandedLayers.value.add(block.componentId)
 	}
+}
+
+const blockExists = (block: Block) => {
+	return props.blocks.find((b) => b.componentId === block.componentId)
+}
+
+const blockExistsInTree = (block: Block): boolean => {
+	if (blockExists(block)) {
+		return true
+	}
+	for (const layer of childLayers.value) {
+		if (layer.blockExistsInTree(block)) {
+			return true
+		}
+	}
+	return false
 }
 
 const canShowChildLayer = (block: Block) => {
@@ -214,6 +265,139 @@ const openBlockEditor = (block: Block, e: MouseEvent) => {
 	} else {
 		canvasStore.activeCanvas?.selectBlock(block, e, false, false)
 	}
+}
+
+// --- Drag & drop reordering ---
+interface DragState {
+	draggedElement: HTMLElement | null
+	hoverTarget: HTMLElement | null
+	hoverPosition: "before" | "after" | "inside" | null
+}
+
+const showDropIndicator = ref(false)
+const dropIndicatorTop = ref(0)
+const dropIndicatorLeft = ref(0)
+const dragState: DragState = { draggedElement: null, hoverTarget: null, hoverPosition: null }
+
+const resetDropIndicators = () => {
+	showDropIndicator.value = false
+	canvasStore.layerDraggingOverBlock = null
+}
+
+const checkMove = () => false // Prevent automatic reordering
+
+const onDragStart = (event: any) => {
+	canvasStore.isDragging = true
+	resetDropIndicators()
+	dragState.draggedElement = event.item
+	document.addEventListener("mousemove", onMouseMove)
+}
+
+const updateDropIndicator = (layerItem: HTMLElement, relativeY: number, elementHeight: number) => {
+	if (!rootContainer.value) return
+
+	const rect = layerItem.getBoundingClientRect()
+	const containerRect = rootContainer.value.getBoundingClientRect()
+	const indent = parseInt(layerItem.dataset.indent || "0", 10)
+	const showAbove = relativeY < elementHeight / 2
+
+	dropIndicatorTop.value = showAbove ? rect.top - containerRect.top : rect.bottom - containerRect.top
+	dropIndicatorLeft.value = indent
+	dragState.hoverPosition = showAbove ? "before" : "after"
+
+	showDropIndicator.value = indent === 0 && showAbove ? false : true
+}
+
+const onMouseMove = (event: MouseEvent) => {
+	if (!dragState.draggedElement) return
+
+	const target = document.elementFromPoint(event.clientX, event.clientY)
+	const layerItem = target?.closest(".component-layer-item") as HTMLElement | null
+
+	if (!layerItem || layerItem === dragState.draggedElement) {
+		resetDropIndicators()
+		return
+	}
+
+	const componentId = layerItem.dataset.componentLayerId
+	const block = canvasStore.activeCanvas?.findBlock(componentId!)
+
+	if (!block) {
+		resetDropIndicators()
+		return
+	}
+
+	const rect = layerItem.getBoundingClientRect()
+	const relativeY = event.clientY - rect.top
+	const elementHeight = rect.height
+	const isInCenterZone = relativeY > elementHeight * 0.25 && relativeY < elementHeight * 0.75
+
+	dragState.hoverTarget = layerItem
+
+	if (block.canHaveChildren() && isInCenterZone) {
+		// Highlight parent block for nested drop
+		canvasStore.layerDraggingOverBlock = componentId!
+		showDropIndicator.value = false
+		dragState.hoverPosition = "inside"
+	} else {
+		// Show line indicator for sibling drop
+		canvasStore.layerDraggingOverBlock = null
+		updateDropIndicator(layerItem, relativeY, elementHeight)
+	}
+}
+
+const removeFromParent = (block: Block) => {
+	const parent = block.getParentBlock()
+	if (parent?.children) {
+		const index = parent.children.indexOf(block)
+		if (index > -1) parent.children.splice(index, 1)
+	}
+}
+
+const moveBlockInside = (draggedBlock: Block, targetBlock: Block) => {
+	removeFromParent(draggedBlock)
+	if (!targetBlock.children) targetBlock.children = []
+	targetBlock.children.push(draggedBlock)
+	draggedBlock.parentBlock = targetBlock
+}
+
+const moveBlockAdjacent = (draggedBlock: Block, targetBlock: Block, position: "before" | "after") => {
+	const targetParent = targetBlock.getParentBlock()
+	if (!targetParent?.children) return
+
+	removeFromParent(draggedBlock)
+	const targetIndex = targetParent.children.indexOf(targetBlock)
+	const insertIndex = position === "before" ? targetIndex : targetIndex + 1
+	targetParent.children.splice(insertIndex, 0, draggedBlock)
+	draggedBlock.parentBlock = targetParent
+}
+
+const onDragEnd = (e: DragEvent) => {
+	canvasStore.isDragging = false
+	resetDropIndicators()
+	document.removeEventListener("mousemove", onMouseMove)
+
+	const { draggedElement, hoverTarget, hoverPosition } = dragState
+	if (!draggedElement || !hoverTarget || !hoverPosition) {
+		Object.assign(dragState, { draggedElement: null, hoverTarget: null, hoverPosition: null })
+		return
+	}
+
+	const draggedBlock = canvasStore.activeCanvas?.findBlock(draggedElement.dataset.componentLayerId!)
+	const targetBlock = canvasStore.activeCanvas?.findBlock(hoverTarget.dataset.componentLayerId!)
+
+	if (draggedBlock && targetBlock && draggedBlock !== targetBlock) {
+		if (hoverPosition === "inside") {
+			moveBlockInside(draggedBlock, targetBlock)
+		} else {
+			moveBlockAdjacent(draggedBlock, targetBlock, hoverPosition)
+		}
+
+		// Select the moved block
+		canvasStore.activeCanvas?.selectBlock(draggedBlock, e)
+	}
+
+	Object.assign(dragState, { draggedElement: null, hoverTarget: null, hoverPosition: null })
 }
 
 // @ts-ignore
@@ -261,5 +445,6 @@ const slotIndent = computed(() => childIndent + 16)
 
 defineExpose({
 	toggleExpanded,
+	blockExistsInTree,
 })
 </script>

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -291,11 +291,18 @@ const resetDropIndicators = () => {
 	canvasStore.layerDraggingOverBlock = null
 }
 
+const collapseBlockElement = (draggedElementID: string) => {
+	if (draggedElementID && expandedLayers.value.has(draggedElementID)) {
+		expandedLayers.value.delete(draggedElementID)
+	}
+}
+
 const checkMove = () => false // Prevent automatic reordering
 
 const onDragStart = (event: any) => {
 	canvasStore.isDragging = true
 	resetDropIndicators()
+	collapseBlockElement(event.item.dataset.componentLayerId)
 	dragState.draggedElement = event.item
 	document.addEventListener("mousemove", onMouseMove)
 }
@@ -316,12 +323,13 @@ const updateDropIndicator = (layerItem: HTMLElement, relativeY: number, elementH
 }
 
 const onMouseMove = (event: MouseEvent) => {
-	if (!dragState.draggedElement) return
+	const draggedElement = dragState.draggedElement
+	if (!draggedElement) return
 
 	const target = document.elementFromPoint(event.clientX, event.clientY)
 	const layerItem = target?.closest(".component-layer-item") as HTMLElement | null
 
-	if (!layerItem || layerItem === dragState.draggedElement) {
+	if (!layerItem || layerItem === draggedElement) {
 		resetDropIndicators()
 		return
 	}
@@ -330,6 +338,13 @@ const onMouseMove = (event: MouseEvent) => {
 	const block = canvasStore.activeCanvas?.findBlock(componentId!)
 
 	if (!block) {
+		resetDropIndicators()
+		return
+	}
+
+	// Prevent dropping a block into its own descendants
+	const draggedBlock = canvasStore.activeCanvas?.findBlock(draggedElement.dataset.componentLayerId!)
+	if (draggedBlock && block.isDescendantOf(draggedBlock)) {
 		resetDropIndicators()
 		return
 	}
@@ -393,7 +408,12 @@ const onDragEnd = (e: DragEvent) => {
 	const draggedBlock = canvasStore.activeCanvas?.findBlock(draggedElement.dataset.componentLayerId!)
 	const targetBlock = canvasStore.activeCanvas?.findBlock(hoverTarget.dataset.componentLayerId!)
 
-	if (draggedBlock && targetBlock && draggedBlock !== targetBlock) {
+	if (
+		draggedBlock &&
+		targetBlock &&
+		draggedBlock !== targetBlock &&
+		!targetBlock.isDescendantOf(draggedBlock)
+	) {
 		if (hoverPosition === "inside") {
 			moveBlockInside(draggedBlock, targetBlock)
 		} else {

--- a/frontend/src/components/StudioLeftPanel.vue
+++ b/frontend/src/components/StudioLeftPanel.vue
@@ -51,10 +51,10 @@
 
 				<PagesPanel v-show="activeTab === 'Pages'" class="mx-2 my-3" />
 				<ComponentPanel v-show="activeTab === 'Add Component'" class="mx-2 my-3" />
-				<div v-show="activeTab === 'Layers'" class="p-3">
+				<div v-show="activeTab === 'Layers'" class="p-3 pr-0">
 					<ComponentLayers
 						v-if="canvasStore.activeCanvas"
-						class="no-scrollbar overflow-auto"
+						class="w-fit min-w-full pr-3"
 						ref="pageLayers"
 						:blocks="[canvasStore.activeCanvas?.getRootBlock() as Block]"
 					/>

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -47,6 +47,7 @@ const useCanvasStore = defineStore("canvasStore", () => {
 
 	// drag & drop
 	const isDragging = ref(false)
+	const layerDraggingOverBlock = ref<string | null>(null)
 	const dropTarget = reactive({
 		x: null as number | null,
 		y: null as number | null,
@@ -185,6 +186,7 @@ const useCanvasStore = defineStore("canvasStore", () => {
 		// drag & drop
 		dropTarget,
 		isDragging,
+		layerDraggingOverBlock,
 		handleDragStart,
 		handleDragEnd,
 		// fragment mode

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -239,15 +239,6 @@ class Block implements BlockOptions {
 		return null;
 	}
 
-	isDescendantOf(ancestor: Block): boolean {
-		let current = this.getParentBlock();
-		while (current) {
-			if (current.componentId === ancestor.componentId) return true;
-			current = current.getParentBlock();
-		}
-		return false;
-	}
-
 	getIcon() {
 		switch(true) {
 			case this.isRoot():

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -239,6 +239,15 @@ class Block implements BlockOptions {
 		return null;
 	}
 
+	isDescendantOf(ancestor: Block): boolean {
+		let current = this.getParentBlock();
+		while (current) {
+			if (current.componentId === ancestor.componentId) return true;
+			current = current.getParentBlock();
+		}
+		return false;
+	}
+
 	getIcon() {
 		switch(true) {
 			case this.isRoot():


### PR DESCRIPTION
**Before**:
- No visual indicator for drop target in layers panel
- Could not move a block inside an empty container

https://github.com/user-attachments/assets/c6521f6d-9c4a-4389-8944-ca8b4a2e67ea

**After**:

https://github.com/user-attachments/assets/f7201490-c347-492a-a5e0-e4ceba3d9ebe

- Shows drop target indicator
- Can now add inside an empty container/block
- UI fixes
	- Reduce opacity for children if parent is not visible
	- Layer panel is now scrollable to easily view deeply nested layers/long block names
	- Clicking on a slot block now expands the slot and parent