### PR TITLE
fix: teleport editor elements to canvas's own overlay

### DIFF
--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -1,12 +1,7 @@
 <template>
 	<div ref="canvasContainer" @click="handleClick">
 		<slot name="header"></slot>
-		<div
-			class="overlay absolute"
-			:class="{ 'pointer-events-none': isOverDropZone }"
-			id="overlay"
-			ref="overlay"
-		/>
+		<div class="overlay absolute" :class="{ 'pointer-events-none': isOverDropZone }" ref="overlay" />
 		<Transition name="fade">
 			<div
 				class="absolute bottom-0 left-0 right-0 top-0 z-[19] grid w-full place-items-center bg-surface-gray-1"

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -86,7 +86,7 @@
 		/>
 	</template>
 
-	<teleport to="#overlay" v-if="canvasProps?.overlayElement">
+	<teleport :to="canvasProps.overlayElement" v-if="canvasProps?.overlayElement">
 		<!-- prettier-ignore -->
 		<ComponentEditor
 			v-if="loadEditor"


### PR DESCRIPTION
fragment mode showed duplicate editors while teleporting to the same overlay div