### PR TITLE
feat: remember selected panels & open file in editor so that they persist on refresh

### DIFF
--- a/frontend/src/components/FileExplorer.vue
+++ b/frontend/src/components/FileExplorer.vue
@@ -644,8 +644,12 @@ watch(
 		const remembered = appName ? lastOpenFiles.value[appName] : undefined
 		openFile.value = null
 		selectedNode.value = null
-		await loadTree()
-		reopenLastFile(remembered)
+		try {
+			await loadTree()
+			reopenLastFile(remembered)
+		} finally {
+			if (appName && remembered && !openFile.value) lastOpenFiles.value[appName] = remembered
+		}
 	},
 	{ immediate: true },
 )

--- a/frontend/src/components/FileExplorer.vue
+++ b/frontend/src/components/FileExplorer.vue
@@ -185,6 +185,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from "vue"
 import { vOnClickOutside } from "@vueuse/components"
+import { useStorage } from "@vueuse/core"
 import { Button, Dialog, ErrorMessage, FormControl, Tree, toast, Tooltip } from "frappe-ui"
 import CodeEditorDock from "@/components/CodeEditorDock.vue"
 import ContextMenu from "@/components/ContextMenu.vue"
@@ -625,15 +626,36 @@ function openFileIsUnder(path: string, isFolder: boolean): boolean {
 	return openFile.value.path === path || (isFolder && openFile.value.path.startsWith(`${path}/`))
 }
 
+// remember last opened file
+const lastOpenFiles = useStorage<Record<string, string>>("studioOpenFiles", {})
+watch(
+	() => openFile.value?.path,
+	(path) => {
+		const appName = app.value?.name
+		if (!appName) return
+		if (path) lastOpenFiles.value[appName] = path
+		else delete lastOpenFiles.value[appName]
+	},
+)
+
 watch(
 	() => app.value?.name,
-	() => {
+	async (appName) => {
+		const remembered = appName ? lastOpenFiles.value[appName] : undefined
 		openFile.value = null
 		selectedNode.value = null
-		loadTree()
+		await loadTree()
+		reopenLastFile(remembered)
 	},
 	{ immediate: true },
 )
+
+function reopenLastFile(path: string | undefined) {
+	const node = path ? findNode(path) : null
+	if (!node) return
+	selectedNode.value = node
+	openNode(node)
+}
 
 async function onStudioFilesChanged() {
 	await loadTree()

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -1,5 +1,5 @@
-import { ref, reactive, nextTick, computed, toRaw, readonly } from "vue"
-import { useDebounceFn } from "@vueuse/core"
+import { ref, nextTick, computed, toRaw, readonly } from "vue"
+import { useDebounceFn, useStorage } from "@vueuse/core"
 import router from "@/router/studio_router"
 import { defineStore } from "pinia"
 
@@ -36,15 +36,20 @@ import { toast } from "frappe-ui"
 import { createResource } from "frappe-ui"
 
 const useStudioStore = defineStore("store", () => {
-	const studioLayout = reactive({
-		leftPanelWidth: 338,
-		rightPanelWidth: 275,
-		showLeftPanel: true,
-		showRightPanel: true,
-		leftPanelActiveTab: <LeftPanelOptions>"Add Component",
-		leftPanelComponentTab: <leftPanelComponentTabOptions>"Standard",
-		rightPanelActiveTab: <RightPanelOptions>"Properties",
-	})
+	const studioLayout = useStorage(
+		"studioLayout",
+		{
+			leftPanelWidth: 338,
+			rightPanelWidth: 275,
+			showLeftPanel: true,
+			showRightPanel: true,
+			leftPanelActiveTab: <LeftPanelOptions>"Add Component",
+			leftPanelComponentTab: <leftPanelComponentTabOptions>"Standard",
+			rightPanelActiveTab: <RightPanelOptions>"Properties",
+		},
+		localStorage,
+		{ mergeDefaults: true },
+	)
 	const mode = ref<StudioMode>("select")
 	const componentContextMenu = ref<InstanceType<typeof ComponentContextMenu> | null>(null)
 
@@ -63,15 +68,15 @@ const useStudioStore = defineStore("store", () => {
 	const selectedVueComponent = ref<string | null>(null)
 
 	function navigateToCodeFile(studioFilePath: string) {
-		studioLayout.leftPanelActiveTab = "Code"
-		studioLayout.showLeftPanel = true
+		studioLayout.value.leftPanelActiveTab = "Code"
+		studioLayout.value.showLeftPanel = true
 		selectedVueFile.value = studioFilePath
 	}
 
 	function navigateToVueComponent(componentName: string) {
-		studioLayout.leftPanelActiveTab = "Add Component"
-		studioLayout.leftPanelComponentTab = "Custom"
-		studioLayout.showLeftPanel = true
+		studioLayout.value.leftPanelActiveTab = "Add Component"
+		studioLayout.value.leftPanelComponentTab = "Custom"
+		studioLayout.value.showLeftPanel = true
 		selectedVueComponent.value = componentName
 	}
 
@@ -286,7 +291,7 @@ const useStudioStore = defineStore("store", () => {
 							action: {
 								label: "Edit Pages",
 								onClick: () => {
-									studioLayout.leftPanelActiveTab = "Pages"
+									studioLayout.value.leftPanelActiveTab = "Pages"
 								}
 							}
 						})


### PR DESCRIPTION
Remember the selected panels & open file in the editor so that they persist on refresh. It's annoying to change tabs every time