### PR TITLE
fix(UX): Dynamic Style Setter

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -71,6 +71,7 @@ declare module 'vue' {
     ListBox: typeof import('./src/components/ListBox.vue')['default']
     LucideActivity: typeof import('~icons/lucide/activity')['default']
     LucideChevronDown: typeof import('~icons/lucide/chevron-down')['default']
+    LucideChevronRight: typeof import('~icons/lucide/chevron-right')['default']
     LucideChevronUp: typeof import('~icons/lucide/chevron-up')['default']
     LucideFlaskConical: typeof import('~icons/lucide/flask-conical')['default']
     LucidePaperclip: typeof import('~icons/lucide/paperclip')['default']

--- a/frontend/src/components/ComponentStyles.vue
+++ b/frontend/src/components/ComponentStyles.vue
@@ -555,7 +555,7 @@ const styleSectionProperties = [
 		component: ColorInput,
 		getProps: () => {
 			return {
-				label: "Text Color",
+				label: "Color",
 				modelValue: blockController.getStyle("color"),
 				property: "textColor",
 			}

--- a/frontend/src/components/DynamicStyleSetter.vue
+++ b/frontend/src/components/DynamicStyleSetter.vue
@@ -19,7 +19,12 @@
 		:width="600"
 		v-if="showDynamicValueModal"
 	>
-		<template #header><div class="text-base-semibold text-ink-gray-7">Set Dynamic Value</div></template>
+		<template #header>
+			<div class="text-base-semibold text-ink-gray-7">
+				Set Dynamic Value
+				<span v-if="propertyLabel" class="text-ink-gray-5">&middot; {{ propertyLabel }}</span>
+			</div>
+		</template>
 		<template #content>
 			<Code
 				language="javascript"
@@ -36,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { Button, ErrorMessage } from "frappe-ui"
 import Code from "@/components/Code.vue"
 import IconButton from "@/components/IconButton.vue"
@@ -55,6 +60,7 @@ const emit = defineEmits<{
 const triggerButton = ref<typeof IconButton | null>(null)
 const showDynamicValueModal = ref(false)
 const getCompletions = useStudioCompletions()
+const propertyLabel = computed(() => props.property?.getProps?.()?.label as string)
 
 const dynamicValue = ref("")
 watch(

--- a/frontend/src/components/DynamicStyleSetter.vue
+++ b/frontend/src/components/DynamicStyleSetter.vue
@@ -1,26 +1,17 @@
 <template>
-	<Dropdown
-		:options="[
-			{
-				label: 'Set Dynamic Value',
-				onClick: () => {
-					showDynamicValueModal = !showDynamicValueModal
-				},
-			},
-		]"
-	>
-		<IconButton
-			ref="dropdownTrigger"
-			:icon="LucideCirclePlus"
-			placement="left"
-			class="mr-1"
-			size="sm"
-			tabIndex="-1"
-		/>
-	</Dropdown>
+	<IconButton
+		ref="triggerButton"
+		:icon="LucideCirclePlus"
+		label="Set Dynamic Value"
+		tooltipPlacement="left"
+		class="mr-1"
+		size="sm"
+		tabIndex="-1"
+		@click="showDynamicValueModal = !showDynamicValueModal"
+	/>
 	<DraggablePopup
 		v-model="showDynamicValueModal"
-		:container="dropdownTrigger?.rootRef"
+		:container="triggerButton?.rootRef"
 		placement="middle-right"
 		:clickOutsideToClose="false"
 		:placementOffset="20"
@@ -45,7 +36,6 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue"
-import { Dropdown } from "frappe-ui"
 import Code from "@/components/Code.vue"
 import IconButton from "@/components/IconButton.vue"
 import Block from "@/utils/block"
@@ -59,7 +49,7 @@ const emit = defineEmits<{
 	(event: "update:modelValue", value: string): void
 }>()
 
-const dropdownTrigger = ref<typeof IconButton | null>(null)
+const triggerButton = ref<typeof IconButton | null>(null)
 const showDynamicValueModal = ref(false)
 const getCompletions = useStudioCompletions()
 

--- a/frontend/src/components/DynamicStyleSetter.vue
+++ b/frontend/src/components/DynamicStyleSetter.vue
@@ -27,8 +27,9 @@
 				:emitOnChange="true"
 				:completions="(context: CompletionContext) => getCompletions(context, block?.getCompletions())"
 			/>
-			<div class="mt-2 flex items-center justify-end gap-2">
-				<Button variant="solid" @click="setStyle">Set</Button>
+			<div class="mt-2 flex items-center justify-between gap-2">
+				<ErrorMessage v-if="error" :message="error" />
+				<Button class="ml-auto" variant="solid" @click="setStyle">Set</Button>
 			</div>
 		</template>
 	</DraggablePopup>
@@ -36,10 +37,12 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue"
+import { Button, ErrorMessage } from "frappe-ui"
 import Code from "@/components/Code.vue"
 import IconButton from "@/components/IconButton.vue"
 import Block from "@/utils/block"
 import { useStudioCompletions } from "@/utils/useStudioCompletions"
+import { getExpressionError } from "@/utils/parseCode"
 import type { CompletionContext } from "@codemirror/autocomplete"
 import type { BlockProperty } from "@/components/ComponentStyles.vue"
 import LucideCirclePlus from "~icons/lucide/circle-plus"
@@ -71,7 +74,14 @@ watch(
 	{ immediate: true, deep: true },
 )
 
+const error = ref("")
+watch(dynamicValue, () => (error.value = ""))
+
 const setStyle = () => {
+	// CSS values like var(--ink-red-5) must be quoted to be valid JS, flag them before saving
+	error.value = getExpressionError(dynamicValue.value) || ""
+	if (error.value) return
+
 	emit("update:modelValue", dynamicValue.value)
 	showDynamicValueModal.value = false
 }

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -90,6 +90,9 @@ export const STUDIO_COMPONENTS = [
 // Matches strings that are entirely wrapped in double curly braces, e.g., "{{ expression }}" (allows whitespace inside)
 export const DYNAMIC_EXPRESSION_REGEX = /^\{\{[\s\S]*\}\}$/
 
+// Matches every {{ ... }} expression in a string and captures its inner contents
+export const DYNAMIC_EXPRESSION_CONTENT_REGEX = /\{\{([\s\S]*?)\}\}/g
+
 // Match a double-quoted string and capture its inner content, including escaped chars.
 // This pattern safely captures the contents of a JSON-style double-quoted string,
 // preserving escaped sequences (e.g. \" or \\n) in the captured group.

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -191,11 +191,11 @@ export function getScriptError(code: string): ScriptSyntaxError | null {
 	}
 }
 
-// Validate the contents of every {{ ... }} in a value and return the first syntax error or null if all parse
+// Validate the contents of every {{ ... }} in a value and return the first problem, or null if all parse
 export function getExpressionError(value: string): string | null {
 	for (const match of value.matchAll(DYNAMIC_EXPRESSION_CONTENT_REGEX)) {
 		const expression = match[1].trim()
-		if (!expression) continue
+		if (!expression) return "Expression cannot be empty"
 
 		try {
 			const parsed = parseExpressionAt(expression, 0, { ecmaVersion: "latest" })

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -193,6 +193,10 @@ export function getScriptError(code: string): ScriptSyntaxError | null {
 
 // Validate the contents of every {{ ... }} in a value and return the first problem, or null if all parse
 export function getExpressionError(value: string): string | null {
+	const unmatchedBraces = value.replace(DYNAMIC_EXPRESSION_CONTENT_REGEX, "")
+	if (unmatchedBraces.includes("{{")) return "Missing closing '}}'"
+	if (unmatchedBraces.includes("}}")) return "Missing opening '{{'"
+
 	for (const match of value.matchAll(DYNAMIC_EXPRESSION_CONTENT_REGEX)) {
 		const expression = match[1].trim()
 		if (!expression) return "Expression cannot be empty"

--- a/frontend/src/utils/parseCode.ts
+++ b/frontend/src/utils/parseCode.ts
@@ -1,6 +1,7 @@
 import { parse, parseExpressionAt } from "acorn"
 import type { Node } from "acorn"
 import { LRUCache } from "@/utils/cache"
+import { DYNAMIC_EXPRESSION_CONTENT_REGEX } from "@/utils/constants"
 import { isRef, unref } from "vue"
 
 const fnCache = new LRUCache<boolean>(20)
@@ -188,6 +189,29 @@ export function getScriptError(code: string): ScriptSyntaxError | null {
 			column: error.loc?.column ?? 0,
 		}
 	}
+}
+
+// Validate the contents of every {{ ... }} in a value and return the first syntax error or null if all parse
+export function getExpressionError(value: string): string | null {
+	for (const match of value.matchAll(DYNAMIC_EXPRESSION_CONTENT_REGEX)) {
+		const expression = match[1].trim()
+		if (!expression) continue
+
+		try {
+			const parsed = parseExpressionAt(expression, 0, { ecmaVersion: "latest" })
+			const trailing = expression.slice(parsed.end)
+			if (trailing.trim()) return describeExpressionError("Unexpected token", trailing)
+		} catch (error: any) {
+			const message = error.message.replace(/\s*\(\d+:\d+\)$/, "")
+			return describeExpressionError(message, expression.slice(error.pos ?? 0))
+		}
+	}
+	return null
+}
+
+function describeExpressionError(message: string, remaining: string) {
+	const token = remaining.trim().split(/\s/)[0]?.slice(0, 20)
+	return token ? `${message} near '${token}'` : message
 }
 
 function walkAST(node: any, callback: (node: Node) => void) {


### PR DESCRIPTION
**Before**: 2 clicks to get to the dynamic value popup

<img width="1252" height="932" alt="image" src="https://github.com/user-attachments/assets/8e99063c-a7e8-4f2e-a5fb-4c6a27493345" />

**After**:

Show the Dynamic Value Selector directly on clicking the + button instead of opening a dropdown with only 1 option first
Also added a label for the actual style property being edited. Without it the popup might seem disorienting

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/930b0ebe-0a04-42b6-a861-15b036c56dda" />

Eval style expression and show an error instead of silently setting an invalid expression

<img width="3024" height="1720" alt="image" src="https://github.com/user-attachments/assets/d48b9c03-3be4-4a12-8a2e-124abf1b5bc8" />
