### PR TITLE
fix: normalize keyboard shortcuts to ignore CapsLock and Shift casing

### DIFF
--- a/frontend/src/components/ComponentInterface.vue
+++ b/frontend/src/components/ComponentInterface.vue
@@ -153,7 +153,7 @@ import Code from "@/components/Code.vue"
 import ColorInput from "@/components/ColorInput.vue"
 import PropsEditor from "@/components/PropsEditor.vue"
 import useComponentEditorStore from "@/stores/componentEditorStore"
-import { isCtrlOrCmd } from "@/utils/helpers"
+import { isCtrlOrCmd, isKey } from "@/utils/helpers"
 
 const componentEditorStore = useComponentEditorStore()
 const componentInputs = computed(() => componentEditorStore.componentInputs)
@@ -234,7 +234,7 @@ const setInputControl = () => {
 }
 
 const handleInputKeydown = (e: KeyboardEvent) => {
-	if (isCtrlOrCmd(e) && e.key === "s") {
+	if (isCtrlOrCmd(e) && isKey(e, "s")) {
 		e.preventDefault()
 		saveInput()
 	}

--- a/frontend/src/components/SearchBlock.vue
+++ b/frontend/src/components/SearchBlock.vue
@@ -165,6 +165,7 @@ import { computed, nextTick, onMounted, Ref, ref } from "vue"
 import { toast } from "frappe-ui"
 import OptionToggle from "@/components/OptionToggle.vue"
 import { jsToJson } from "@/utils/serializer"
+import { isKey } from "@/utils/helpers"
 
 const canvasStore = useCanvasStore()
 
@@ -291,7 +292,7 @@ const handlePrimaryAction = () => {
 
 const handleKeydown = (event: KeyboardEvent) => {
 	// Cmd+F or Ctrl+F for quick search
-	if ((event.metaKey || event.ctrlKey) && event.key === "f") {
+	if ((event.metaKey || event.ctrlKey) && isKey(event, "f")) {
 		event.preventDefault()
 		const input = searchInput.value?.querySelector?.("input") || searchInput.value
 		if (input && "focus" in input && typeof input.focus === "function") {
@@ -299,7 +300,7 @@ const handleKeydown = (event: KeyboardEvent) => {
 		}
 	}
 	// Escape to clear search
-	if (event.key === "Escape") {
+	if (isKey(event, "Escape")) {
 		query.value = ""
 		replaceQuery.value = ""
 	}

--- a/frontend/src/components/StudioRightPanel.vue
+++ b/frontend/src/components/StudioRightPanel.vue
@@ -101,6 +101,8 @@ const tabs = computed(() => {
 	return _tabs
 })
 
+import { isKey } from "@/utils/helpers"
+
 const showSearchInput = computed(
 	() =>
 		(activeTab.value === "Properties" || activeTab.value === "Styles") &&
@@ -109,7 +111,7 @@ const showSearchInput = computed(
 const searchInput = ref<InstanceType<typeof Input> | null>(null)
 // command + f should focus on search input
 window.addEventListener("keydown", (e) => {
-	if (e.key === "f" && (e.metaKey || e.ctrlKey)) {
+	if (isKey(e, "f") && (e.metaKey || e.ctrlKey)) {
 		e.preventDefault()
 		searchInput.value?.$el?.querySelector("input")?.focus()
 	}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -439,6 +439,12 @@ function getColorFromToken(tokenString: string) {
 }
 
 // general utils
+
+function isKey(e: KeyboardEvent | KeyboardEvent, key: string) {
+	if (!e.key) return false
+	return e.key.toLowerCase() === key.toLowerCase()
+}
+
 function isCtrlOrCmd(e: KeyboardEvent | MouseEvent) {
 	return e.ctrlKey || e.metaKey;
 }
@@ -563,6 +569,7 @@ export {
 	isColorToken,
 	getColorFromToken,
 	// general utils
+	isKey,
 	isCtrlOrCmd,
 	copyToClipboard,
 	setClipboardData,

--- a/frontend/src/utils/useStudioEvents.ts
+++ b/frontend/src/utils/useStudioEvents.ts
@@ -2,7 +2,7 @@ import useStudioStore from "@/stores/studioStore"
 import useCanvasStore from "@/stores/canvasStore"
 import { useEventListener } from "@vueuse/core"
 import blockController from "@/utils/blockController"
-import { isCtrlOrCmd, isTargetEditable, setClipboardData, numberToPx, isHTML } from "@/utils/helpers"
+import { isKey, isCtrlOrCmd, isTargetEditable, setClipboardData, numberToPx, isHTML } from "@/utils/helpers"
 import { getBlockCopy, getBlockCopyWithoutParent, getComponentBlock, isJSONString } from "@/utils/serializer"
 import Block from "@/utils/block"
 import type { BlockOptions } from "@/types"
@@ -95,7 +95,7 @@ export function useStudioEvents() {
 		if (isTargetEditable(e)) return
 
 		// delete
-		if ((e.key === "Backspace" || e.key === "Delete") && blockController.isAnyBlockSelected()) {
+		if ((isKey(e, "Backspace") || isKey(e, "Delete")) && blockController.isAnyBlockSelected()) {
 			for (const block of blockController.getSelectedBlocks()) {
 				canvasStore.activeCanvas?.removeBlock(block, e.shiftKey)
 			}
@@ -105,7 +105,7 @@ export function useStudioEvents() {
 		}
 
 		// duplicate
-		if (e.key === "d" && isCtrlOrCmd(e)) {
+		if (isKey(e, "d") && isCtrlOrCmd(e)) {
 			if (blockController.isAnyBlockSelected() && !blockController.multipleBlocksSelected()) {
 				e.preventDefault()
 				const block = blockController.getSelectedBlocks()[0]
@@ -115,21 +115,21 @@ export function useStudioEvents() {
 		}
 
 		// undo
-		if (e.key === "z" && isCtrlOrCmd(e) && !e.shiftKey && canvasStore.activeCanvas?.history?.canUndo()) {
+		if (isKey(e, "z") && isCtrlOrCmd(e) && !e.shiftKey && canvasStore.activeCanvas?.history?.canUndo()) {
 			canvasStore.activeCanvas?.history.undo()
 			e.preventDefault()
 			return
 		}
 
 		// redo
-		if (e.key === "z" && e.shiftKey && isCtrlOrCmd(e) && canvasStore.activeCanvas?.history?.canRedo) {
+		if (isKey(e, "z") && e.shiftKey && isCtrlOrCmd(e) && canvasStore.activeCanvas?.history?.canRedo) {
 			canvasStore.activeCanvas?.history.redo()
 			e.preventDefault()
 			return
 		}
 
 		// search block
-		if (e.key === "f" && isCtrlOrCmd(e) && e.shiftKey) {
+		if (isKey(e, "f") && isCtrlOrCmd(e) && e.shiftKey) {
 			e.preventDefault();
 			store.showSearchBlock = true;
 		}
@@ -138,12 +138,12 @@ export function useStudioEvents() {
 			return
 		}
 
-		if (e.key === "c") {
+		if (isKey(e, "c")) {
 			store.mode = "container"
 			return
 		}
 
-		if (e.key === "v") {
+		if (isKey(e, "v")) {
 			store.mode = "select"
 			return
 		}

--- a/frontend/src/utils/useStudioEvents.ts
+++ b/frontend/src/utils/useStudioEvents.ts
@@ -122,7 +122,7 @@ export function useStudioEvents() {
 		}
 
 		// redo
-		if (isKey(e, "z") && e.shiftKey && isCtrlOrCmd(e) && canvasStore.activeCanvas?.history?.canRedo) {
+		if (isKey(e, "z") && e.shiftKey && isCtrlOrCmd(e) && canvasStore.activeCanvas?.history?.canRedo()) {
 			canvasStore.activeCanvas?.history.redo()
 			e.preventDefault()
 			return


### PR DESCRIPTION
## Description
This PR fixes a bug where global keyboard shortcuts (`Ctrl+Z`, `Ctrl+D`, `Ctrl+F`, etc.) would silently fail if the user had `CapsLock` engaged or was holding `Shift`. It also fixes a minor bug in `useStudioEvents.ts` where the `canRedo` function was referenced but not actually executed in the `Ctrl+Shift+Z` handler.

## Root Cause
When `CapsLock` or `Shift` is active, `KeyboardEvent.key` returns the uppercase character (e.g., `"Z"` instead of `"z"`). Since the frontend used strict equality checks (`e.key === "z"`), these shortcuts failed to trigger under those conditions.

## Changes
- **`helpers.ts`**: Introduced an `isKey(e, key)` helper that normalizes casing before comparison.
- **`useStudioEvents.ts`**: Replaced all raw `.key` alphabet checks with `isKey()`.
- **`SearchBlock.vue` & `ComponentInterface.vue` & `StudioRightPanel.vue`**: Applied the `isKey()` helper to local shortcuts (`Ctrl+F` and `Ctrl+S`) for consistency.
- **Redo Fix**: Changed `canRedo` to `canRedo()` to ensure the redo stack check actually evaluates.

## Testing
- Enable `CapsLock` and verify that `Ctrl+Z` (Undo), `Ctrl+Shift+Z` (Redo), `Ctrl+D` (Duplicate) and other shortcuts work correctly on the canvas.