### PR TITLE
feat: Select & edit multiple blocks

### DIFF
--- a/frontend/src/components/ArrayInput.vue
+++ b/frontend/src/components/ArrayInput.vue
@@ -46,7 +46,7 @@
 				</div>
 			</div>
 		</template>
-		<EmptyState v-else message="No items added" />
+		<EmptyState v-else :message="emptyMessage || 'No items added'" />
 
 		<Button variant="outline" class="w-full" icon-left="plus" @click="addItem">Add</Button>
 	</div>
@@ -65,6 +65,7 @@ const props = defineProps<{
 	label?: string
 	itemTypes?: Record<string, any>
 	required?: boolean
+	emptyMessage?: string
 }>()
 
 const emit = defineEmits(["update:modelValue"])

--- a/frontend/src/components/Code.vue
+++ b/frontend/src/components/Code.vue
@@ -54,7 +54,7 @@ import {
 } from "@codemirror/autocomplete"
 import { Compartment, Extension } from "@codemirror/state"
 import { indentService, indentUnit, LRLanguage } from "@codemirror/language"
-import { EditorView, keymap } from "@codemirror/view"
+import { EditorView, keymap, placeholder as placeholderExtension } from "@codemirror/view"
 import { indentMore, indentLess } from "@codemirror/commands"
 import { indentationMarkers } from "@replit/codemirror-indentation-markers"
 import { tomorrow } from "thememirror"
@@ -78,6 +78,7 @@ const props = withDefaults(
 		completions?: Function | null
 		label?: string
 		description?: string
+		placeholder?: string
 		required?: boolean
 		readonly?: boolean
 		borderless?: boolean
@@ -260,6 +261,7 @@ const extensions = computed(() => {
 			},
 		}),
 		keymap.of([{ key: "Tab", run: indentMore, shift: indentLess }]),
