### PR TITLE
feat!: Allow wiring any event with modifiers, remove Switch App Page & other event actions in favour of "Script"

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -171,27 +171,7 @@ const componentEvents = computed(() => {
 	const events: Record<string, Function | undefined> = {}
 	Object.entries(props.block.componentEvents).forEach(([eventName, event]) => {
 		const getEventFn = () => {
-			if (event.action === "Call API") {
-				return (...eventArgs: any[]) => {
-					const path: string[] = event.api_endpoint.split(".")
-					// get resource
-					const resource = codeStore.resources[path[0]]
-					event.eventArgs = eventArgs
-
-					if (resource) {
-						// access and call whitelisted method
-						resource[path[1]].submit()
-					} else {
-						createResource({
-							url: event.api_endpoint,
-							auto: true,
-							params: codeStore.getAPIParams(event.params, evaluationContext.value),
-							onSuccess: handleSuccess(event),
-							onError: handleError(event),
-						})
-					}
-				}
-			} else if (event.action === "Insert a Document") {
+			if (event.action === "Insert a Document") {
 				return (...eventArgs: any[]) => {
 					const fields: Record<string, any> = {}
 					event.fields.forEach((field: Field) => {
@@ -259,8 +239,6 @@ const handleSuccess = (event: any) => (data: DataResult) => {
 	} else {
 		if (event.action === "Insert a Document") {
 			toast.success(event.success_message || `${event.doctype} created successfully`)
-		} else if (event.action === "Call API" && event.success_message) {
-			toast.success(event.success_message)
 		}
 	}
 }
@@ -277,8 +255,6 @@ const handleError = (event: any) => (error: any) => {
 	} else {
 		if (event.action === "Insert a Document") {
 			toast.error(event.error_message || `Error creating ${event.doctype}`)
-		} else if (event.action === "Call API" && event.error_message) {
-			toast.error(event.error_message)
 		}
 	}
 }

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -60,7 +60,6 @@
 import Block from "@/utils/block"
 import { computed, onMounted, ref, useAttrs, inject, type ComputedRef, h } from "vue"
 import type { ComponentPublicInstance } from "vue"
-import { useRouter } from "vue-router"
 import { createResource } from "frappe-ui"
 import { getComponentRoot, isHTML, isObjectEmpty } from "@/utils/helpers"
 import { useScreenSize } from "@/utils/useScreenSize"
@@ -168,17 +167,11 @@ const showComponent = computed(() => {
 })
 
 // events
-const router = useRouter()
-
 const componentEvents = computed(() => {
 	const events: Record<string, Function | undefined> = {}
 	Object.entries(props.block.componentEvents).forEach(([eventName, event]) => {
 		const getEventFn = () => {
-			if (event.action === "Switch App Page") {
-				return () => {
-					router.push(event.page)
-				}
-			} else if (event.action === "Call API") {
+			if (event.action === "Call API") {
 				return (...eventArgs: any[]) => {
 					const path: string[] = event.api_endpoint.split(".")
 					// get resource

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -65,6 +65,7 @@ import { getComponentRoot, isHTML, isObjectEmpty } from "@/utils/helpers"
 import { useScreenSize } from "@/utils/useScreenSize"
 import { isDynamicValue } from "@/utils/code"
 import { resolveEventListener } from "@/utils/eventModifiers"
+import useComponentInstance from "@/utils/useComponentInstance"
 
 import useCodeStore from "@/stores/codeStore"
 import { toast } from "frappe-ui"
@@ -171,13 +172,15 @@ const showComponent = computed(() => {
 type Listener = (...args: any[]) => any
 type ListenerMap = Record<string, Listener | Listener[]>
 
+const componentInstance = useComponentInstance(() => props.block)
+const componentEmits = computed<string[]>(() => componentInstance.value?.emits || [])
+
 const componentEvents = computed(() => {
 	const events: ListenerMap = {}
 	Object.entries(props.block.componentEvents).forEach(([eventName, event]) => {
 		const handler = getEventHandler(event)
 		if (!handler) return
-		// "keydown.enter", "click.prevent" etc. resolve to a base event + guarded handler
-		const { name, listener } = resolveEventListener(eventName, handler)
+		const { name, listener } = resolveEventListener(eventName, handler, componentEmits.value)
 		addListener(events, name, listener)
 	})
 	return events

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -64,6 +64,7 @@ import { createResource } from "frappe-ui"
 import { getComponentRoot, isHTML, isObjectEmpty } from "@/utils/helpers"
 import { useScreenSize } from "@/utils/useScreenSize"
 import { isDynamicValue } from "@/utils/code"
+import { resolveEventListener } from "@/utils/eventModifiers"
 
 import useCodeStore from "@/stores/codeStore"
 import { toast } from "frappe-ui"
@@ -167,65 +168,66 @@ const showComponent = computed(() => {
 })
 
 // events
-const componentEvents = computed(() => {
-	const events: Record<string, Function | undefined> = {}
-	Object.entries(props.block.componentEvents).forEach(([eventName, event]) => {
-		const getEventFn = () => {
-			if (event.action === "Insert a Document") {
-				return (...eventArgs: any[]) => {
-					const fields: Record<string, any> = {}
-					event.fields.forEach((field: Field) => {
-						fields[field.field] = codeStore.getValueFromVariable(field.value, evaluationContext.value)
-					})
-					event.eventArgs = eventArgs
-					createResource({
-						url: "frappe.client.insert",
-						method: "POST",
-						params: {
-							doc: {
-								doctype: event.doctype,
-								...fields,
-							},
-						},
-						onSuccess: handleSuccess(event),
-						onError: handleError(event),
-					}).submit()
-				}
-			} else if (event.action === "Run Script") {
-				return (...eventArgs: any[]) => {
-					codeStore.executeUserScript(
-						event.script,
-						repeaterContext?.value,
-						componentContext?.value,
-						eventArgs,
-					)
-				}
-			}
-		}
-		events[eventName] = getEventFn()
-	})
+type Listener = (...args: any[]) => any
+type ListenerMap = Record<string, Listener | Listener[]>
 
+const componentEvents = computed(() => {
+	const events: ListenerMap = {}
+	Object.entries(props.block.componentEvents).forEach(([eventName, event]) => {
+		const handler = getEventHandler(event)
+		if (!handler) return
+		// "keydown.enter", "click.prevent" etc. resolve to a base event + guarded handler
+		const { name, listener } = resolveEventListener(eventName, handler)
+		addListener(events, name, listener)
+	})
 	return events
 })
 
-const mergedListeners = computed(() => {
-	const merged: Record<string, Function | Array<Function> | undefined> = { ...vModelListeners.value }
-
-	Object.entries(componentEvents.value).forEach(([eventName, handler]) => {
-		if (merged[eventName] && handler) {
-			const existingHandler = merged[eventName]
-			if (Array.isArray(existingHandler)) {
-				merged[eventName] = [...existingHandler, handler]
-			} else {
-				merged[eventName] = [existingHandler, handler]
-			}
-		} else {
-			merged[eventName] = handler
+function getEventHandler(event: any): Listener | undefined {
+	if (event.action === "Insert a Document") {
+		return (...eventArgs: any[]) => {
+			const fields: Record<string, any> = {}
+			event.fields.forEach((field: Field) => {
+				fields[field.field] = codeStore.getValueFromVariable(field.value, evaluationContext.value)
+			})
+			event.eventArgs = eventArgs
+			createResource({
+				url: "frappe.client.insert",
+				method: "POST",
+				params: { doc: { doctype: event.doctype, ...fields } },
+				onSuccess: handleSuccess(event),
+				onError: handleError(event),
+			}).submit()
 		}
-	})
+	} else if (event.action === "Run Script") {
+		return (...eventArgs: any[]) => {
+			codeStore.executeUserScript(event.script, repeaterContext?.value, componentContext?.value, eventArgs)
+		}
+	}
+}
 
+const mergedListeners = computed(() => {
+	const merged: ListenerMap = {}
+	for (const [name, listener] of Object.entries(vModelListeners.value)) {
+		addListener(merged, name, listener as Listener)
+	}
+	for (const [name, listener] of Object.entries(componentEvents.value)) {
+		const handlers = Array.isArray(listener) ? listener : [listener]
+		handlers.forEach((handler) => addListener(merged, name, handler))
+	}
 	return merged
 })
+
+function addListener(map: ListenerMap, name: string, listener: Listener) {
+	const existing = map[name]
+	if (!existing) {
+		map[name] = listener
+	} else if (Array.isArray(existing)) {
+		existing.push(listener)
+	} else {
+		map[name] = [existing, listener]
+	}
+}
 
 const handleSuccess = (event: any) => (data: DataResult) => {
 	if (event.on_success === "script" && event.on_success_script) {

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -149,8 +149,7 @@ import ItemActions from "@/components/ItemActions.vue"
 
 import { isObjectEmpty, confirm, getParamsArray, getParamsObj } from "@/utils/helpers"
 
-import type { SelectOption } from "@/types"
-import type { Actions, ActionConfigurations, ComponentEvent } from "@/types/ComponentEvent"
+import type { ActionConfigurations, ComponentEvent } from "@/types/ComponentEvent"
 import { Link } from "frappe-ui/frappe"
 import Grid from "@/components/Grid.vue"
 import Code from "@/components/Code.vue"
@@ -172,8 +171,6 @@ const showAddEventDialog = ref(false)
 const emptyEvent: ComponentEvent = {
 	event: "click",
 	action: "Run Script",
-	page: "",
-	url: "",
 	// call api
 	api_endpoint: "",
 	params: [],
@@ -359,46 +356,6 @@ const actions: ActionConfigurations = {
 			},
 		},
 	],
-	"Switch App Page": [
-		{
-			component: FormControl,
-			getProps: () => {
-				return {
-					type: "autocomplete",
-					options: Object.values(store.appPages || [])?.map((page) => {
-						return {
-							value: page.name,
-							label: page.page_title,
-						}
-					}),
-					label: "Page",
-					modelValue: newEvent.value.page,
-				}
-			},
-			events: {
-				"update:modelValue": (val: SelectOption) => {
-					newEvent.value.page = val.value
-				},
-			},
-		},
-	],
-	"Open Webpage": [
-		{
-			component: FormControl,
-			getProps: () => {
-				return {
-					type: "input",
-					label: "URL",
-					modelValue: newEvent.value.url,
-				}
-			},
-			events: {
-				"update:modelValue": (val: string) => {
-					newEvent.value.url = val
-				},
-			},
-		},
-	],
 }
 
 const actionControls = computed(() => {
@@ -449,12 +406,6 @@ function getEvent(event: ComponentEvent): ComponentEvent {
 		_event.doctype = event.doctype
 		_event.fields = event.fields
 		setEventCallbackFields(_event, event)
-	} else if (event.action === "Switch App Page") {
-		if (event.page) {
-			_event.page = store.getAppPageRoute(event.page)
-		}
-	} else if (event.action === "Open Webpage") {
-		_event.url = event.url
 	}
 
 	if (event.oldEvent) {

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -147,7 +147,7 @@ import Block from "@/utils/block"
 import EmptyState from "@/components/EmptyState.vue"
 import ItemActions from "@/components/ItemActions.vue"
 
-import { isObjectEmpty, confirm, getParamsArray, getParamsObj } from "@/utils/helpers"
+import { isObjectEmpty, confirm } from "@/utils/helpers"
 
 import type { ActionConfigurations, ComponentEvent } from "@/types/ComponentEvent"
 import { Link } from "frappe-ui/frappe"
@@ -165,15 +165,11 @@ const props = defineProps<{
 }>()
 const store = useStudioStore()
 const getEditorCompletions = useStudioCompletions(true)
-const getCompletions = useStudioCompletions()
 
 const showAddEventDialog = ref(false)
 const emptyEvent: ComponentEvent = {
 	event: "click",
 	action: "Run Script",
-	// call api
-	api_endpoint: "",
-	params: [],
 	// insert document
 	doctype: "",
 	fields: [],
@@ -272,48 +268,6 @@ const actions: ActionConfigurations = {
 			},
 		},
 	],
-	"Call API": [
-		{
-			component: FormControl,
-			getProps: () => {
-				return {
-					type: "input",
-					label: "API Endpoint",
-					modelValue: newEvent.value.api_endpoint,
-					autocomplete: "off",
-				}
-			},
-			events: {
-				"update:modelValue": (val: string) => {
-					newEvent.value.api_endpoint = val
-				},
-			},
-		},
-		{
-			component: Grid,
-			getProps: () => {
-				return {
-					label: "Parameters",
-					columns: [
-						{ label: "Key", fieldname: "key", fieldtype: "Data" },
-						{
-							label: "Value",
-							fieldname: "value",
-							fieldtype: "Code",
-							completions: getCompletions,
-						},
-					],
-					rows: newEvent.value.params || [],
-					showDeleteBtn: true,
-				}
-			},
-			events: {
-				"update:rows": (val: any) => {
-					newEvent.value.params = val
-				},
-			},
-		},
-	],
 	"Insert a Document": [
 		{
 			component: Link,
@@ -363,10 +317,7 @@ const actionControls = computed(() => {
 })
 
 const showSuccessFailureOptions = computed(() => {
-	return (
-		(newEvent.value.action === "Insert a Document" && newEvent.value.doctype) ||
-		newEvent.value.action === "Call API"
-	)
+	return newEvent.value.action === "Insert a Document" && newEvent.value.doctype
 })
 
 function getFnBoilerplate(event: "success" | "error") {
@@ -396,12 +347,6 @@ function getEvent(event: ComponentEvent): ComponentEvent {
 	}
 	if (event.action === "Run Script") {
 		_event.script = event.script || ""
-	} else if (event.action === "Call API") {
-		_event.api_endpoint = event.api_endpoint
-		setEventCallbackFields(_event, event)
-		if (Array.isArray(event.params)) {
-			_event.params = getParamsObj(event.params)
-		}
 	} else if (event.action === "Insert a Document") {
 		_event.doctype = event.doctype
 		_event.fields = event.fields
@@ -455,7 +400,6 @@ const openEvent = (event: ComponentEvent) => {
 		...event,
 		isEditing: true,
 		oldEvent: event.event,
-		params: getParamsArray(event.params),
 	}
 	showAddEventDialog.value = true
 }

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -31,7 +31,14 @@
 			>
 				<template #default>
 					<div class="flex flex-col gap-3">
-						<FormControl type="combobox" :options="eventOptions" label="Event" v-model="newEvent.event" />
+						<FormControl
+							type="combobox"
+							:options="eventOptions"
+							:allowCustomValue="true"
+							label="Event"
+							v-model="newEvent.event"
+							description="Type any event, optionally with modifiers — e.g. keydown.enter, click.prevent, submit.prevent.stop"
+						/>
 						<FormControl
 							type="combobox"
 							:options="Object.keys(actions)"

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -303,7 +303,7 @@ const actions: ActionConfigurations = {
 							label: "Variable",
 							fieldname: "value",
 							fieldtype: "select",
-							options: store.variableOptions,
+							options: [...store.variableOptions, ...store.pageScriptBindingOptions],
 						},
 					],
 					rows: newEvent.value.fields,

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -31,20 +31,14 @@
 			>
 				<template #default>
 					<div class="flex flex-col gap-3">
-						<FormControl
-							type="combobox"
+						<Combobox
 							:options="eventOptions"
 							:allowCustomValue="true"
 							label="Event"
 							v-model="newEvent.event"
 							description="Type any event, optionally with modifiers — e.g. keydown.enter, click.prevent, submit.prevent.stop"
 						/>
-						<FormControl
-							type="combobox"
-							:options="Object.keys(actions)"
-							label="Action"
-							v-model="newEvent.action"
-						/>
+						<Combobox :options="Object.keys(actions)" label="Action" v-model="newEvent.action" />
 						<component
 							v-for="control in actionControls"
 							:key="control.component.name"
@@ -148,7 +142,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from "vue"
-import { FormControl, createResource, Dialog, TabButtons } from "frappe-ui"
+import { Combobox, FormControl, createResource, Dialog, TabButtons } from "frappe-ui"
 import useStudioStore from "@/stores/studioStore"
 import Block from "@/utils/block"
 import EmptyState from "@/components/EmptyState.vue"
@@ -257,6 +251,7 @@ const actions: ActionConfigurations = {
 			getProps: () => {
 				return {
 					label: "Script",
+					isFormInput: true,
 					language: "javascript",
 					modelValue: newEvent.value.script,
 					height: "400px",

--- a/frontend/src/components/Filters.vue
+++ b/frontend/src/components/Filters.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col gap-1.5">
-		<span v-if="label" class="block text-xs text-ink-gray-5">{{ label }}</span>
+		<FormInputLabel v-if="label">{{ label }}</FormInputLabel>
 		<div class="rounded-lg border border-outline-elevation-2 bg-surface-base">
 			<div class="min-w-[400px] p-2">
 				<div
@@ -83,6 +83,7 @@ import { Combobox, FeatherIcon, FormControl } from "frappe-ui"
 import { computed, h, ref, watch } from "vue"
 import { Link } from "frappe-ui/frappe"
 
+import FormInputLabel from "@/components/FormInputLabel.vue"
 import type { DocTypeField, Fieldtype, Filter, Operators } from "@/types"
 import { isObjectEmpty } from "@/utils/helpers"
 import type { Filters } from "@/types/Studio/StudioResource"

--- a/frontend/src/components/Grid.vue
+++ b/frontend/src/components/Grid.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col">
-		<div v-if="label" class="mb-1.5 text-xs text-ink-gray-5">{{ label }}</div>
+		<FormInputLabel v-if="label" :label="label">{{ label }}</FormInputLabel>
 
 		<div class="rounded border border-gray-100">
 			<!-- Header -->
@@ -104,6 +104,7 @@ import Draggable from "vuedraggable"
 
 import { Link } from "frappe-ui/frappe"
 import { generateId } from "@/utils/helpers"
+import FormInputLabel from "@/components/FormInputLabel.vue"
 import type { GridColumn, GridRow } from "@/types/doctype"
 
 const props = defineProps<{

--- a/frontend/src/components/PageScript.vue
+++ b/frontend/src/components/PageScript.vue
@@ -65,7 +65,7 @@ import useStudioStore from "@/stores/studioStore"
 
 const store = useStudioStore()
 const codeStore = useCodeStore()
-const getCompletions = useStudioCompletions(true)
+const getCompletions = useStudioCompletions(true, true)
 
 const activePage = computed(() => store.activePage)
 

--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -6,7 +6,7 @@
 		@after-leave="reset"
 	>
 		<template #default>
-			<div class="flex flex-col space-y-4">
+			<div class="flex flex-col gap-4">
 				<FormControl
 					label="Data Source Name"
 					:required="true"
@@ -121,13 +121,11 @@
 						v-model="newResource.document_name"
 					/>
 
-					<div class="mt-5">
-						<Checkbox
-							size="sm"
-							v-model="newResource.fetch_document_using_filters"
-							label="Dynamically fetch document using filters"
-						/>
-					</div>
+					<Checkbox
+						size="sm"
+						v-model="newResource.fetch_document_using_filters"
+						label="Dynamically fetch document using filters"
+					/>
 
 					<Filters
 						v-if="newResource.fetch_document_using_filters"
@@ -144,9 +142,7 @@
 					/>
 				</template>
 
-				<div class="mt-5">
-					<Checkbox size="sm" label="Auto fetch data on load" v-model="newResource.auto" />
-				</div>
+				<Checkbox size="sm" label="Auto fetch data on load" v-model="newResource.auto" />
 
 				<!-- Transform Results for any Resource Type -->
 				<ScriptSection
@@ -204,7 +200,6 @@ import { computed, ref, watch } from "vue"
 import { createResource, Dialog, FormControl, Checkbox } from "frappe-ui"
 import { Link } from "frappe-ui/frappe"
 import ScriptSection from "@/components/ScriptSection.vue"
-import InputLabel from "@/components/InputLabel.vue"
 import Filters from "@/components/Filters.vue"
 import Grid from "@/components/Grid.vue"
 

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -231,7 +231,7 @@ function selectBlock(block: Block, e: MouseEvent | null, multiSelect = false, se
 		setActiveBreakpoint(breakpoint)
 	}
 
-	if (block.isText() || block.isContainer()) {
+	if (block.isRoot() || block.isText() || block.isContainer()) {
 		// combined props and styles
 		store.studioLayout.rightPanelActiveTab = "Styles"
 	} else {

--- a/frontend/src/components/StudioRightPanel.vue
+++ b/frontend/src/components/StudioRightPanel.vue
@@ -93,7 +93,9 @@ const canvasStore = useCanvasStore()
 const activeTab = computed(() => store.studioLayout.rightPanelActiveTab)
 
 const showInterfaceTab = computed(() => canvasStore.editingMode === "component")
-const combinePropsAndStylesTab = computed(() => blockController.isText() || blockController.isContainer())
+const combinePropsAndStylesTab = computed(
+	() => blockController.isRoot() || blockController.isText() || blockController.isContainer(),
+)
 const tabs = computed(() => {
 	let _tabs = showInterfaceTab.value
 		? ["Interface", "Properties", "Styles", "Events"]

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -155,7 +155,7 @@ const useCodeStore = defineStore("codeStore", () => {
 			// be async (e.g. awaiting a resource fetch). Effects (watch/computed) created BEFORE the
 			// first await are owned by the page scope; declare them before awaiting so they're
 			// disposed on navigation.
-			const bindings = runInPageScriptScope(() => (setup as Function)(globalExecutionContext.value))
+			const bindings = runInPageScriptScope(() => (setup as Function)(scriptContext.value))
 			return (await bindings) || {}
 		} catch (error) {
 			reportPageScriptError(error)
@@ -204,10 +204,10 @@ const useCodeStore = defineStore("codeStore", () => {
 				has(_target, key) {
 					// let globals (console, Function, …) fall through to the outer scope
 					if (key === Symbol.unscopables) return false
-					return key in globalExecutionContext.value
+					return key in interpretedScriptContext.value
 				},
 				get(_target, key) {
-					return (globalExecutionContext.value as Record<string | symbol, any>)[key]
+					return (interpretedScriptContext.value as Record<string | symbol, any>)[key]
 				},
 			},
 		)
@@ -223,7 +223,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		}) || {}
 	}
 
-	const globalContext = computed(() => {
+	const evalContext = computed(() => {
 		return {
 			...variables.value,
 			...resources.value,
@@ -234,12 +234,10 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	})
 
-	const globalExecutionContext = computed(() => {
-		// Script context: variables and page-script bindings are passed as refs so scripts can
-		// read/write `.value`, and the Vue reactivity APIs are available for `<script setup>` code.
+	// Base context for every script scope — event/success/error handlers, function-value props, and page-script setup.
+	const scriptContext = computed(() => {
 		const variablesRefs = toRefs(variables.value)
 		return {
-			...vueReactivityApis,
 			...variablesRefs,
 			...resources.value,
 			...pageScriptBindings.value,
@@ -249,11 +247,19 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	})
 
+	// for non-standard pages: scriptContext + vueReactivityApis since it can't import them
+	const interpretedScriptContext = computed(() => {
+		return {
+			...vueReactivityApis,
+			...scriptContext.value,
+		}
+	})
+
 	function getDynamicValue(value: string, localContext: ExpressionEvaluationContext) {
 		let result = ""
 		let lastIndex = 0
 
-		const context = { ...globalContext.value, ...localContext }
+		const context = { ...evalContext.value, ...localContext }
 
 		if (!isDynamicValue(value)) {
 			return evaluateExpression(value, context)
@@ -324,7 +330,7 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	function evaluateExpression(expression: string, localContext: ExpressionEvaluationContext) {
 		try {
-			const context = { ...globalContext.value, ...localContext }
+			const context = { ...evalContext.value, ...localContext }
 			// Replace dot notation with optional chaining via AST
 			const safeExpression = toOptionalChaining(expression)
 
@@ -353,7 +359,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		eventArgs?: any[],
 	) {
 		try {
-			const context = { ...globalExecutionContext.value, ...repeaterContext, ...componentContext, eventArgs }
+			const context = { ...scriptContext.value, ...repeaterContext, ...componentContext, eventArgs }
 
 			const scriptToExecute = `
 				with (context) {
@@ -379,7 +385,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	) {
 		try {
 			const context = {
-				...globalExecutionContext.value,
+				...scriptContext.value,
 				...repeaterContext,
 				...componentContext,
 				eventArgs,
@@ -408,7 +414,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	) {
 		try {
 			const context = {
-				...globalExecutionContext.value,
+				...scriptContext.value,
 				...repeaterContext,
 				...componentContext,
 				eventArgs,
@@ -583,11 +589,11 @@ const useCodeStore = defineStore("codeStore", () => {
 			const fn = new Function(
 				"h",
 				...Object.keys(registeredComponents),
-				...Object.keys(globalExecutionContext.value),
+				...Object.keys(scriptContext.value),
 				...Object.keys(localContext),
 				`return (${value})`
 			)
-			return fn(h, ...Object.values(registeredComponents), ...Object.values(globalExecutionContext.value), ...Object.values(localContext))
+			return fn(h, ...Object.values(registeredComponents), ...Object.values(scriptContext.value), ...Object.values(localContext))
 		} catch (e) {
 			return value
 		}
@@ -613,8 +619,9 @@ const useCodeStore = defineStore("codeStore", () => {
 		setPageScript,
 		applyPageScriptHMR,
 		// code execution
-		globalContext,
-		globalExecutionContext,
+		evalContext,
+		scriptContext,
+		interpretedScriptContext,
 		getDynamicValue,
 		evaluateDynamicValues,
 		executeUserScript,

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -506,6 +506,14 @@ const useStudioStore = defineStore("store", () => {
 		return options
 	})
 
+	const pageScriptBindingOptions = computed<VariableOption[]>(() => {
+		return Object.entries(codeStore.pageScriptTemplateBindings).map(([key, value]) => ({
+			value: key,
+			label: key,
+			type: typeof value,
+		}))
+	})
+
 	return {
 		// layout
 		studioLayout,
@@ -557,6 +565,7 @@ const useStudioStore = defineStore("store", () => {
 		variableConfigs,
 		setPageData,
 		variableOptions,
+		pageScriptBindingOptions,
 	}
 })
 

--- a/frontend/src/types/ComponentEvent.ts
+++ b/frontend/src/types/ComponentEvent.ts
@@ -2,7 +2,7 @@ import type { Component } from "vue"
 
 export type Events = 'click' | 'change' | 'focus' | 'blur' | 'submit' | 'keydown' | 'keyup' | 'keypress'
 
-export type Actions = 'Call API' | 'Insert a Document' | 'Run Script'
+export type Actions = 'Insert a Document' | 'Run Script'
 
 export type Field = {
 	field: string
@@ -13,18 +13,15 @@ export type Field = {
 export type ComponentEvent = {
 	event: Events | string
 	action: Actions
-	/** action = 'Call API */
-	api_endpoint?: string
-	params?: Record<string, any>
 	/** action = 'Insert a Document' */
 	doctype?: string
 	fields?: Array<Field>
-	// on success for 'Call API' and 'Insert a Document'
+	// on success for 'Insert a Document'
 	on_success?: "message" | "script",
 	success_message?: string
 	on_success_script?: string,
 	on_error?: "message" | "script",
-	// on error for 'Call API' and 'Insert a Document'
+	// on error for 'Insert a Document'
 	error_message?: string,
 	on_error_script?: string,
 	/** action = 'Run Script' */

--- a/frontend/src/types/ComponentEvent.ts
+++ b/frontend/src/types/ComponentEvent.ts
@@ -2,7 +2,7 @@ import type { Component } from "vue"
 
 export type Events = 'click' | 'change' | 'focus' | 'blur' | 'submit' | 'keydown' | 'keyup' | 'keypress'
 
-export type Actions = 'Call API' | 'Switch App Page' | 'Open Webpage' | 'Insert a Document' | 'Run Script'
+export type Actions = 'Call API' | 'Insert a Document' | 'Run Script'
 
 export type Field = {
 	field: string
@@ -16,10 +16,6 @@ export type ComponentEvent = {
 	/** action = 'Call API */
 	api_endpoint?: string
 	params?: Record<string, any>
-	/** action = 'Switch App Page */
-	page?: string
-	/** action = 'Open Webpage' */
-	url?: string
 	/** action = 'Insert a Document' */
 	doctype?: string
 	fields?: Array<Field>

--- a/frontend/src/utils/eventModifiers.ts
+++ b/frontend/src/utils/eventModifiers.ts
@@ -18,8 +18,13 @@ const SYSTEM_MODIFIERS = ["stop", "prevent", "self", "exact", "ctrl", "shift", "
  * not run for listeners bound dynamically through `v-on="object"`, so we reproduce
  * it here. Key modifiers go through `withKeys`, the rest through `withModifiers`.
  */
-export function resolveEventListener(rawName: string, handler: EventHandler, emits: string[] = []): ResolvedEvent {
-	if (emits.includes(rawName)) return { name: rawName, listener: handler }
+export function resolveEventListener(
+	rawName: string,
+	handler: EventHandler,
+	emits: string[] | Record<string, any> = [],
+): ResolvedEvent {
+	const emitNames = Array.isArray(emits) ? emits : Object.keys(emits)
+	if (emitNames.includes(rawName)) return { name: rawName, listener: handler }
 
 	const [name, ...modifiers] = rawName.split(".")
 	if (!modifiers.length) return { name, listener: handler }

--- a/frontend/src/utils/eventModifiers.ts
+++ b/frontend/src/utils/eventModifiers.ts
@@ -1,0 +1,44 @@
+import { withKeys, withModifiers } from "vue"
+
+type EventHandler = (...args: any[]) => any
+
+export interface ResolvedEvent {
+	name: string
+	listener: EventHandler
+}
+
+// Guard modifiers handled by Vue's `withModifiers` (event-level behaviour).
+const SYSTEM_MODIFIERS = ["stop", "prevent", "self", "exact", "ctrl", "shift", "alt", "meta", "left", "middle", "right"]
+
+/**
+ * Parse a Vue-style event name with modifiers (e.g. "keydown.enter", "click.prevent")
+ * into a base event name and a handler wrapped with the matching guards.
+ *
+ * The template compiler normally applies this `@event.modifier` sugar, but it does
+ * not run for listeners bound dynamically through `v-on="object"`, so we reproduce
+ * it here. Key modifiers go through `withKeys`, the rest through `withModifiers`.
+ */
+export function resolveEventListener(rawName: string, handler: EventHandler): ResolvedEvent {
+	const [name, ...modifiers] = rawName.split(".")
+	if (!modifiers.length) return { name, listener: handler }
+
+	const isKeyboardEvent = name.startsWith("key")
+	const guards: string[] = []
+	const keys: string[] = []
+
+	for (const modifier of modifiers) {
+		if (!modifier) continue
+		// `left` / `right` are arrow keys on keyboard events but mouse buttons elsewhere
+		const isAmbiguous = modifier === "left" || modifier === "right"
+		if (SYSTEM_MODIFIERS.includes(modifier) && !(isKeyboardEvent && isAmbiguous)) {
+			guards.push(modifier)
+		} else {
+			keys.push(modifier)
+		}
+	}
+
+	let listener = handler
+	if (guards.length) listener = withModifiers(listener, guards as any)
+	if (keys.length) listener = withKeys(listener, keys)
+	return { name, listener }
+}

--- a/frontend/src/utils/eventModifiers.ts
+++ b/frontend/src/utils/eventModifiers.ts
@@ -18,7 +18,9 @@ const SYSTEM_MODIFIERS = ["stop", "prevent", "self", "exact", "ctrl", "shift", "
  * not run for listeners bound dynamically through `v-on="object"`, so we reproduce
  * it here. Key modifiers go through `withKeys`, the rest through `withModifiers`.
  */
-export function resolveEventListener(rawName: string, handler: EventHandler): ResolvedEvent {
+export function resolveEventListener(rawName: string, handler: EventHandler, emits: string[] = []): ResolvedEvent {
+	if (emits.includes(rawName)) return { name: rawName, listener: handler }
+
 	const [name, ...modifiers] = rawName.split(".")
 	if (!modifiers.length) return { name, listener: handler }
 

--- a/frontend/src/utils/pageScriptCompletions.ts
+++ b/frontend/src/utils/pageScriptCompletions.ts
@@ -5,7 +5,7 @@ import type { CompletionSource } from "@/types"
 import { getCompletions } from "./autocompletions"
 import { vueImportCompletions } from "./vueApiCompletions"
 
-// A code-mode page script's `setup(context)` param holds the page's runtime context. Treat that
+// An ES module/standard app's page script's `setup(context)` param holds the page's runtime context. Treat that
 // param as a single object whose members are the page's data sources, variables, route and router,
 // then reuse the event-script completion engine — it reads nested objects straight off the live
 // values, so `context.todos.data` completes the same way `todos.data` does in an event script.

--- a/frontend/src/utils/useStudioCompletions.ts
+++ b/frontend/src/utils/useStudioCompletions.ts
@@ -8,7 +8,7 @@ import { vueApiSources } from "./vueApiCompletions"
 import type { CompletionContext } from "@codemirror/autocomplete"
 import * as globalUtils from "@/utils/globalUtils"
 
-export const useStudioCompletions = (canEditValues: boolean = false) => {
+export const useStudioCompletions = (canEditValues: boolean = false, includeVueApis: boolean = false) => {
 	const codeStore = useCodeStore()
 
 	const completionSources = computed(() => {
@@ -136,7 +136,11 @@ export const useStudioCompletions = (canEditValues: boolean = false) => {
 			})
 		})
 
-		sources.push(...vueApiSources())
+		// Only the interpreted page script has the Vue reactivity APIs injected into its scope; other
+		// editors (event/callback/transform handlers, dynamic-value expressions) don't.
+		if (includeVueApis) {
+			sources.push(...vueApiSources())
+		}
 
 		return sources
 	})

--- a/frontend/src/utils/vueApiCompletions.ts
+++ b/frontend/src/utils/vueApiCompletions.ts
@@ -9,7 +9,7 @@ import { vueReactivityApis } from "@/stores/codeStore"
 // suggest (and auto-import) in code files.
 const VUE_API_NAMES = Object.keys(vueReactivityApis)
 
-// Interpreted page/event scripts: the APIs are injected globally, so completion just inserts a call.
+// Interpreted page script: the APIs are injected into its scope, so completion just inserts a call.
 export function vueApiSources(): CompletionSource[] {
 	return VUE_API_NAMES.map((name) => ({
 		item: undefined,

--- a/studio/patches.txt
+++ b/studio/patches.txt
@@ -14,3 +14,4 @@ studio.studio.doctype.studio_page.patches.migrate_dialog_to_frappe_ui_v1
 studio.studio.doctype.studio_page.patches.migrate_watchers_to_page_script
 studio.studio.doctype.studio_page.patches.migrate_espresso_color_tokens_v2
 studio.studio.doctype.studio_page.patches.migrate_text_size_tokens_v2
+studio.studio.doctype.studio_page.patches.migrate_event_actions_to_script

--- a/studio/studio/doctype/studio_page/patches/migrate_event_actions_to_script.py
+++ b/studio/studio/doctype/studio_page/patches/migrate_event_actions_to_script.py
@@ -1,13 +1,14 @@
 import json
+import re
 
 import frappe
 
 
 def execute():
-	"""Migrate the removed "Switch App Page" and "Open Webpage" event actions to "Run Script".
+	"""Migrate the removed "Switch App Page", "Open Webpage" and "Call API" event actions to "Run Script".
 
 	These built-in actions were dropped in favour of scripts, so existing events are
-	rewritten to equivalent router.push / window.open calls.
+	rewritten to equivalent router.push / window.open / call() calls.
 	"""
 	Page = frappe.qb.DocType("Studio Page")
 	pages = (
@@ -18,6 +19,8 @@ def execute():
 			| Page.draft_blocks.like("%Switch App Page%")
 			| Page.blocks.like("%Open Webpage%")
 			| Page.draft_blocks.like("%Open Webpage%")
+			| Page.blocks.like("%Call API%")
+			| Page.draft_blocks.like("%Call API%")
 		)
 		.run(as_dict=True)
 	)
@@ -63,12 +66,89 @@ def migrate_event(event):
 	action = event.get("action")
 	if action == "Switch App Page":
 		event["script"] = f"router.push({json.dumps(event.get('page') or '')})"
+		stale_fields = ("page",)
 	elif action == "Open Webpage":
 		event["script"] = f"window.open({json.dumps(event.get('url') or '')})"
+		stale_fields = ("url",)
+	elif action == "Call API":
+		event["script"] = build_call_script(event)
+		# success/error callbacks are now inlined into the script; these fields are
+		# Call-API-specific here and must not be touched for "Insert a Document" events
+		stale_fields = (
+			"api_endpoint",
+			"params",
+			"on_success",
+			"success_message",
+			"on_success_script",
+			"on_error",
+			"error_message",
+			"on_error_script",
+		)
 	else:
 		return False
 
 	event["action"] = "Run Script"
-	event.pop("page", None)
-	event.pop("url", None)
+	for field in stale_fields:
+		event.pop(field, None)
 	return True
+
+
+def build_call_script(event):
+	"""Rebuild a Call API event as a call() script with its success/error callbacks.
+
+	Note: the old runtime had a shortcut where an endpoint matching a registered
+	resource called `resource.submit()` instead of issuing a fresh request. That path
+	is not reproduced here; every Call API event becomes a plain `call(endpoint, params)`,
+	which matches the common (non-resource) behaviour.
+	"""
+	args = json.dumps(event.get("api_endpoint") or "")
+	params = event.get("params") or {}
+	if params:
+		args += f", {params_to_object_literal(params)}"
+
+	script = f"call({args})"
+	if success := callback_body(event, "success"):
+		script += f"\n\t.then((data) => {{\n\t\t{success}\n\t}})"
+	if error := callback_body(event, "error"):
+		script += f"\n\t.catch((error) => {{\n\t\t{error}\n\t}})"
+	return script
+
+
+def callback_body(event, kind):
+	arg, fn = ("data", "onSuccess") if kind == "success" else ("error", "onError")
+	if event.get(f"on_{kind}") == "script" and event.get(f"on_{kind}_script"):
+		return f"{event[f'on_{kind}_script']}\n\t\treturn {fn}({arg});"
+
+	message = event.get("success_message" if kind == "success" else "error_message")
+	if message:
+		toast_fn = "toast.success" if kind == "success" else "toast.error"
+		return f"{toast_fn}({json.dumps(message)});"
+	return None
+
+
+def params_to_object_literal(params):
+	entries = ", ".join(
+		f"{json.dumps(key)}: {value_to_js_expression(value)}" for key, value in params.items()
+	)
+	return f"{{ {entries} }}"
+
+
+SINGLE_EXPRESSION = re.compile(r"^\s*\{\{(.+?)\}\}\s*$", re.DOTALL)
+EMBEDDED_EXPRESSION = re.compile(r"\{\{(.+?)\}\}")
+
+
+def value_to_js_expression(value):
+	"""Convert a stored param value (literal or {{ }} template) to a JS expression."""
+	if not isinstance(value, str):
+		return json.dumps(value)
+
+	single = SINGLE_EXPRESSION.match(value)
+	if single:
+		return single.group(1).strip()
+
+	if EMBEDDED_EXPRESSION.search(value):
+		template = value.replace("`", "\\`")
+		template = EMBEDDED_EXPRESSION.sub(lambda m: "${" + m.group(1).strip() + "}", template)
+		return f"`{template}`"
+
+	return json.dumps(value)

--- a/studio/studio/doctype/studio_page/patches/migrate_event_actions_to_script.py
+++ b/studio/studio/doctype/studio_page/patches/migrate_event_actions_to_script.py
@@ -1,0 +1,74 @@
+import json
+
+import frappe
+
+
+def execute():
+	"""Migrate the removed "Switch App Page" and "Open Webpage" event actions to "Run Script".
+
+	These built-in actions were dropped in favour of scripts, so existing events are
+	rewritten to equivalent router.push / window.open calls.
+	"""
+	Page = frappe.qb.DocType("Studio Page")
+	pages = (
+		frappe.qb.from_(Page)
+		.select(Page.name, Page.blocks, Page.draft_blocks)
+		.where(
+			Page.blocks.like("%Switch App Page%")
+			| Page.draft_blocks.like("%Switch App Page%")
+			| Page.blocks.like("%Open Webpage%")
+			| Page.draft_blocks.like("%Open Webpage%")
+		)
+		.run(as_dict=True)
+	)
+
+	for page in {p.name: p for p in pages}.values():
+		updates = {}
+		for field in ("blocks", "draft_blocks"):
+			blocks = frappe.parse_json(page.get(field) or "[]")
+			if blocks and migrate_blocks(blocks):
+				updates[field] = frappe.as_json(blocks)
+		if updates:
+			frappe.get_doc("Studio Page", page.name).update(updates).save()
+
+	components = frappe.get_all("Studio Component", fields=["name", "block"])
+	for component in components:
+		if not component.get("block"):
+			continue
+		block = frappe.parse_json(component.get("block"))
+		if migrate_blocks([block]):
+			frappe.get_doc("Studio Component", component.name).update({"block": frappe.as_json(block)}).save()
+
+
+def migrate_blocks(blocks):
+	"""Recursively rewrite legacy event actions. Returns True if anything changed."""
+	changed = False
+	for block in blocks:
+		for event in (block.get("componentEvents") or {}).values():
+			if migrate_event(event):
+				changed = True
+
+		if block.get("children"):
+			changed = migrate_blocks(block["children"]) or changed
+
+		for slot in (block.get("componentSlots") or {}).values():
+			content = slot.get("slotContent") if slot else None
+			if isinstance(content, list):
+				changed = migrate_blocks(content) or changed
+
+	return changed
+
+
+def migrate_event(event):
+	action = event.get("action")
+	if action == "Switch App Page":
+		event["script"] = f"router.push({json.dumps(event.get('page') or '')})"
+	elif action == "Open Webpage":
+		event["script"] = f"window.open({json.dumps(event.get('url') or '')})"
+	else:
+		return False
+
+	event["action"] = "Run Script"
+	event.pop("page", None)
+	event.pop("url", None)
+	return True


### PR DESCRIPTION
## Add any event listener + support event modifiers

Before this, you could only attach event listeners for some specific events: 'click' | 'change' | 'focus' | 'blur' | 'submit' | 'keydown' | 'keyup' | 'keypress' + emits from the component

<img width="1262" height="1116" alt="image" src="https://github.com/user-attachments/assets/22b5693c-b14e-44ad-aac7-ed9599b85be8" />

You can now type any event here that's not listed and also add [Event Modifiers](https://vuejs.org/guide/essentials/event-handling.html#event-modifiers) to it

https://github.com/user-attachments/assets/e9d3fba2-2114-4124-b5ed-0bf56b48f8bb

## Reduce event action options [BREAKING]

Removed 'Switch App Page', 'Open WebPage', 'Call API' event actions in favour of 'Script'. Added a patch for the same. Might need reviewing.
Retained 'Insert a Document' helper because it can help fetch and map fields that could be helpful. 

## Expose direct Vue reactivity APIs in interpreted/custom page scripts only

After https://github.com/frappe/studio/pull/182 the global execution context always had access to ref, reactive, watcher, computed, etc. This is only needed in custom/non-exported pages because they can't import these APIs. 

Also, event/success/error/function-prop scripts run via bare new Function outside pageScriptScope. There's no active effect scope, so any watch/watchEffect/computed/watchDebounced created there is orphaned - never disposed, leaking effects that keep firing across navigations. And ref/reactive/shallowRef created in a one-shot handler is simply pointless (discarded when it returns).

So, only exposed them in interpreted page scripts. Also fixed autocompletions to respect this.

## Fixes
- Variable selector in Insert Document now shows pageScriptBindings too
- Skip showing the Properties panel for body
- Label inconsistencies after frappe-ui upgrade