### PR TITLE
feat!: invoke `handleEvent` function with event args, eliminate `eventArgs` positional array, replace regex with AST parsing for code

### DIFF
--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -549,25 +549,23 @@ function getScriptDescription(eventName: string): string {
 		const componentSlug = props.block.componentName.toLowerCase()
 		docsLink = `https://ui.frappe.io/docs/components/${componentSlug}#emit-events`
 	}
-	let docs = `You can access event arguments by writing an arrow function: ${getCodeBlock(
-		"(event, value) => { ... }",
-	)}<br><br>`
+	let docs = `Define a ${getCodeBlock(
+		"handleEvent",
+	)} function to access event arguments with named parameters:<br><br>`
 
 	if (docsLink) {
 		docs += `
-			<b>Example:</b> The ${getCodeBlock(
-				"change",
-			)} event on DatePicker emits the selected date, which can be accessed as:<br>
+			<b>Example:</b> The ${getCodeBlock("change")} event on DatePicker emits the selected date:<br>
 			${getCodeBlock(
-				"(date) => { myVar.value = date }",
+				"function handleEvent(date) { myVar.value = date }",
 			)} <br><br>Refer to the <a class="underline" href="${docsLink}" target="_blank">${[
 				props.block?.componentName,
 			]} documentation</a> to see what arguments are emitted for ${eventName} event
 		`
 	} else {
 		docs += `
-			<b>Example:</b> For a ${getCodeBlock("click")} event, you can access the MouseEvent object as:<br>
-			${getCodeBlock("(mouseEvent) => { console.log(mouseEvent) }")}
+			<b>Example:</b> For a ${getCodeBlock("click")} event:<br>
+			${getCodeBlock("function handleEvent(mouseEvent) { console.log(mouseEvent) }")}
 		`
 	}
 	return docs

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -549,8 +549,8 @@ function getScriptDescription(eventName: string): string {
 		const componentSlug = props.block.componentName.toLowerCase()
 		docsLink = `https://ui.frappe.io/docs/components/${componentSlug}#emit-events`
 	}
-	let docs = `You can access event arguments using the ${getCodeBlock("eventArgs")} array: ${getCodeBlock(
-		"eventArgs[index]",
+	let docs = `You can access event arguments by writing an arrow function: ${getCodeBlock(
+		"(event, value) => { ... }",
 	)}<br><br>`
 
 	if (docsLink) {
@@ -559,7 +559,7 @@ function getScriptDescription(eventName: string): string {
 				"change",
 			)} event on DatePicker emits the selected date, which can be accessed as:<br>
 			${getCodeBlock(
-				"const date = eventArgs[0]",
+				"(date) => { myVar.value = date }",
 			)} <br><br>Refer to the <a class="underline" href="${docsLink}" target="_blank">${[
 				props.block?.componentName,
 			]} documentation</a> to see what arguments are emitted for ${eventName} event
@@ -567,7 +567,7 @@ function getScriptDescription(eventName: string): string {
 	} else {
 		docs += `
 			<b>Example:</b> For a ${getCodeBlock("click")} event, you can access the MouseEvent object as:<br>
