### PR TITLE
fix: get computed style of component that doesn't have block style configured

### DIFF
--- a/frontend/src/components/ComponentStyles.vue
+++ b/frontend/src/components/ComponentStyles.vue
@@ -144,7 +144,7 @@ const layoutSectionProperties = [
 						value: "grid",
 					},
 				],
-				modelValue: blockController.getStyle("display"),
+				modelValue: blockController.getRenderedStyle("display"),
 			}
 		},
 		searchKeyWords: "Layout, Display, Flex, Grid, Flexbox, Flex Box, FlexBox",

--- a/frontend/src/components/StudioCanvas.vue
+++ b/frontend/src/components/StudioCanvas.vue
@@ -381,6 +381,7 @@ defineExpose({
 	history,
 	rootComponent,
 	canvasProps,
+	canvasContainer,
 	// canvas utils
 	findBlock,
 	removeBlock,

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -441,14 +441,13 @@ class Block implements BlockOptions {
 	}
 
 	getRenderedElement(): HTMLElement | null {
-		const canvasStore = useCanvasStore()
-		const breakpoint = canvasStore.activeCanvas?.activeBreakpoint
-		const selector = `.__studio_component__[data-component-id="${this.componentId}"]`
-		if (breakpoint) {
-			const element = document.querySelector(`${selector}[data-breakpoint="${breakpoint}"]`)
-			if (element) return element as HTMLElement
-		}
-		return document.querySelector(selector) as HTMLElement | null
+		const activeCanvas = useCanvasStore().activeCanvas
+		const breakpoint = activeCanvas?.activeBreakpoint
+		if (!breakpoint) return null
+		const scope: ParentNode = activeCanvas?.canvasContainer || document
+		return scope.querySelector(
+			`.__studio_component__[data-component-id="${this.componentId}"][data-breakpoint="${breakpoint}"]`,
+		)
 	}
 
 	getPadding() {

--- a/frontend/src/utils/block.ts
+++ b/frontend/src/utils/block.ts
@@ -424,11 +424,31 @@ class Block implements BlockOptions {
 	}
 
 	isFlex() {
-		return this.getStyle("display") === "flex"
+		return this.getRenderedStyle("display") === "flex"
 	}
 
 	isGrid() {
-		return this.getStyle("display") === "grid"
+		return this.getRenderedStyle("display") === "grid"
+	}
+
+	// detect actual layout type directly from rendered element if not set in block styles
+	getRenderedStyle(style: styleProperty): StyleValue {
+		const configuredStyle = this.getStyle(style)
+		if (configuredStyle || typeof document === "undefined") return configuredStyle
+		const element = this.getRenderedElement()
+		if (!element) return undefined
+		return (getComputedStyle(element) as unknown as Record<string, StyleValue>)[style] || undefined
+	}
+
+	getRenderedElement(): HTMLElement | null {
+		const canvasStore = useCanvasStore()
+		const breakpoint = canvasStore.activeCanvas?.activeBreakpoint
+		const selector = `.__studio_component__[data-component-id="${this.componentId}"]`
+		if (breakpoint) {
+			const element = document.querySelector(`${selector}[data-breakpoint="${breakpoint}"]`)
+			if (element) return element as HTMLElement
+		}
+		return document.querySelector(selector) as HTMLElement | null
 	}
 
 	getPadding() {

--- a/frontend/src/utils/blockController.ts
+++ b/frontend/src/utils/blockController.ts
@@ -81,6 +81,17 @@ const blockController = {
 		});
 		return styleValue;
 	},
+	getRenderedStyle: (style: styleProperty) => {
+		let styleValue = "__initial__" as StyleValue;
+		canvasStore.activeCanvas?.selectedBlocks.forEach((block) => {
+			if (styleValue === "__initial__") {
+				styleValue = block.getRenderedStyle(style);
+			} else if (styleValue !== block.getRenderedStyle(style)) {
+				styleValue = "Mixed";
+			}
+		});
+		return styleValue;
+	},
 	setStyle: (style: styleProperty, value: StyleValue) => {
 		if (value === "unset") {
 			value = null


### PR DESCRIPTION
Useful to detect the layout type of blocks that get the flex/grid class from somewhere. Useful to show controls for styling flex/grid items