### PR TITLE
feat: show repeater icon on a repeater/repeated block to visually identify them

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -74,6 +74,7 @@ declare module 'vue' {
     LucideChevronUp: typeof import('~icons/lucide/chevron-up')['default']
     LucideFlaskConical: typeof import('~icons/lucide/flask-conical')['default']
     LucidePaperclip: typeof import('~icons/lucide/paperclip')['default']
+    LucideRepeat: typeof import('~icons/lucide/repeat')['default']
     MarginHandler: typeof import('./src/components/MarginHandler.vue')['default']
     MarkdownEditor: typeof import('./src/components/AppLayout/MarkdownEditor.vue')['default']
     MissingComponent: typeof import('./src/components/MissingComponent.vue')['default']

--- a/frontend/src/components/ComponentEditor.vue
+++ b/frontend/src/components/ComponentEditor.vue
@@ -10,9 +10,10 @@
 		<!-- Component name label -->
 		<span
 			v-if="!props.block.isRoot()"
-			class="absolute -top-3 left-0 inline-block text-xs"
+			class="absolute -top-3 left-0 inline-flex items-center gap-1 text-xs"
 			:class="componentLabelClasses"
 		>
+			<LucideRepeat v-if="block.isRepeater() || block.isRepeated()" class="h-3 w-3 shrink-0" />
 			{{ block.getBlockDescription() }}
 		</span>
 
@@ -92,6 +93,7 @@ import BoxResizer from "@/components/BoxResizer.vue"
 import PaddingHandler from "@/components/PaddingHandler.vue"
 import MarginHandler from "@/components/MarginHandler.vue"
 import Code from "@/components/Code.vue"
+import LucideRepeat from "~icons/lucide/repeat"
 
 import Block from "@/utils/block"
 import useStudioStore from "@/stores/studioStore"

--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -69,6 +69,12 @@
 							{{ element.getBlockDescription() }}
 						</span>
 
+						<LucideRepeat
+							v-if="element.isRepeated()"
+							title="Repeated for each data item"
+							class="h-3 w-3 shrink-0 text-ink-gray-4"
+						/>
+
 						<!-- toggle visibility -->
 						<div class="ml-auto flex items-center gap-2">
 							<div
@@ -153,6 +159,7 @@ import ComponentLayers from "@/components/ComponentLayers.vue"
 import useCanvasStore from "@/stores/canvasStore"
 import Block from "@/utils/block"
 import SlotIcon from "@/components/Icons/SlotIcon.vue"
+import LucideRepeat from "~icons/lucide/repeat"
 import type { Slot } from "@/types"
 
 type LayerInstance = InstanceType<typeof ComponentLayers>

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -713,6 +713,10 @@ class Block implements BlockOptions {
 		return this.componentName === "Repeater"
 	}
 
+	isRepeated() {
+		return Boolean(this.getParentBlock()?.isRepeater())
+	}
+
 	setRepeaterDataItem(repeaterDataItem: Record<string, any>) {
 		// temporarily set repeater data item on selected block for autocompletions
 		this.repeaterDataItem = repeaterDataItem


### PR DESCRIPTION
Repeater/repeated block now shows the repeater icon for better identification:

https://github.com/user-attachments/assets/4c8498c3-af89-4c73-a274-2d8cecfbde09

**Repeater block:**

<img width="1508" height="857" alt="repeater" src="https://github.com/user-attachments/assets/c3009ae8-276a-4b6e-a5d5-47caafe0a149" />

**Repeated block:**

<img width="1508" height="857" alt="repeated-block" src="https://github.com/user-attachments/assets/234ab1c3-e56b-4aa0-8f5c-e8684814f54e" />