-			${getCodeBlock("const mouseEvent = eventArgs[0]")}
+			${getCodeBlock("(mouseEvent) => { console.log(mouseEvent) }")}
 		`
 	}
 	return docs

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -251,28 +251,16 @@ const useCodeStore = defineStore("codeStore", () => {
 		try {
 			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, eventArgs }
 
-			if (isFunctionExpression(script)) {
-				try {
-					const fn = new Function("context", `
-						with (context) {
-							return (${script});
-						}
-					`)(context);
-					if (typeof fn === "function") {
-						return fn(...(eventArgs || []));
-					}
-				} catch (e) {
-					// Fall back to standard script execution
-				}
-			}
-
 			const scriptToExecute = `
 				with (context) {
 				${script}
+				if (typeof handleEvent === "function") {
+					return handleEvent(...(context.eventArgs || []));
+				}
 				}
 			`;
 			const scriptFunction = new Function("context", scriptToExecute);
-			scriptFunction(context);
+			return scriptFunction(context);
 		} catch (error) {
 			console.error(`Error executing the script: ${script}`, error)
 		}
@@ -292,21 +280,6 @@ const useCodeStore = defineStore("codeStore", () => {
 				...componentContext,
 				eventArgs,
 				data,
-			}
-
-			if (isFunctionExpression(script)) {
-				try {
-					const fn = new Function("ctx", `
-						with (ctx) {
-							return (${script});
-						}
-					`)(context);
-					if (typeof fn === "function") {
-						return fn(data, ...(eventArgs || []));
-					}
-				} catch (e) {
-					// Fall back to standard script execution
-				}
 			}
 
 			const successFn = new Function(
@@ -336,21 +309,6 @@ const useCodeStore = defineStore("codeStore", () => {
 				...componentContext,
 				eventArgs,
 				error,
-			}
-
-			if (isFunctionExpression(script)) {
-				try {
-					const fn = new Function("ctx", `
-						with (ctx) {
-							return (${script});
-						}
-					`)(context);
-					if (typeof fn === "function") {
-						return fn(error, ...(eventArgs || []));
-					}
-				} catch (e) {
-					// Fall back to standard script execution
-				}
 			}
 
 			const errorFn = new Function(

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -253,13 +253,29 @@ const useCodeStore = defineStore("codeStore", () => {
 		try {
 			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, eventArgs }
 
+			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
+			if (isCodeFirstFunction) {
+				try {
+					const fn = new Function("context", `
+						with (context) {
+							return (${script});
+						}
+					`)(context);
+					if (typeof fn === "function") {
+						return fn(...(eventArgs || []));
+					}
+				} catch (e) {
+					// Fall back to standard script execution
+				}
+			}
+
 			const scriptToExecute = `
 				with (context) {
 				${script}
 				}
 			`;
 			const scriptFunction = new Function("context", scriptToExecute);
-			scriptFunction(context, resources);
+			scriptFunction(context);
 		} catch (error) {
 			console.error(`Error executing the script: ${script}`, error)
 		}
@@ -280,6 +296,23 @@ const useCodeStore = defineStore("codeStore", () => {
 				eventArgs,
 				data,
 			}
+
+			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
+			if (isCodeFirstFunction) {
+				try {
+					const fn = new Function("ctx", `
+						with (ctx) {
+							return (${script});
+						}
+					`)(context);
+					if (typeof fn === "function") {
+						return fn(data, ...(eventArgs || []));
+					}
+				} catch (e) {
+					// Fall back to standard script execution
+				}
+			}
+
 			const successFn = new Function(
 				"ctx",
 				`with(ctx) {
@@ -308,6 +341,23 @@ const useCodeStore = defineStore("codeStore", () => {
 				eventArgs,
 				error,
 			}
+
+			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
+			if (isCodeFirstFunction) {
+				try {
+					const fn = new Function("ctx", `
+						with (ctx) {
+							return (${script});
+						}
+					`)(context);
+					if (typeof fn === "function") {
+						return fn(error, ...(eventArgs || []));
+					}
+				} catch (e) {
+					// Fall back to standard script execution
+				}
+			}
+
 			const errorFn = new Function(
 				"ctx",
 				`with(ctx) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -8,7 +8,7 @@ import { studioWatchers } from "@/data/studioWatchers"
 import * as globalUtils from "@/utils/globalUtils"
 import { getInitialVariableValue, getValueFromObject, setValueInObject } from "@/utils/helpers"
 import { isDynamicValue, normalizeDynamicValue } from "@/utils/code"
-import { FUNCTION_STRING_REGEX } from "@/utils/constants"
+import { isFunctionExpression, toOptionalChaining } from "@/utils/parseCode"
 import type { Filters, Resource, DocumentResource, DataResult } from "@/types/Studio/StudioResource"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
@@ -194,7 +194,7 @@ const useCodeStore = defineStore("codeStore", () => {
 			if (isDynamicValue(value)) {
 				return getDynamicValue(value, localContext)
 			}
-			if (FUNCTION_STRING_REGEX.test(value)) {
+			if (isFunctionExpression(value)) {
 				const func = stringToFunction(value, localContext)
 				if (typeof func === "function") {
 					return func
@@ -221,10 +221,8 @@ const useCodeStore = defineStore("codeStore", () => {
 	function evaluateExpression(expression: string, localContext: ExpressionEvaluationContext) {
 		try {
 			const context = { ...globalContext.value, ...localContext }
-			// Replace dot notation with optional chaining
-			const safeExpression = expression.replace(/(\w+)(?:\.(\w+))+/g, (match) => {
-				return match.split('.').join('?.')
-			})
+			// Replace dot notation with optional chaining via AST
+			const safeExpression = toOptionalChaining(expression)
 
 			// Create a function that takes the context as an argument
 			const func = new Function('context', `
@@ -253,8 +251,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		try {
 			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, eventArgs }
 
-			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
-			if (isCodeFirstFunction) {
+			if (isFunctionExpression(script)) {
 				try {
 					const fn = new Function("context", `
 						with (context) {
@@ -297,8 +294,7 @@ const useCodeStore = defineStore("codeStore", () => {
 				data,
 			}
 
-			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
-			if (isCodeFirstFunction) {
+			if (isFunctionExpression(script)) {
 				try {
 					const fn = new Function("ctx", `
 						with (ctx) {
@@ -342,8 +338,7 @@ const useCodeStore = defineStore("codeStore", () => {
 				error,
 			}
 
-			const isCodeFirstFunction = /^\s*(?:async\s+)?(?:function(?:\s+|\()|\([^)]*\)\s*=>|[a-zA-Z_$][a-zA-Z0-9_$]*\s*=>)/.test(script);
-			if (isCodeFirstFunction) {
+			if (isFunctionExpression(script)) {
 				try {
 					const fn = new Function("ctx", `
 						with (ctx) {

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -1,0 +1,36 @@
+export class LRUCache<T> {
+	max: number
+	cache: Map<string, T>
+	constructor(max = 10) {
+		this.max = max
+		this.cache = new Map<string, T>()
+	}
+
+	get(key: string): T | undefined {
+		const item = this.cache.get(key)
+		if (item !== undefined) {
+			// Move to end (most recently used)
+			this.cache.delete(key)
+			this.cache.set(key, item)
+		}
+		return item
+	}
+
+	set(key: string, val: T) {
+		// refresh key
+		if (this.cache.has(key))
+			this.cache.delete(key)
+		// evict oldest
+		else if (this.cache.size === this.max)
+			this.cache.delete(this.first()!)
+		this.cache.set(key, val)
+	}
+
+	first() {
+		return this.cache.keys().next().value
+	}
+
+	clear() {
+		this.cache.clear()
+	}
+}

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,8 +1,8 @@
 import {
-	FUNCTION_STRING_REGEX,
 	DYNAMIC_EXPRESSION_REGEX,
 	QUOTED_STRING_CONTENT_REGEX,
 } from "@/utils/constants"
+import { isFunctionExpression } from "@/utils/parseCode"
 
 export function isDynamicValue(value: string) {
 	// Check if the prop value is a string and contains a dynamic expression
@@ -28,7 +28,7 @@ export function normalizeCode(json5String: string) {
 export function unquoteFunctions(json5String: string) {
 	return json5String.replace(QUOTED_STRING_CONTENT_REGEX, (match, content) => {
 		const unescaped = unescape(content)
-		if (FUNCTION_STRING_REGEX.test(unescaped)) {
+		if (isFunctionExpression(unescaped)) {
 			return unescaped
 		}
 		return match

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -57,12 +57,6 @@ export const STUDIO_COMPONENTS = [
 	"MarkdownEditor",
 ]
 
-// Matches a complete function (function declaration or arrow function)
-// - Function declaration: (async)? function name?(...) {...}
-// - Arrow function: (async)? (...) => expr or (...) => {...}
-export const FUNCTION_STRING_REGEX =
-	/^\s*(?:async\s+)?(?:(?:function\s*[a-zA-Z_$][a-zA-Z0-9_$]*\s*\([^)]*\)\s*\{[\s\S]*\})|(?:(?:\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>\s*(?:\{[\s\S]*\}|[^,;{}]+)))\s*$/
-
 // Matches strings that are entirely wrapped in double curly braces, e.g., "{{ expression }}" (allows whitespace inside)
 export const DYNAMIC_EXPRESSION_REGEX = /^\{\{[\s\S]*\}\}$/
 

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -1,15 +1,17 @@
 import { parse, parseExpressionAt } from "acorn"
 import type { Node } from "acorn"
 
-/**
- * Detect if a string is a function expression (arrow function, function expression, etc.)
- * Uses AST parsing instead of regex for reliability with edge cases like:
- * - destructured params: ({a, b}) => {}
- * - default values: (a = 1) => {}
- * - async functions: async function(e) {}
- * - named function expressions: function handler(e) {}
- */
 export function isFunctionExpression(code: string): boolean {
+	const trimmed = code.trimStart()
+	if (
+		!trimmed.startsWith("(") &&
+		!trimmed.startsWith("function") &&
+		!trimmed.startsWith("async") &&
+		!code.includes("=>")
+	) {
+		return false
+	}
+
 	// Try parsing as a full program first
 	try {
 		const ast = parse(code, { ecmaVersion: "latest", sourceType: "module" })
@@ -46,17 +48,9 @@ interface MemberExpressionNode extends Node {
 	optional: boolean
 }
 
-/**
- * Convert member expressions (a.b.c) to optional chaining (a?.b?.c)
- * via AST walking. Only targets non-computed, non-optional MemberExpression nodes.
- *
- * Unlike the regex approach, this correctly handles:
- * - Method calls: items.filter(i => i.active) — chains are handled, arrow is untouched
- * - Computed access: obj[key].name — skips the computed [key] part
- * - String literals — untouched
- * - Ternaries — each branch handled independently
- */
 export function toOptionalChaining(expression: string): string {
+	if (!expression.includes(".")) return expression
+
 	try {
 		const ast = parse(expression, { ecmaVersion: "latest", sourceType: "module" })
 		// Collect all dot positions that need to become ?.
@@ -92,9 +86,6 @@ export function toOptionalChaining(expression: string): string {
 	}
 }
 
-/**
- * Simple recursive AST walker
- */
 function walkAST(node: any, callback: (node: Node) => void) {
 	if (!node || typeof node !== "object") return
 

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -1,6 +1,8 @@
 import { parse, parseExpressionAt } from "acorn"
 import type { Node } from "acorn"
+import { LRUCache } from "@/utils/cache"
 
+const fnCache = new LRUCache<boolean>(20)
 export function isFunctionExpression(code: string): boolean {
 	const trimmed = code.trimStart()
 	if (
@@ -12,29 +14,35 @@ export function isFunctionExpression(code: string): boolean {
 		return false
 	}
 
-	// Try parsing as a full program first
+	const cached = fnCache.get(code)
+	if (cached !== undefined) return cached
+
 	try {
 		const ast = parse(code, { ecmaVersion: "latest", sourceType: "module" })
 		if (ast.body.length === 1) {
 			const node = ast.body[0]
 			if (node.type === "ExpressionStatement") {
-				return (
+				const result =
 					node.expression.type === "ArrowFunctionExpression" ||
 					node.expression.type === "FunctionExpression"
-				)
+				fnCache.set(code, result)
+				return result
 			}
 		}
+		fnCache.set(code, false)
 		return false
 	} catch {
-		// bare `function(x) {}` doesn't parse as a program statement,
+		// anonymous `function(x) {}` doesn't parse as a program statement,
 		// try parsing as an expression
 		try {
 			const expr = parseExpressionAt(code, 0, { ecmaVersion: "latest" })
-			return (
+			const result =
 				expr.type === "ArrowFunctionExpression" ||
 				expr.type === "FunctionExpression"
-			)
+			fnCache.set(code, result)
+			return result
 		} catch {
+			fnCache.set(code, false)
 			return false
 		}
 	}
@@ -48,8 +56,12 @@ interface MemberExpressionNode extends Node {
 	optional: boolean
 }
 
+const optionalChainingCache = new LRUCache<string>(20)
 export function toOptionalChaining(expression: string): string {
 	if (!expression.includes(".")) return expression
+
+	const cached = optionalChainingCache.get(expression)
+	if (cached !== undefined) return cached
 
 	try {
 		const ast = parse(expression, { ecmaVersion: "latest", sourceType: "module" })
@@ -70,8 +82,6 @@ export function toOptionalChaining(expression: string): string {
 			}
 		})
 
-		if (dotPositions.length === 0) return expression
-
 		// Sort positions in reverse order to avoid index shifting during replacement
 		dotPositions.sort((a, b) => b - a)
 
@@ -79,9 +89,9 @@ export function toOptionalChaining(expression: string): string {
 		for (const pos of dotPositions) {
 			result = result.slice(0, pos) + "?." + result.slice(pos + 1)
 		}
+		optionalChainingCache.set(expression, result)
 		return result
 	} catch {
-		// If parsing fails, return expression as-is
 		return expression
 	}
 }

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -1,0 +1,115 @@
+import { parse, parseExpressionAt } from "acorn"
+import type { Node } from "acorn"
+
+/**
+ * Detect if a string is a function expression (arrow function, function expression, etc.)
+ * Uses AST parsing instead of regex for reliability with edge cases like:
+ * - destructured params: ({a, b}) => {}
+ * - default values: (a = 1) => {}
+ * - async functions: async function(e) {}
+ * - named function expressions: function handler(e) {}
+ */
+export function isFunctionExpression(code: string): boolean {
+	// Try parsing as a full program first
+	try {
+		const ast = parse(code, { ecmaVersion: "latest", sourceType: "module" })
+		if (ast.body.length === 1) {
+			const node = ast.body[0]
+			if (node.type === "ExpressionStatement") {
+				return (
+					node.expression.type === "ArrowFunctionExpression" ||
+					node.expression.type === "FunctionExpression"
+				)
+			}
+		}
+		return false
+	} catch {
+		// bare `function(x) {}` doesn't parse as a program statement,
+		// try parsing as an expression
+		try {
+			const expr = parseExpressionAt(code, 0, { ecmaVersion: "latest" })
+			return (
+				expr.type === "ArrowFunctionExpression" ||
+				expr.type === "FunctionExpression"
+			)
+		} catch {
+			return false
+		}
+	}
+}
+
+interface MemberExpressionNode extends Node {
+	type: "MemberExpression"
+	object: Node
+	property: Node
+	computed: boolean
+	optional: boolean
+}
+
+/**
+ * Convert member expressions (a.b.c) to optional chaining (a?.b?.c)
+ * via AST walking. Only targets non-computed, non-optional MemberExpression nodes.
+ *
+ * Unlike the regex approach, this correctly handles:
+ * - Method calls: items.filter(i => i.active) — chains are handled, arrow is untouched
+ * - Computed access: obj[key].name — skips the computed [key] part
+ * - String literals — untouched
+ * - Ternaries — each branch handled independently
+ */
+export function toOptionalChaining(expression: string): string {
+	try {
+		const ast = parse(expression, { ecmaVersion: "latest", sourceType: "module" })
+		// Collect all dot positions that need to become ?.
+		const dotPositions: number[] = []
+		walkAST(ast, (node: Node) => {
+			if (
+				node.type === "MemberExpression" &&
+				!(node as MemberExpressionNode).computed &&
+				!(node as MemberExpressionNode).optional
+			) {
+				const memberNode = node as MemberExpressionNode
+				// The dot is between object.end and property.start
+				const dotIndex = expression.indexOf(".", memberNode.object.end!)
+				if (dotIndex !== -1 && dotIndex < memberNode.property.start!) {
+					dotPositions.push(dotIndex)
+				}
+			}
+		})
+
+		if (dotPositions.length === 0) return expression
+
+		// Sort positions in reverse order to avoid index shifting during replacement
+		dotPositions.sort((a, b) => b - a)
+
+		let result = expression
+		for (const pos of dotPositions) {
+			result = result.slice(0, pos) + "?." + result.slice(pos + 1)
+		}
+		return result
+	} catch {
+		// If parsing fails, return expression as-is
+		return expression
+	}
+}
+
+/**
+ * Simple recursive AST walker
+ */
+function walkAST(node: any, callback: (node: Node) => void) {
+	if (!node || typeof node !== "object") return
+
+	callback(node)
+
+	for (const key of Object.keys(node)) {
+		const child = node[key]
+		if (Array.isArray(child)) {
+			for (const item of child) {
+				if (item && typeof item === "object" && item.type) {
+					walkAST(item, callback)
+				}
+			}
+		} else if (child && typeof child === "object" && child.type) {
+			walkAST(child, callback)
+		}
+	}
+}


### PR DESCRIPTION
## Event Handling

**Before:**

<img width="3248" height="2112" alt="image" src="https://github.com/user-attachments/assets/b56ce92f-1e46-42bc-b75f-f7c1a6abf1f7" />

Since https://github.com/frappe/studio/pull/153, event arguments would have to be accessed from the `eventArgs` array passed to the event execution closure. This was an awkward syntax

**After**:

<img width="3248" height="2112" alt="image" src="https://github.com/user-attachments/assets/634ad840-5987-46b7-a258-922967698805" />

Modified script execution logic to automatically invoke a `handleEvent` function with event arguments if it exists. If users don't want access to `eventArgs`, they can write a normal script without the `handleEvent` function

> [!IMPORTANT]
>  **BREAKING CHANGE**
> eventArgs array will no longer work in event scripts. Refactor to use handleEvent function everywhere you need access to event arguments

## Code Parsing and Evaluation:

* Replaced regular expression-based function detection (`FUNCTION_STRING_REGEX`) with a new AST-based `isFunctionExpression` utility, improving reliability when identifying function expressions in user code.
* Introduced `toOptionalChaining` utility to safely convert dot notation to optional chaining in dynamic expressions using AST parsing, replacing the previous regex approach for improved accuracy
* This is done to make user-written code parsing more robust so we don't run into issues like [this one](https://github.com/frappe/studio/pull/142)
* Both these results are cached using LRUCache for quick access