### PR TITLE
feat: reuse resources and blocks across page loads

### DIFF
--- a/frontend/src/components/ResourceDialog.vue
+++ b/frontend/src/components/ResourceDialog.vue
@@ -144,6 +144,13 @@
 
 				<Checkbox size="sm" label="Auto fetch data on load" v-model="newResource.auto" />
 
+				<Checkbox
+					v-if="newResource.resource_type === 'API Resource'"
+					size="sm"
+					label="Cache data across page loads"
+					v-model="newResource.cache"
+				/>
+
 				<!-- Transform Results for any Resource Type -->
 				<ScriptSection
 					title="Transform Results"
@@ -237,6 +244,7 @@ const emptyResource: Resource = {
 	on_success: "",
 	on_error: "",
 	auto: true,
+	cache: false,
 }
 
 const newResource = ref<Resource>({ ...emptyResource })

--- a/frontend/src/data/studioResources.ts
+++ b/frontend/src/data/studioResources.ts
@@ -7,6 +7,7 @@ export const studioPageResources = createListResource({
 		"resource_type",
 		"resource_name",
 		"auto",
+		"cache",
 		"fields",
 		"filters",
 		"limit",

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -24,39 +24,47 @@ const codeStore = useCodeStore()
 const page = ref<StudioPage | null>(null)
 
 const rootBlock = ref<Block | null>(null)
+let renderedPath: string | null = null
 
-async function loadPage() {
-	let { pageRoute } = route.params as { pageRoute: string[] }
-	const isDynamic = route.meta?.isDynamic
-
-	let currentPath = "/"
-	if (isDynamic) {
-		currentPath = route.matched?.[0]?.path
-	} else if (pageRoute) {
-		currentPath = pageRoute[0]
-	}
-
+async function loadPage(force: boolean = false) {
+	const currentPath = resolvePagePath()
 	if (!currentPath) {
 		rootBlock.value = null
+		renderedPath = null
 		return
 	}
 
-	page.value = await findPageWithRoute(window.app_name, currentPath)
+	const isSamePage = !force && currentPath === renderedPath
+	if (!isSamePage) {
+		const nextPage = await findPageWithRoute(window.app_name, currentPath)
+		if (!nextPage) return
+		page.value = nextPage
+	}
 	if (!page.value) return
+
 	await store.setPageData(page.value)
 	await codeStore.setPageScript(page.value, Boolean(page.value.is_standard))
+
+	if (isSamePage) return
 
 	const blocks = window.is_preview
 		? JSON.parse(page.value?.draft_blocks || page.value?.blocks)
 		: JSON.parse(page.value?.blocks)
 	if (blocks) {
 		rootBlock.value = getBlockInstance(blocks[0])
+		renderedPath = currentPath
 	}
 }
 
-watch(() => route.path, loadPage, { immediate: true })
+watch(() => route.path, () => loadPage(), { immediate: true })
 
-if (window.is_preview) useLivePreview(page, loadPage)
+if (window.is_preview) useLivePreview(page, () => loadPage(true))
+
+function resolvePagePath() {
+	if (route.meta?.isDynamic) return route.matched?.[0]?.path
+	const { pageRoute } = route.params as { pageRoute: string[] }
+	return pageRoute ? pageRoute[0] : "/"
+}
 
 usePageMeta(() => {
 	return {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -449,7 +449,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		switch (resource.resource_type) {
 			case "Document":
 				return getDocumentResource(resource, context)
-			case "Document List":
+			case "Document List": {
 				const params: any = {
 					doctype: resource.document_type,
 					fields: fields.length ? fields : "*",
@@ -463,7 +463,8 @@ const useCodeStore = defineStore("codeStore", () => {
 					params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
 				}
 				return createListResource(params)
-			case "API Resource":
+			}
+			case "API Resource": {
 				const apiParams = getAPIParams(resource.params, context)
 				return createResource({
 					url: resource.url,
@@ -474,6 +475,7 @@ const useCodeStore = defineStore("codeStore", () => {
 					...getTransforms(resource),
 					...getSuccessErrorHandlers(resource),
 				})
+			}
 		}
 	}
 

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -55,7 +55,6 @@ const useCodeStore = defineStore("codeStore", () => {
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
-		resources.value = {}
 
 		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
 			const newResource = await getNewResource(resource, {
@@ -73,14 +72,16 @@ const useCodeStore = defineStore("codeStore", () => {
 
 		const resolvedResources = await Promise.all(resourcePromises)
 
+		const nextResources: Record<string, Resource> = {}
 		resolvedResources.forEach((item) => {
-			resources.value[item.resource_name] = item.value
+			nextResources[item.resource_name] = item.value
 			if (setResourceConfig) {
 				if (!item.value) return
-				resources.value[item.resource_name].resource_id = item.resource_id
-				resources.value[item.resource_name].resource_type = item.resource_type
+				nextResources[item.resource_name].resource_id = item.resource_id
+				nextResources[item.resource_name].resource_type = item.resource_type
 			}
 		})
+		resources.value = nextResources
 	}
 
 	async function setPageVariables(page: StudioPage) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -13,7 +13,7 @@ import * as globalUtils from "@/utils/globalUtils"
 import { getInitialVariableValue, getValueFromObject, setValueInObject } from "@/utils/helpers"
 import { isDynamicValue, normalizeDynamicValue } from "@/utils/code"
 import { isFunctionExpression, toOptionalChaining, getTopLevelBindings } from "@/utils/parseCode"
-import type { Filters, Resource, DocumentResource, DataResult } from "@/types/Studio/StudioResource"
+import type { Filters, Resource, APIResource, DocumentResource, DataResult } from "@/types/Studio/StudioResource"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
 import type { ExpressionEvaluationContext } from "@/types"
@@ -464,15 +464,22 @@ const useCodeStore = defineStore("codeStore", () => {
 				}
 				return createListResource(params)
 			case "API Resource":
+				const apiParams = getAPIParams(resource.params, context)
 				return createResource({
 					url: resource.url,
 					method: resource.method,
-					params: getAPIParams(resource.params, context),
+					params: apiParams,
 					auto: resource.auto,
+					cache: getCacheOption(resource, apiParams),
 					...getTransforms(resource),
 					...getSuccessErrorHandlers(resource),
 				})
 		}
+	}
+
+	function getCacheOption(resource: APIResource, params: Record<string, any> | string | null) {
+		if (!resource.cache) return undefined
+		return [resource.resource_name, resource.url, resource.method, JSON.stringify(params)]
 	}
 
 	function getAPIParams(params: Record<string, any> | string | null = null, context: ExpressionEvaluationContext) {

--- a/frontend/src/types/Studio/StudioResource.ts
+++ b/frontend/src/types/Studio/StudioResource.ts
@@ -9,6 +9,8 @@ interface BaseResource {
 	resource_type: ResourceType
 	/** Whether to automatically fetch data on first load */
 	auto?: boolean
+	/** Whether to reuse the resource and its data across page loads, keyed on url + params */
+	cache?: boolean
 	transform?: string | null
 	on_success?: string
 	on_error?: string

--- a/studio/studio/doctype/studio_page_resource/studio_page_resource.json
+++ b/studio/studio/doctype/studio_page_resource/studio_page_resource.json
@@ -14,6 +14,7 @@
   "sort_field",
   "sort_order",
   "auto",
+  "cache",
   "document_resource_section",
   "document_type",
   "column_break_mkdu",
@@ -173,6 +174,13 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Auto fetch data on load"
+  },
+  {
+   "default": "0",
+   "description": "Reuse this resource and its data across page loads, keyed on url + params",
+   "fieldname": "cache",
+   "fieldtype": "Check",
+   "label": "Cache data across page loads"
   }
  ],
  "grid_page_length": 50,


### PR DESCRIPTION
## Summary

Navigating between Studio pages was always a cold load: every resource refetched and the whole block tree was reinstantiated. Three related changes:

- **Cache API resource data across page loads.** Adds a "Cache data across page loads" checkbox for API Resources, so fetched data is reused instead of refetched. The cache key is derived from resource name, url, method, and resolved params, since `createResource` returns a cache hit *before* url/params/transform are applied — a name-only key would serve one page's data to another.
- **Don't clear resources while new ones resolve.** `setPageResources` reset `resources` to `{}` before awaiting the resource promises, leaving components rendered against an empty map for the duration of the fetch. With caching on, that turned an instant cache hit into a flash of empty state. The map is now built locally and swapped in atomically.
- **Keep the block tree mounted on same-page navigation.** The route watcher rebuilt `rootBlock` on every path change, so navigating between routes served by the same page (a list and its detail route, a view switch) destroyed component state. It now tracks the last rendered path: same-page navigation still refreshes resources and the page script, since route params may have changed, but leaves the existing blocks in place.

## Test plan

- [ ] Add an API Resource to a Studio page, enable "Cache data across page loads", confirm data persists across navigation without refetching
- [ ] Confirm resources without caching enabled still fetch fresh data as before
- [ ] Confirm checkbox only shows for API Resource type
- [ ] Navigate between two routes served by the same page and confirm the blocks stay mounted (component state survives) while route-param-dependent resources re-resolve
- [ ] Navigate to a different page and confirm the block tree is rebuilt as before