### PR TITLE
feat: add option to revert page changes since last publish

### DIFF
--- a/frontend/src/components/PublishButton.vue
+++ b/frontend/src/components/PublishButton.vue
@@ -18,6 +18,19 @@
 		<Dropdown
 			:options="[
 				{
+					group: 'Revert',
+					hideLabel: true,
+					items: [
+						{
+							label: 'Revert Changes',
+							icon: LucideRotateCcw,
+							onClick: () => store.revertPage(),
+							condition: () =>
+								Boolean(store.activePage?.published) && Boolean(store.activePage?.draft_blocks),
+						},
+					],
+				},
+				{
 					group: 'Publish',
 					hideLabel: true,
 					items: [
@@ -72,6 +85,7 @@ import { Dropdown } from "frappe-ui"
 import useStudioStore from "@/stores/studioStore"
 import LucideCircleDashed from "~icons/lucide/circle-dashed"
 import LucideGlobe from "~icons/lucide/globe"
+import LucideRotateCcw from "~icons/lucide/rotate-ccw"
 import GlobeOff from "@/components/Icons/GlobeOff.vue"
 
 defineProps<{

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -232,18 +232,22 @@ const useStudioStore = defineStore("store", () => {
 			}
 		}
 		const pageData = jsToJson(pageBlocks.value.map((block) => getBlockCopyWithoutParent(block)))
+		const savedPage = selectedPage.value
 
 		return studioPages.runDocMethod
 			.submit({
-				name: selectedPage.value,
+				name: savedPage,
 				method: "save_draft",
 				draft_blocks: pageData,
 				known_modified: activePage.value?.modified,
 			})
 			.then((response: any) => {
+				// a save that resolves after the user switched pages must not stamp this page's
+				// timestamp/draft marker onto the newly opened one
+				if (activePage.value?.name !== savedPage) return
 				syncPageModified(response)
 				// track that the page now has unpublished changes (drives the "Revert Changes" option)
-				if (activePage.value) activePage.value.draft_blocks = pageData
+				activePage.value.draft_blocks = pageData
 			})
 			.catch(handlePageWriteConflict)
 			.finally(() => {
@@ -389,13 +393,19 @@ const useStudioStore = defineStore("store", () => {
 					const response = await studioPages.runDocMethod.submit({
 						name: selectedPage.value,
 						method: "revert",
+						known_modified: activePage.value?.modified,
 					})
+					syncPageModified(response)
 					await setPage(selectedPage.value!)
 					toast.success("Changes reverted")
 				} catch (error: any) {
-					toast.error("Failed to revert the changes", {
-						description: error?.messages?.join(", "),
-					})
+					try {
+						handlePageWriteConflict(error)
+					} catch {
+						toast.error("Failed to revert the changes", {
+							description: error?.messages?.join(", "),
+						})
+					}
 				}
 			},
 		})

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -194,6 +194,9 @@ const useStudioStore = defineStore("store", () => {
 	async function setPage(pageName: string) {
 		settingPage.value = true
 		pageConflict.value = false
+		// leaving the current page: drop its in-flight-save flag so the new page isn't blocked
+		// waiting on a save it doesn't own (that save's own callback no longer clears this flag)
+		savingPage.value = false
 		const page = await fetchPage(pageName)
 		if (!page) {
 			settingPage.value = false
@@ -251,7 +254,7 @@ const useStudioStore = defineStore("store", () => {
 			})
 			.catch(handlePageWriteConflict)
 			.finally(() => {
-				savingPage.value = false
+				if (activePage.value?.name === savedPage) savingPage.value = false
 			})
 	}
 

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -240,7 +240,11 @@ const useStudioStore = defineStore("store", () => {
 				draft_blocks: pageData,
 				known_modified: activePage.value?.modified,
 			})
-			.then(syncPageModified)
+			.then((response: any) => {
+				syncPageModified(response)
+				// track that the page now has unpublished changes (drives the "Revert Changes" option)
+				if (activePage.value) activePage.value.draft_blocks = pageData
+			})
 			.catch(handlePageWriteConflict)
 			.finally(() => {
 				savingPage.value = false
@@ -370,6 +374,31 @@ const useStudioStore = defineStore("store", () => {
 				},
 			}
 		)
+	}
+
+	function revertPage() {
+		if (!activePage.value) return
+		dialog.confirm({
+			title: "Revert changes",
+			message:
+				"This will discard all changes made to the page since it was last published. Are you sure you want to continue?",
+			confirmLabel: "Revert",
+			theme: "yellow",
+			onConfirm: async () => {
+				try {
+					const response = await studioPages.runDocMethod.submit({
+						name: selectedPage.value,
+						method: "revert",
+					})
+					await setPage(selectedPage.value!)
+					toast.success("Changes reverted")
+				} catch (error: any) {
+					toast.error("Failed to revert the changes", {
+						description: error?.messages?.join(", "),
+					})
+				}
+			},
+		})
 	}
 
 	async function publishApp() {
@@ -645,6 +674,7 @@ const useStudioStore = defineStore("store", () => {
 		reloadActivePageScript,
 		publishPage,
 		unpublishPage,
+		revertPage,
 		publishApp,
 		unpublishApp,
 		openPageInBrowser,

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -390,12 +390,11 @@ const useStudioStore = defineStore("store", () => {
 			theme: "yellow",
 			onConfirm: async () => {
 				try {
-					const response = await studioPages.runDocMethod.submit({
+					await studioPages.runDocMethod.submit({
 						name: selectedPage.value,
 						method: "revert",
 						known_modified: activePage.value?.modified,
 					})
-					syncPageModified(response)
 					await setPage(selectedPage.value!)
 					toast.success("Changes reverted")
 				} catch (error: any) {

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -325,6 +325,14 @@ class StudioPage(Document):
 		self.published = 0
 		self.save()
 
+	@frappe.whitelist()
+	def revert(self):
+		"""Discard the working draft so the page falls back to its published blocks (see save_draft)."""
+		self.draft_blocks = None
+		self._skip_validate = True  # blocks only change
+		self.save()
+		return self.modified
+
 	def validate_conflicts_with_other_pages(self):
 		other_pages = frappe.get_all(
 			"Studio Page",

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -326,8 +326,8 @@ class StudioPage(Document):
 		self.save()
 
 	@frappe.whitelist()
-	def revert(self):
-		"""Discard the working draft so the page falls back to its published blocks (see save_draft)."""
+	def revert(self, known_modified: str | None = None):
+		self.reject_if_stale(known_modified)
 		self.draft_blocks = None
 		self._skip_validate = True  # blocks only change
 		self.save()


### PR DESCRIPTION
In the backend, every page maintains `blocks` and `draft_blocks`. `blocks` get overwritten by`draft_blocks` on publish. But if you make a series of unwanted changes, you can't revert to the last "published" state from the frontend.

Added **Revert Changes** option in the primary button dropdown

https://github.com/user-attachments/assets/0a739953-d122-4f8a-8765-afa1b1bf1d72

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/19905a7c-770e-4c7f-b93a-9bbb0394c3d6" />
