### PR TITLE
fix: lucide icons as class names don't get resolved

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -46,7 +46,7 @@ export default {
 		"./node_modules/frappe-ui/frappe/**/*.{vue,js,ts,jsx,tsx}",
 		"../node_modules/frappe-ui/frappe/**/*.{vue,js,ts,jsx,tsx}",
 		"../../frappe/ui/src/**/*.{vue,js,ts,jsx,tsx}",
-		"../../*/studio/**/*.{vue,js,ts,jsx,tsx}",
+		"../../*/studio/**/*.{vue,js,ts,jsx,tsx,json}",
 		"!../../*/studio/**/node_modules/**",
 	],
 	theme: {

--- a/frontend/vite/studioFolderWatcher.js
+++ b/frontend/vite/studioFolderWatcher.js
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs"
+import { isCSSRequest } from "vite"
 
 /**
  * Vite plugin for editing exported apps' `<app>/studio/` folders from Studio.
@@ -69,8 +70,12 @@ function studioFolderWatcher(appsDir) {
 		hotUpdate({ type, file, modules }) {
 			if (!isUnderStudioFolder(file)) return
 			if (type !== "update") return []
-			// skip .json files (exporting them leads to a full reload)
-			if (file.endsWith(".json")) return []
+			// Exported page JSON is a tailwind content source (icon class names live in
+			// page data), so hot-update the stylesheets that scan it (their importers) —
+			// but drop everything else, since exporting json otherwise leads to a full reload.
+			if (file.endsWith(".json")) {
+				return modules.flatMap((mod) => [...mod.importers].filter((imp) => isCSSRequest(imp.url)))
+			}
 			if (modules.length > 0) return
 			return []
 		},


### PR DESCRIPTION
**Before:**

<img width="1512" height="855" alt="image" src="https://github.com/user-attachments/assets/9f195441-49af-4f96-aca8-0ed98e67e005" />


**After:**

<img width="1512" height="855" alt="image" src="https://github.com/user-attachments/assets/f9086880-f6f2-4602-953b-445ca10cbb84" />
