### PR TITLE
fix: add frappe-ui molecules directory to tailwind content glob

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -31,6 +31,8 @@ export default {
 		"./src/**/*.{vue,js,ts,jsx,tsx}",
 		"./node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}",
 		"../node_modules/frappe-ui/src/components/**/*.{vue,js,ts,jsx,tsx}",
+		"./node_modules/frappe-ui/src/molecules/**/*.{vue,js,ts,jsx,tsx}",
+		"../node_modules/frappe-ui/src/molecules/**/*.{vue,js,ts,jsx,tsx}",
 		"./node_modules/frappe-ui/frappe/**/*.{vue,js,ts,jsx,tsx}",
 		"../node_modules/frappe-ui/frappe/**/*.{vue,js,ts,jsx,tsx}",
 		"../../*/studio/**/*.{vue,js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- Add `frappe-ui/src/molecules/**` (both root and nested node_modules paths) to the Tailwind `content` glob so utility classes used in frappe-ui molecule components are generated.

## Test plan
- [ ] Verify Tailwind picks up classes from frappe-ui molecule components after this change