### PR TITLE
fix: slot scope doesn't get set when block is selected from the Layers panel

### DIFF
--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -242,6 +242,16 @@ const showComponent = computed(() => {
 const isHovered = ref(false)
 const isSelected = computed(() => canvasStore.activeCanvas?.selectedBlockIds?.has(props.block.componentId))
 
+watch(
+	[isSelected, () => slotScope?.value],
+	([selected, scope]) => {
+		if (selected && scope) {
+			props.block.setSlotScope(scope)
+		}
+	},
+	{ immediate: true },
+)
+
 const target = computed<HTMLElement | null>(() => {
 	if (!componentRef.value) return null
 	const root = getComponentRoot(componentRef)
@@ -294,9 +304,6 @@ const handleClick = (e: MouseEvent) => {
 	const domEvent = e instanceof Event ? e : null
 	const block = (domEvent && getClickedComponent(domEvent)) || props.block
 	canvasStore.activeCanvas?.selectBlock(block, domEvent)
-	if (slotScope?.value) {
-		block.setSlotScope(slotScope.value)
-	}
 
 	if (!domEvent) return
 

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -243,10 +243,12 @@ const isHovered = ref(false)
 const isSelected = computed(() => canvasStore.activeCanvas?.selectedBlockIds?.has(props.block.componentId))
 
 watch(
-	[isSelected, () => slotScope?.value],
-	([selected, scope]) => {
-		if (selected && scope) {
-			props.block.setSlotScope(scope)
+	isSelected,
+	(selected) => {
+		if (selected && slotScope?.value && !props.block.slotScope) {
+			props.block.setSlotScope(slotScope.value)
+		} else if (!selected && props.block.slotScope) {
+			props.block.setSlotScope(null)
 		}
 	},
 	{ immediate: true },
@@ -304,6 +306,9 @@ const handleClick = (e: MouseEvent) => {
 	const domEvent = e instanceof Event ? e : null
 	const block = (domEvent && getClickedComponent(domEvent)) || props.block
 	canvasStore.activeCanvas?.selectBlock(block, domEvent)
+	if (slotScope?.value) {
+		block.setSlotScope(slotScope.value)
+	}
 
 	if (!domEvent) return
 

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -707,7 +707,7 @@ class Block implements BlockOptions {
 	}
 
 	// scoped slots
-	setSlotScope(slotScope: SlotScope) {
+	setSlotScope(slotScope: SlotScope | null) {
 		// temporarily set the enclosing scoped slot props on selected block for autocompletions
 		this.slotScope = slotScope
 	}


### PR DESCRIPTION
Set it on selection instead of clicking on the canvas
Follow-up fix for https://github.com/frappe/studio/pull/200