### PR TITLE
feat: set Route Variables for editing/testing dynamic route pages

### DIFF
--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -11,7 +11,7 @@
 					<ItemActions
 						class="-mt-1 self-start"
 						:menuOptions="getResourceMenu(resource, resource_name)"
-						@edit="openResource(resource)"
+						@edit="openResource(resource_name)"
 					/>
 				</div>
 			</div>
@@ -188,21 +188,22 @@ const addResource = (resource: Resource) => {
 		})
 }
 
-const deleteResource = async (resource: Resource, resource_name: string) => {
+const deleteResource = async (resource_name: string) => {
 	const confirmed = await confirm(`Are you sure you want to delete the data source ${resource_name}?`)
-	if (confirmed) {
-		studioPageResources.delete
-			.submit(resource.resource_id)
-			.then(async () => {
-				if (store.activePage) {
-					await codeStore.setPageResources(store.activePage, true)
-				}
-				toast.success(`Data Source ${resource_name} deleted successfully`)
-			})
-			.catch(() => {
-				toast.error(`Failed to delete data source ${resource_name}`)
-			})
-	}
+	if (!confirmed) return
+	const stored = await getStoredResource(resource_name)
+	if (!stored) return
+	studioPageResources.delete
+		.submit(stored.resource_id)
+		.then(async () => {
+			if (store.activePage) {
+				await codeStore.setPageResources(store.activePage, true)
+			}
+			toast.success(`Data Source ${resource_name} deleted successfully`)
+		})
+		.catch(() => {
+			toast.error(`Failed to delete data source ${resource_name}`)
+		})
 }
 
 const editResource = async (resource: Resource) => {
@@ -230,15 +231,18 @@ const getResourceValues = (resource: Resource) => {
 	}
 }
 
-const openResource = async (resource: Resource) => {
+const openResource = async (resource_name: string) => {
+	existingResource.value = await getStoredResource(resource_name)
+	showResourceDialog.value = true
+}
+
+const getStoredResource = async (resource_name: string) => {
 	studioPageResources.filters = {
 		parent: store.activePage?.name,
-		name: resource.resource_id,
+		resource_name: resource_name,
 	}
 	await studioPageResources.reload()
-
-	existingResource.value = studioPageResources.data[0]
-	showResourceDialog.value = true
+	return studioPageResources.data[0]
 }
 
 const getResourceMenu = (resource: Resource, resource_name: string) => {
@@ -247,7 +251,7 @@ const getResourceMenu = (resource: Resource, resource_name: string) => {
 			label: "Delete",
 			icon: "lucide-trash",
 			theme: "red",
-			onClick: () => deleteResource(resource, resource_name),
+			onClick: () => deleteResource(resource_name),
 		},
 		{
 			label: "Copy Object",

--- a/frontend/src/components/PageOptions.vue
+++ b/frontend/src/components/PageOptions.vue
@@ -40,6 +40,25 @@
 					</div>
 				</div>
 			</div>
+
+			<!-- Dynamic Route Variables: design-time test values for params like /articles/:category -->
+			<CollapsibleSection
+				v-if="routeVariableNames.length"
+				sectionName="Route Variables"
+				class="mt-2 w-full [&>div>h3]:!text-base [&>div>h3]:!text-ink-gray-5"
+			>
+				<div v-for="name in routeVariableNames" :key="name" class="flex w-full flex-col gap-2">
+					<label class="block text-xs text-ink-gray-5">{{ name.replace(/_/g, " ") }}</label>
+					<Input
+						type="text"
+						variant="outline"
+						class="w-full"
+						:placeholder="`Test value for :${name}`"
+						:modelValue="store.routeVariables[name] || ''"
+						@update:modelValue="(val: string) => store.setRouteVariable(name, val)"
+					/>
+				</div>
+			</CollapsibleSection>
 		</div>
 	</div>
 </template>
@@ -50,6 +69,8 @@ import useStudioStore from "@/stores/studioStore"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { StudioApp } from "@/types/Studio/StudioApp"
 import Input from "@/components/Input.vue"
+import CollapsibleSection from "@/components/CollapsibleSection.vue"
+import { getRouteVariables } from "@/utils/helpers"
 
 const store = useStudioStore()
 const props = defineProps<{
@@ -57,6 +78,8 @@ const props = defineProps<{
 	app: StudioApp
 	isOpen: boolean
 }>()
+
+const routeVariableNames = computed(() => getRouteVariables(props.page.route || ""))
 
 const inputRef = ref<InstanceType<typeof Input> | null>(null)
 

--- a/frontend/src/components/StudioToolbar.vue
+++ b/frontend/src/components/StudioToolbar.vue
@@ -87,6 +87,12 @@
 							<span class="flex max-w-96 truncate text-base text-ink-gray-5">
 								{{ routeString }}
 							</span>
+							<Tooltip
+								v-if="!store.areRouteVariablesSet"
+								text="Set route variable values here to preview page data"
+							>
+								<FeatherIcon name="alert-circle" class="h-[14px] w-[14px] text-ink-amber-6" />
+							</Tooltip>
 						</div>
 						<FeatherIcon
 							name="external-link"

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -507,8 +507,13 @@ const useCodeStore = defineStore("codeStore", () => {
 		if (keys.length === 1 && keys[0] === "name") {
 			return filters.name
 		}
-		// other filters (e.g. category = tech) need a server lookup to find one matching doc
-		return await call("studio.api.get_docname", { doctype: resource.document_type, filters })
+		// other filters (e.g. category = tech) need a lookup for one matching doc's name
+		const doc = await call("frappe.client.get_value", {
+			doctype: resource.document_type,
+			fieldname: "name",
+			filters,
+		})
+		return doc?.name
 	}
 
 	const getEvaluatedFilters = (filters: Filters | null = null, context: ExpressionEvaluationContext) => {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -487,11 +487,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	const getDocumentResource = async (resource: DocumentResource, context: ExpressionEvaluationContext) => {
 		let docname = resource.document_name
 		if (resource.fetch_document_using_filters && resource.filters) {
-			// fetch the docname based on filters
-			docname = await call(
-				"studio.api.get_docname",
-				{ doctype: resource.document_type, filters: getEvaluatedFilters(resource.filters, context) }
-			)
+			docname = await resolveDocnameFromFilters(resource, context)
 		}
 
 		return createDocumentResource({
@@ -502,6 +498,17 @@ const useCodeStore = defineStore("codeStore", () => {
 			...getSuccessErrorHandlers(resource),
 			...getWhitelistedMethods(resource),
 		})
+	}
+
+	const resolveDocnameFromFilters = async (resource: DocumentResource, context: ExpressionEvaluationContext) => {
+		const filters = getEvaluatedFilters(resource.filters, context) || {}
+		// the common `name = {{ route.params.id }}` case resolves to the docname itself — no server lookup needed
+		const keys = Object.keys(filters)
+		if (keys.length === 1 && keys[0] === "name") {
+			return filters.name
+		}
+		// other filters (e.g. category = tech) need a server lookup to find one matching doc
+		return await call("studio.api.get_docname", { doctype: resource.document_type, filters })
 	}
 
 	const getEvaluatedFilters = (filters: Filters | null = null, context: ExpressionEvaluationContext) => {

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -471,6 +471,13 @@ const useStudioStore = defineStore("store", () => {
 		return newRoute
 	})
 
+	// route variables on the active page that have no test value yet — used to nudge the user, since
+	// unset variables render the page's empty state (no doc / no rows) which can look like a bug
+	const areRouteVariablesSet = computed(() => {
+		if (!activePage.value) return true
+		return getRouteVariables(activePage.value.route).every((name) => !!routeVariables.value[name])
+	})
+
 	function loadRouteVariables(page: StudioPage) {
 		const key = `${page.name}:routeVariables`
 		try {
@@ -608,6 +615,7 @@ const useStudioStore = defineStore("store", () => {
 		openPageInBrowser,
 		routeObject,
 		routeVariables,
+		areRouteVariablesSet,
 		setRouteVariable,
 		// app build
 		generateAppBuild,

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -471,8 +471,16 @@ const useStudioStore = defineStore("store", () => {
 	})
 
 	function loadRouteVariables(page: StudioPage) {
-		const stored = localStorage.getItem(`${page.name}:routeVariables`)
-		routeVariables.value = stored ? JSON.parse(stored) : {}
+		const key = `${page.name}:routeVariables`
+		try {
+			const stored = localStorage.getItem(key)
+			const parsed = stored ? JSON.parse(stored) : null
+			routeVariables.value = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {}
+		} catch (error) {
+			console.error(`Failed to parse route variables for ${page.name}, resetting`, error)
+			routeVariables.value = {}
+			localStorage.removeItem(key)
+		}
 	}
 
 	async function setRouteVariable(name: string, value: string) {

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -514,8 +514,8 @@ const useStudioStore = defineStore("store", () => {
 		const page = activePage.value
 		if (!page) return
 		// re-resolve data sources with the new value, then re-run the page script so bindings that
-		// derive from a resource (e.g. refs seeded from note.doc via a watcher) re-bind to the new doc
-		await codeStore.setPageResources(page)
+		// derive from a resource (e.g. refs seeded from note.doc via a watcher) re-bind to the new doc.
+		await codeStore.setPageResources(page, true)
 		await codeStore.setPageScript(page, Boolean(page.is_standard))
 	}, 300)
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -475,15 +475,17 @@ const useStudioStore = defineStore("store", () => {
 		routeVariables.value = stored ? JSON.parse(stored) : {}
 	}
 
-	function setRouteVariable(name: string, value: string) {
+	async function setRouteVariable(name: string, value: string) {
 		if (!activePage.value) return
 		routeVariables.value[name] = value
 		localStorage.setItem(
 			`${activePage.value.name}:routeVariables`,
 			JSON.stringify(routeVariables.value),
 		)
-		// re-resolve data sources so the canvas reflects the new test value
-		codeStore.setPageResources(activePage.value)
+		// re-resolve data sources with the new value, then re-run the page script so bindings that
+		// derive from a resource (e.g. refs seeded from note.doc via a watcher) re-bind to the new doc
+		await codeStore.setPageResources(activePage.value)
+		await codeStore.setPageScript(activePage.value, Boolean(activePage.value.is_standard))
 	}
 
 	const codeStore = useCodeStore()

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -381,7 +381,7 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	function openPageInBrowser(app: StudioApp, page: StudioPage, preview: boolean = false) {
-		let route = `/${app.route}${page.route}`
+		let route = `/${app.route}${resolveRouteVariables(page.route)}`
 		if (preview) {
 			route = `/dev${route}`
 		}
@@ -397,6 +397,15 @@ const useStudioStore = defineStore("store", () => {
 				targetWindow?.location.reload()
 			}, 50)
 		}
+	}
+
+	// substitute test route variables set by the user into the dynamic route so preview opens the concrete URL,
+	// e.g. "/notes/:id" + { id: "note-1" } -> "/notes/note-1" (unset params keep their placeholder)
+	function resolveRouteVariables(route: string) {
+		return getRouteVariables(route).reduce((resolved, name) => {
+			const value = routeVariables.value[name]
+			return value ? resolved.replace(`:${name}`, encodeURIComponent(value)) : resolved
+		}, route)
 	}
 
 	// custom components

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -1,4 +1,5 @@
 import { ref, reactive, nextTick, computed, toRaw, readonly } from "vue"
+import { useDebounceFn } from "@vueuse/core"
 import router from "@/router/studio_router"
 import { defineStore } from "pinia"
 
@@ -483,18 +484,24 @@ const useStudioStore = defineStore("store", () => {
 		}
 	}
 
-	async function setRouteVariable(name: string, value: string) {
+	function setRouteVariable(name: string, value: string) {
 		if (!activePage.value) return
 		routeVariables.value[name] = value
 		localStorage.setItem(
 			`${activePage.value.name}:routeVariables`,
 			JSON.stringify(routeVariables.value),
 		)
+		resetState()
+	}
+
+	const resetState = useDebounceFn(async () => {
+		const page = activePage.value
+		if (!page) return
 		// re-resolve data sources with the new value, then re-run the page script so bindings that
 		// derive from a resource (e.g. refs seeded from note.doc via a watcher) re-bind to the new doc
-		await codeStore.setPageResources(activePage.value)
-		await codeStore.setPageScript(activePage.value, Boolean(activePage.value.is_standard))
-	}
+		await codeStore.setPageResources(page)
+		await codeStore.setPageScript(page, Boolean(page.is_standard))
+	}, 300)
 
 	const codeStore = useCodeStore()
 	codeStore.setRouteObject(routeObject)

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -7,6 +7,7 @@ import {
 	fetchPage,
 	confirm,
 	getInitialVariableValue,
+	getRouteVariables,
 } from "@/utils/helpers"
 import { getBlockInstance, getRootBlock, getBlockCopyWithoutParent, jsToJson } from "@/utils/serializer"
 import { studioPages } from "@/data/studioPages"
@@ -178,6 +179,9 @@ const useStudioStore = defineStore("store", () => {
 	const savingPage = ref(false)
 	const settingPage = ref(false)
 
+	// design-time test values for dynamic route variables (e.g. { category: "tech" }), persists in localStorage
+	const routeVariables = ref<Record<string, string>>({})
+
 	async function setPage(pageName: string) {
 		settingPage.value = true
 		const page = await fetchPage(pageName)
@@ -186,6 +190,7 @@ const useStudioStore = defineStore("store", () => {
 			return
 		}
 		activePage.value = page
+		loadRouteVariables(page)
 		await setPageData(page)
 		await codeStore.setPageScript(page, Boolean(page.is_standard))
 
@@ -454,15 +459,32 @@ const useStudioStore = defineStore("store", () => {
 		if (!activePage.value) return ""
 
 		const newRoute = toRaw(router.currentRoute.value)
-		// Extract param names from active page's route (e.g., ["employee", "id"] from "/hr/:employee/:id")
-		const paramNames = (activePage.value.route.match(/:\w+/g) || []).map(param => param.slice(1))
+		// Seed each dynamic param with its design-time test value (empty string when unset),
+		// e.g. "/hr/:employee/:id" -> { employee, id } filled from routeVariables
+		const paramNames = getRouteVariables(activePage.value.route)
 		newRoute.params = paramNames.reduce((params, name) => {
-			params[name] = ""
+			params[name] = routeVariables.value[name] ?? ""
 			return params
 		}, {} as Record<string, string>)
 
 		return newRoute
 	})
+
+	function loadRouteVariables(page: StudioPage) {
+		const stored = localStorage.getItem(`${page.name}:routeVariables`)
+		routeVariables.value = stored ? JSON.parse(stored) : {}
+	}
+
+	function setRouteVariable(name: string, value: string) {
+		if (!activePage.value) return
+		routeVariables.value[name] = value
+		localStorage.setItem(
+			`${activePage.value.name}:routeVariables`,
+			JSON.stringify(routeVariables.value),
+		)
+		// re-resolve data sources so the canvas reflects the new test value
+		codeStore.setPageResources(activePage.value)
+	}
 
 	const codeStore = useCodeStore()
 	codeStore.setRouteObject(routeObject)
@@ -568,6 +590,8 @@ const useStudioStore = defineStore("store", () => {
 		unpublishApp,
 		openPageInBrowser,
 		routeObject,
+		routeVariables,
+		setRouteVariable,
 		// app build
 		generateAppBuild,
 		// styles

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -283,6 +283,17 @@ async function findPageWithRoute(appName: string, pageRoute: string) {
 	return fetchPage(pageName)
 }
 
+// extract dynamic route variables from a vue-router route, e.g. "/articles/:category" -> ["category"]
+function getRouteVariables(route: string): string[] {
+	const variables = [] as string[]
+	route.split("/").forEach((part) => {
+		if (part.startsWith(":") && part.length > 1) {
+			variables.push(part.slice(1))
+		}
+	})
+	return variables
+}
+
 // data
 function getAutocompleteValues(data: SelectOption[]) {
 	if (!data.length || typeof data[0] === "string") return data
@@ -547,6 +558,7 @@ export {
 	// page
 	fetchPage,
 	findPageWithRoute,
+	getRouteVariables,
 	// data
 	getAutocompleteValues,
 	getParamsObj,

--- a/studio/api.py
+++ b/studio/api.py
@@ -13,15 +13,6 @@ from studio.utils import has_page_write_perm
 
 
 @frappe.whitelist()
-def get_docname(doctype: str, filters: dict | str) -> str | None:
-	if isinstance(filters, str):
-		filters = frappe.parse_json(filters)
-
-	document = frappe.get_list(doctype, filters=filters, pluck="name", limit=1)
-	return document[0] if document else None
-
-
-@frappe.whitelist()
 def get_doctype_fields(doctype: str) -> list[dict]:
 	fields = frappe.get_meta(doctype).fields
 	# find the name field

--- a/studio/api.py
+++ b/studio/api.py
@@ -13,18 +13,12 @@ from studio.utils import has_page_write_perm
 
 
 @frappe.whitelist()
-def get_docname(doctype: str, filters: dict | str) -> dict:
+def get_docname(doctype: str, filters: dict | str) -> str | None:
 	if isinstance(filters, str):
 		filters = frappe.parse_json(filters)
 
-	# remove name filter if it is dynamic or empty - for fetching a document while testing
-	if "name" in filters and (filters["name"].startswith(":") or not filters["name"]):
-		del filters["name"]
-
 	document = frappe.get_list(doctype, filters=filters, pluck="name", limit=1)
 	return document[0] if document else None
-
-	return None
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

Working on dynamic pages was hard to design/test. You usually have your data sources dependent on dynamic page variables. Eg: A note page /note/:id on load will fetch a note record with name = id param. To test this, earlier Studio used to fetch the first doc from get_list so that you can see and edit things in the editor. But this was non-deterministic. User should have control over test params.

## Set Route Variables for testing

If this is your data source that depends on your route param:

<img width="3016" height="1714" alt="image" src="https://github.com/user-attachments/assets/18e14c12-7ca0-4874-b52e-322b79348d9f" />

You can now set route variables in page options to quickly see and test the UI with different documents. These are stored in local storage so they persist even after a refresh. These variables are also substituted when previewing/publishing a page from the editor.

https://github.com/user-attachments/assets/3dc748e2-f05a-4bbf-bada-e3e79894ec2f