+		props.placeholder ? placeholderExtension(props.placeholder) : [],
 	]
 	if (!props.readonly) {
 		baseExtensions.push(

--- a/frontend/src/components/ComponentEvents.vue
+++ b/frontend/src/components/ComponentEvents.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col">
-		<div v-if="block" class="flex flex-col gap-3">
+		<div v-if="block && !multipleBlocksSelected" class="flex flex-col gap-3">
 			<div class="flex w-full flex-col space-y-1" v-if="!isObjectEmpty(block?.componentEvents)">
 				<div
 					v-for="(event, name) in block?.componentEvents"
@@ -136,7 +136,12 @@
 			</Dialog>
 		</div>
 
-		<EmptyState v-else message="Select a block to edit events" />
+		<EmptyState
+			v-else
+			:message="
+				multipleBlocksSelected ? 'Select a single block to edit events' : 'Select a block to edit events'
+			"
+		/>
 	</div>
 </template>
 
@@ -147,6 +152,7 @@ import useStudioStore from "@/stores/studioStore"
 import Block from "@/utils/block"
 import EmptyState from "@/components/EmptyState.vue"
 import ItemActions from "@/components/ItemActions.vue"
+import blockController from "@/utils/blockController"
 
 import { isObjectEmpty, confirm } from "@/utils/helpers"
 
@@ -166,6 +172,7 @@ const props = defineProps<{
 }>()
 const store = useStudioStore()
 const getEditorCompletions = useStudioCompletions(true)
+const multipleBlocksSelected = computed(() => blockController.multipleBlocksSelected())
 
 const showAddEventDialog = ref(false)
 const emptyEvent: ComponentEvent = {

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -270,7 +270,7 @@ const openBlockEditor = (block: Block, e: MouseEvent) => {
 			`Save ${block.componentName}`,
 		)
 	} else {
-		canvasStore.activeCanvas?.selectBlock(block, e, false, false)
+		canvasStore.activeCanvas?.selectBlock(block, e, false)
 	}
 }
 

--- a/frontend/src/components/ComponentProperties.vue
+++ b/frontend/src/components/ComponentProperties.vue
@@ -1,14 +1,15 @@
 <template>
 	<div class="flex select-none flex-col pb-16" v-show="filteredSections?.length">
-		<EmptyState v-if="!block?.componentName || block?.isRoot()" message="Select a block to edit properties" />
+		<EmptyState v-if="mixedTypeSelection" message="Select blocks of the same component to edit properties" />
+		<EmptyState v-else-if="!block?.componentName" message="Select a block to edit properties" />
 		<div v-else class="flex flex-col gap-3">
 			<!-- props -->
 			<SectionContainer title="Props" v-show="filteredSections.includes('props')">
-				<PropsEditor ref="propsEditor" :block="block" />
+				<PropsEditor ref="propsEditor" :block="block" :multiEdit="multipleBlocksSelected" />
 			</SectionContainer>
 
 			<!-- slots -->
-			<SectionContainer title="Slots" v-show="filteredSections.includes('slots')">
+			<SectionContainer title="Slots" v-show="filteredSections.includes('slots') && !multipleBlocksSelected">
 				<template #actions>
 					<Combobox
 						:options="availableSlots"
@@ -119,6 +120,11 @@ const props = defineProps<{
 }>()
 const getCompletions = useStudioCompletions()
 const studioStore = useStudioStore()
+
+const multipleBlocksSelected = computed(() => blockController.multipleBlocksSelected())
+const mixedTypeSelection = computed(
+	() => multipleBlocksSelected.value && !blockController.selectedBlocksHaveSameType(),
+)
 
 const attributesEditor = ref<InstanceType<typeof ObjectEditor> | null>(null)
 const propsEditor = ref<InstanceType<typeof PropsEditor> | null>(null)

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -85,6 +85,7 @@
 				:options="config.options"
 				:required="config.required"
 				:modelValue="getFormattedValue(propName)"
+				:placeholder="isMixed(propName) ? 'Mixed' : undefined"
 				@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 				class="flex-1"
 				v-bind="config.props"
@@ -108,6 +109,7 @@ import useComponentStore from "@/stores/componentStore"
 import { getComponentProps } from "@/utils/components"
 import { isDynamicValue } from "@/utils/code"
 import useCanvasStore from "@/stores/canvasStore"
+import blockController from "@/utils/blockController"
 import useComponentEditorStore from "@/stores/componentEditorStore"
 import type { ComponentProps } from "@/types"
 import { ComponentInput } from "@/types/Studio/StudioComponent"
@@ -118,6 +120,7 @@ import useComponentInstance from "@/utils/useComponentInstance"
 const props = defineProps<{
 	block?: Block
 	isTestingComponent?: boolean
+	multiEdit?: boolean
 }>()
 
 const getCompletions = useStudioCompletions()
@@ -220,16 +223,32 @@ const isCodeField = (inputType: string) => {
 	return ["code", "html", "array"].includes(inputType)
 }
 
-function setDynamicValue(propName: string, varName: string, bindVariable: boolean) {
-	if (bindVariable) {
-		props.block?.setProp(propName, { $type: "variable", name: varName })
+function setProp(propName: string, value: any) {
+	if (props.multiEdit) {
+		blockController.setProp(propName, value)
 	} else {
-		props.block?.setProp(propName, `{{ ${varName} }}`)
+		props.block?.setProp(propName, value)
 	}
 }
 
+function setDynamicValue(propName: string, varName: string, bindVariable: boolean) {
+	if (bindVariable) {
+		setProp(propName, { $type: "variable", name: varName })
+	} else {
+		setProp(propName, `{{ ${varName} }}`)
+	}
+}
+
+const getRawValue = (propName: string) => {
+	return props.multiEdit ? blockController.getProp(propName) : props.block?.componentProps[propName]
+}
+
+const isMixed = (propName: string) => getRawValue(propName) === "Mixed"
+
 const getFormattedValue = (propName: string) => {
-	const value = props.block?.componentProps[propName]
+	const value = getRawValue(propName)
+	// mixed values across a multi-selection are surfaced via a placeholder, not a real value
+	if (value === "Mixed") return ""
 	if (value?.$type === "variable") {
 		return `{{ ${value.name} }}`
 	}
@@ -237,7 +256,7 @@ const getFormattedValue = (propName: string) => {
 }
 
 const handlePropUpdate = (propName: string, newValue: any) => {
-	props.block?.setProp(propName, newValue)
+	setProp(propName, newValue)
 }
 
 const isVariableBound = (value: any) => {

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -246,12 +246,12 @@ const getRawValue = (propName: string) => {
 	return props.multiEdit ? blockController.getProp(propName) : props.block?.componentProps[propName]
 }
 
-const isMixed = (propName: string) => getRawValue(propName) === "Mixed"
+const isMixed = (propName: string) => props.multiEdit && getRawValue(propName) === "Mixed"
 
 const getFormattedValue = (propName: string) => {
 	const value = getRawValue(propName)
 	// mixed values across a multi-selection are surfaced via a placeholder, not a real value
-	if (value === "Mixed") return ""
+	if (isMixed(propName)) return ""
 	if (value?.$type === "variable") {
 		return `{{ ${value.name} }}`
 	}

--- a/frontend/src/components/PropsEditor.vue
+++ b/frontend/src/components/PropsEditor.vue
@@ -22,6 +22,7 @@
 				:label="propName"
 				language="html"
 				:modelValue="getFormattedValue(propName)"
+				:placeholder="isMixed(propName) ? 'Mixed' : undefined"
 				@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 				:required="config.required"
 				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
@@ -54,6 +55,7 @@
 						:label="propName"
 						language="javascript"
 						:modelValue="getFormattedValue(propName)"
+						:placeholder="isMixed(propName) ? 'Mixed' : undefined"
 						@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 						:required="config.required"
 						:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
@@ -73,6 +75,7 @@
 						:label="propName"
 						:required="config.required"
 						:modelValue="getFormattedValue(propName)"
+						:emptyMessage="isMixed(propName) ? 'Mixed' : undefined"
 						@update:modelValue="(newValue) => handlePropUpdate(propName, newValue)"
 						:itemTypes="config.itemTypes"
 					/>

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -222,10 +222,17 @@ const selectedBlocks = computed(() => {
 	)
 }) as Ref<Block[]>
 
-function selectBlock(block: Block, e: MouseEvent | null, multiSelect = false, setBreakpoint = true) {
+function selectBlock(block: Block, e: MouseEvent | null, setBreakpoint = true) {
 	if (store.settingPage) return
 
-	selectBlockById(block.componentId, e, multiSelect)
+	if (e && e.shiftKey) {
+		selectBlockRange(block)
+	} else if (e && (e.metaKey || e.ctrlKey)) {
+		toggleBlockSelection(block)
+	} else {
+		selectBlockById(block.componentId)
+	}
+
 	if (setBreakpoint && e) {
 		const { breakpoint } = getBlockInfo(e)
 		setActiveBreakpoint(breakpoint)
@@ -239,12 +246,32 @@ function selectBlock(block: Block, e: MouseEvent | null, multiSelect = false, se
 	}
 }
 
-function selectBlockById(blockId: string, e: MouseEvent | null, multiSelect = false) {
-	if (multiSelect) {
-		selectedBlockIds.value.add(blockId)
+function selectBlockById(blockId: string) {
+	selectedBlockIds.value = new Set([blockId])
+}
+
+function toggleBlockSelection(block: Block) {
+	if (selectedBlockIds.value.has(block.componentId)) {
+		selectedBlockIds.value.delete(block.componentId)
 	} else {
-		selectedBlockIds.value = new Set([blockId])
+		selectedBlockIds.value.add(block.componentId)
 	}
+}
+
+function selectBlockRange(block: Block) {
+	const lastSelectedId = Array.from(selectedBlockIds.value).at(-1)
+	const lastSelected = lastSelectedId ? findBlock(lastSelectedId) : null
+	const parent = lastSelected?.getParentBlock()
+	// range selection only works within the same parent; fall back to single select
+	if (!lastSelected || !parent || parent !== block.getParentBlock()) {
+		selectBlockById(block.componentId)
+		return
+	}
+	const start = parent.getChildIndex(lastSelected)
+	const end = parent.getChildIndex(block)
+	parent.children
+		.slice(Math.min(start, end), Math.max(start, end) + 1)
+		.forEach((child) => selectedBlockIds.value.add(child.componentId))
 }
 
 const handleClick = (ev: MouseEvent) => {
@@ -270,7 +297,7 @@ const isRootSelected = computed(() => {
 const selectedSlot = ref<Slot | null>()
 function selectSlot(slot: Slot) {
 	selectedSlot.value = slot
-	selectBlockById(slot.parentBlockId, null)
+	selectBlockById(slot.parentBlockId)
 }
 
 const activeSlotIds = computed(() => {
@@ -359,6 +386,8 @@ defineExpose({
 	selectBlock,
 	scrollBlockIntoView,
 	selectBlockById,
+	toggleBlockSelection,
+	selectBlockRange,
 	clearSelection,
 	isRootSelected,
 	// slots

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -213,6 +213,8 @@ function setActiveBreakpoint(breakpoint: string | null) {
 }
 
 const selectedBlockIds = ref<Set<string>>(new Set())
+// anchor for shift-click range selection, set by plain/multi clicks and held fixed across shift-clicks
+const selectionAnchorId = ref<string | null>(null)
 const selectedBlocks = computed(() => {
 	return (
 		Array.from(selectedBlockIds.value)
@@ -248,6 +250,7 @@ function selectBlock(block: Block, e: MouseEvent | null, setBreakpoint = true) {
 
 function selectBlockById(blockId: string) {
 	selectedBlockIds.value = new Set([blockId])
+	selectionAnchorId.value = blockId
 }
 
 function toggleBlockSelection(block: Block) {
@@ -256,22 +259,22 @@ function toggleBlockSelection(block: Block) {
 	} else {
 		selectedBlockIds.value.add(block.componentId)
 	}
+	selectionAnchorId.value = block.componentId
 }
 
 function selectBlockRange(block: Block) {
-	const lastSelectedId = Array.from(selectedBlockIds.value).at(-1)
-	const lastSelected = lastSelectedId ? findBlock(lastSelectedId) : null
-	const parent = lastSelected?.getParentBlock()
+	const anchor = selectionAnchorId.value ? findBlock(selectionAnchorId.value) : null
+	const parent = anchor?.getParentBlock()
 	// range selection only works within the same parent; fall back to single select
-	if (!lastSelected || !parent || parent !== block.getParentBlock()) {
+	if (!anchor || !parent || parent !== block.getParentBlock()) {
 		selectBlockById(block.componentId)
 		return
 	}
-	const start = parent.getChildIndex(lastSelected)
+	// replace the selection with the anchor→block range so repeated shift-clicks grow/shrink it
+	const start = parent.getChildIndex(anchor)
 	const end = parent.getChildIndex(block)
-	parent.children
-		.slice(Math.min(start, end), Math.max(start, end) + 1)
-		.forEach((child) => selectedBlockIds.value.add(child.componentId))
+	const range = parent.children.slice(Math.min(start, end), Math.max(start, end) + 1)
+	selectedBlockIds.value = new Set(range.map((child) => child.componentId))
 }
 
 const handleClick = (ev: MouseEvent) => {
@@ -285,6 +288,7 @@ const handleClick = (ev: MouseEvent) => {
 
 function clearSelection() {
 	selectedBlockIds.value = new Set()
+	selectionAnchorId.value = null
 }
 
 const isRootSelected = computed(() => {

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -265,15 +265,23 @@ function toggleBlockSelection(block: Block) {
 function selectBlockRange(block: Block) {
 	const anchor = selectionAnchorId.value ? findBlock(selectionAnchorId.value) : null
 	const parent = anchor?.getParentBlock()
-	// range selection only works within the same parent; fall back to single select
-	if (!anchor || !parent || parent !== block.getParentBlock()) {
+	// range selection only works among siblings sharing a parent AND slot; otherwise fall back to single select
+	if (
+		!anchor ||
+		!parent ||
+		parent !== block.getParentBlock() ||
+		anchor.parentSlotName !== block.parentSlotName
+	) {
 		selectBlockById(block.componentId)
 		return
 	}
+	const siblings = anchor.parentSlotName
+		? (parent.getSlotContent(anchor.parentSlotName) as Block[])
+		: parent.children
 	// replace the selection with the anchor→block range so repeated shift-clicks grow/shrink it
 	const start = parent.getChildIndex(anchor)
 	const end = parent.getChildIndex(block)
-	const range = parent.children.slice(Math.min(start, end), Math.max(start, end) + 1)
+	const range = siblings.slice(Math.min(start, end), Math.max(start, end) + 1)
 	selectedBlockIds.value = new Set(range.map((child) => child.componentId))
 }
 

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -237,19 +237,13 @@ class Block implements BlockOptions {
 
 	getSiblingBlock(direction: "next" | "previous") {
 		const parentBlock = this.getParentBlock();
-		let sibling = null as Block | null;
-		if (parentBlock) {
-			const index = parentBlock.getChildIndex(this);
-			if (direction === "next") {
-				sibling = parentBlock.children[index + 1];
-			} else {
-				sibling = parentBlock.children[index - 1];
-			}
-			if (sibling) {
-				return sibling;
-			}
-		}
-		return null;
+		if (!parentBlock) return null;
+		const siblings = this.parentSlotName
+			? (parentBlock.getSlotContent(this.parentSlotName) as Block[])
+			: parentBlock.children;
+		const index = parentBlock.getChildIndex(this);
+		const sibling = direction === "next" ? siblings[index + 1] : siblings[index - 1];
+		return sibling || null;
 	}
 
 	getIcon() {

--- a/frontend/src/utils/blockController.ts
+++ b/frontend/src/utils/blockController.ts
@@ -18,6 +18,12 @@ const blockController = {
 	multipleBlocksSelected: () => {
 		return canvasStore.activeCanvas?.selectedBlocks && canvasStore.activeCanvas?.selectedBlocks.length > 1
 	},
+	selectedBlocksHaveSameType: () => {
+		const blocks = blockController.getSelectedBlocks()
+		if (blocks.length <= 1) return true
+		const type = blocks[0].componentName
+		return blocks.every((block) => block.componentName === type)
+	},
 	getFirstSelectedBlock: () => {
 		return canvasStore.activeCanvas?.selectedBlocks[0] as Block
 	},

--- a/frontend/src/utils/useCanvasUtils.ts
+++ b/frontend/src/utils/useCanvasUtils.ts
@@ -111,10 +111,8 @@ export function useCanvasUtils(
 			block.toggleVisibility(false)
 		}
 		nextTick(() => {
-			if (parentBlock.children.length) {
-				if (nextSibling) {
-					nextSibling.selectBlock()
-				}
+			if (nextSibling) {
+				nextSibling.selectBlock()
 			}
 		})
 	}

--- a/frontend/src/utils/useStudioEvents.ts
+++ b/frontend/src/utils/useStudioEvents.ts
@@ -76,7 +76,10 @@ export function useStudioEvents() {
 			const blockId = target.dataset.componentLayerId || target.dataset.componentId
 			const block = canvasStore.activeCanvas?.findBlock(blockId as string)
 			if (block) {
-				canvasStore.activeCanvas?.selectBlock(block, null)
+				const alreadyInSelection = canvasStore.activeCanvas?.selectedBlockIds.has(block.componentId)
+				if (!(blockController.multipleBlocksSelected() && alreadyInSelection)) {
+					canvasStore.activeCanvas?.selectBlock(block, null)
+				}
 
 				const slotName = target.dataset.slotName
 				if (slotName) {


### PR DESCRIPTION
## Multi-block selection and edits

**Interactions**:
- Shift + Click to select a range of blocks
- Cmd/Ctrl + Click to toggle a single block selection

**Operations**:
- You can now select multiple blocks and edit their styles and props (only if they are the same component eg: 2 or more Buttons)
- Useful for operations like Wrap in Container

https://github.com/user-attachments/assets/ffc375a3-cf40-47b5-95eb-b65219d7acff

