### PR TITLE
fix: components that run array operations on list resource data break during page setup

### DIFF
--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -55,7 +55,6 @@ const useCodeStore = defineStore("codeStore", () => {
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
-		resources.value = {}
 
 		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
 			const newResource = await getNewResource(resource, {
@@ -73,14 +72,16 @@ const useCodeStore = defineStore("codeStore", () => {
 
 		const resolvedResources = await Promise.all(resourcePromises)
 
+		const newResources: Record<string, any> = {}
 		resolvedResources.forEach((item) => {
-			resources.value[item.resource_name] = item.value
+			newResources[item.resource_name] = item.value
 			if (setResourceConfig) {
 				if (!item.value) return
-				resources.value[item.resource_name].resource_id = item.resource_id
-				resources.value[item.resource_name].resource_type = item.resource_type
+				newResources[item.resource_name].resource_id = item.resource_id
+				newResources[item.resource_name].resource_type = item.resource_type
 			}
 		})
+		resources.value = newResources
 	}
 
 	async function setPageVariables(page: StudioPage) {
@@ -462,7 +463,10 @@ const useCodeStore = defineStore("codeStore", () => {
 				if (resource.sort_field) {
 					params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
 				}
-				return createListResource(params)
+				let listResource = createListResource(params)
+				// initialize listResource.data to an empty array to avoid undefined errors in the UI, frappe-ui sets data to null by default
+				listResource.data = []
+				return listResource
 			case "API Resource":
 				return createResource({
 					url: resource.url,


### PR DESCRIPTION
**Before**:

<img width="1512" height="855" alt="image" src="https://github.com/user-attachments/assets/dfc95760-295d-4de4-bf8a-e2041d9d92b0" />


**After**:
- Overwrite resources after resolution
- Initialize `listResource.data` to `[]`
<img width="1512" height="855" alt="image" src="https://github.com/user-attachments/assets/8796aaab-1f6e-476f-b457-92543038922a" />
