### PR TITLE
fix: hide desktop breakpoint when deselected

### DIFF
--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -30,7 +30,7 @@
 					class="w-auto cursor-pointer p-2"
 					v-for="breakpoint in canvasProps.breakpoints"
 					:key="breakpoint.device"
-					@click.stop="breakpoint.visible = !breakpoint.visible"
+					@click.stop="selectBreakpoint(breakpoint)"
 				>
 					<FeatherIcon
 						:name="breakpoint.icon"
@@ -175,7 +175,7 @@ const canvasProps = reactive({
 provide("canvasProps", canvasProps)
 
 const visibleBreakpoints = computed(() => {
-	return canvasProps.breakpoints.filter((breakpoint) => breakpoint.visible || breakpoint.device === "desktop")
+	return canvasProps.breakpoints.filter((breakpoint) => breakpoint.visible)
 })
 watch(
 	() => canvasProps.breakpoints.map((b) => b.visible),
@@ -186,6 +186,12 @@ watch(
 		setScaleAndTranslate()
 	},
 )
+function selectBreakpoint(breakpoint: BreakpointConfig) {
+	breakpoint.visible = !breakpoint.visible
+	if (canvasProps.breakpoints.filter((bp) => bp.visible).length === 0) {
+		breakpoint.visible = true
+	}
+}
 
 // clone props.block into canvas data to avoid mutating them
 const rootComponent = ref(getBlockCopy(props.componentTree, true))


### PR DESCRIPTION
Desktop view wouldn't hide when deselected because it was hardcoded to always stay visible. Fixed that and also made sure at least one breakpoint stays visible at all times.


https://github.com/user-attachments/assets/892b3737-202c-462b-a5de-f7a34ca8daa7



closes: #180 