### PR TITLE
perf: Improve rendering & data handling on route param changes

### DIFF
--- a/frontend/src/components/DataPanel.vue
+++ b/frontend/src/components/DataPanel.vue
@@ -7,7 +7,12 @@
 					:key="resource_name"
 					class="group/item flex flex-row items-center justify-between"
 				>
-					<ObjectBrowser :object="resource" :name="resource_name" class="-ml-[0.9rem] overflow-hidden" />
+					<div class="-ml-[0.9rem] flex items-center gap-1 overflow-hidden">
+						<ObjectBrowser :object="resource" :name="resource_name" />
+						<Tooltip v-if="!resource" text="No matching document found for the current filters">
+							<span class="lucide-alert-circle h-[14px] w-[14px] cursor-pointer text-ink-amber-6" />
+						</Tooltip>
+					</div>
 					<ItemActions
 						class="-mt-1 self-start"
 						:menuOptions="getResourceMenu(resource, resource_name)"
@@ -133,7 +138,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue"
-import { Dialog } from "frappe-ui"
+import { Dialog, Tooltip } from "frappe-ui"
 import useStudioStore from "@/stores/studioStore"
 import useCodeStore from "@/stores/codeStore"
 import CollapsibleSection from "@/components/CollapsibleSection.vue"

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -24,18 +24,21 @@ const codeStore = useCodeStore()
 const page = ref<StudioPage | null>(null)
 
 const rootBlock = ref<Block | null>(null)
+let loadedPath: string | null = null
+
+async function handleRouteChange() {
+	const currentPath = resolveCurrentPath()
+	if (currentPath && currentPath === loadedPath && page.value) {
+		// param-only navigation (/articles/a -> /articles/b): same page, new params.
+		// Keep the block tree mounted; just re-evaluate page data against the new route.
+		await setPageData()
+	} else {
+		await loadPage()
+	}
+}
 
 async function loadPage() {
-	let { pageRoute } = route.params as { pageRoute: string[] }
-	const isDynamic = route.meta?.isDynamic
-
-	let currentPath = "/"
-	if (isDynamic) {
-		currentPath = route.matched?.[0]?.path
-	} else if (pageRoute) {
-		currentPath = pageRoute[0]
-	}
-
+	const currentPath = resolveCurrentPath()
 	if (!currentPath) {
 		rootBlock.value = null
 		return
@@ -43,8 +46,7 @@ async function loadPage() {
 
 	page.value = await findPageWithRoute(window.app_name, currentPath)
 	if (!page.value) return
-	await store.setPageData(page.value)
-	await codeStore.setPageScript(page.value, Boolean(page.value.is_standard))
+	await setPageData()
 
 	const blocks = window.is_preview
 		? JSON.parse(page.value?.draft_blocks || page.value?.blocks)
@@ -52,9 +54,23 @@ async function loadPage() {
 	if (blocks) {
 		rootBlock.value = getBlockInstance(blocks[0])
 	}
+	loadedPath = currentPath
 }
 
-watch(() => route.path, loadPage, { immediate: true })
+async function setPageData() {
+	await store.setPageData(page.value!)
+	await codeStore.setPageScript(page.value!, Boolean(page.value!.is_standard))
+}
+
+function resolveCurrentPath(): string | undefined {
+	const { pageRoute } = route.params as { pageRoute: string[] }
+	// registered page routes carry isDynamic meta; their record path is the page's route pattern
+	if (route.meta?.isDynamic) return route.matched?.[0]?.path
+	if (pageRoute) return pageRoute[0]
+	return "/"
+}
+
+watch(() => route.path, handleRouteChange, { immediate: true })
 
 if (window.is_preview) useLivePreview(page, loadPage)
 

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -25,6 +25,7 @@ const page = ref<StudioPage | null>(null)
 
 const rootBlock = ref<Block | null>(null)
 let loadedPath: string | null = null
+let loadToken = 0
 
 async function handleRouteChange() {
 	const currentPath = resolveCurrentPath()
@@ -37,16 +38,19 @@ async function handleRouteChange() {
 }
 
 async function loadPage() {
+	const token = ++loadToken
 	const currentPath = resolveCurrentPath()
 	if (!currentPath) {
 		rootBlock.value = null
 		return
 	}
+	codeStore.teardownPage()
 
 	page.value = await findPageWithRoute(window.app_name, currentPath)
-	if (!page.value) return
+	if (token !== loadToken || !page.value) return
 	await store.setPageData(page.value)
 	await codeStore.setPageScript(page.value, Boolean(page.value.is_standard))
+	if (token !== loadToken) return
 
 	const blocks = window.is_preview
 		? JSON.parse(page.value?.draft_blocks || page.value?.blocks)

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -59,7 +59,7 @@ async function loadPage() {
 
 function resolveCurrentPath(): string | undefined {
 	const { pageRoute } = route.params as { pageRoute: string[] }
-	// registered page routes carry isDynamic meta; their record path is the page's route pattern
+	// registered page routes carry isDynamic meta
 	if (route.meta?.isDynamic) return route.matched?.[0]?.path
 	if (pageRoute) return pageRoute[0]
 	return "/"

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -24,19 +24,18 @@ const codeStore = useCodeStore()
 const page = ref<StudioPage | null>(null)
 
 const rootBlock = ref<Block | null>(null)
-let loadedPath: string | null = null
-let loadToken = 0
 
+let loadedPath: string | null = null
 async function handleRouteChange() {
 	const currentPath = resolveCurrentPath()
 	if (currentPath && currentPath === loadedPath && page.value) {
-		// param-only navigation (/articles/a -> /articles/b): everything stays mounted —
-		// codeStore's resource watchers re-evaluate route-dependent filters/params and reload themselves
+		// param-only navigation (/articles/a -> /articles/b)
 		return
 	}
 	await loadPage()
 }
 
+let loadToken = 0
 async function loadPage() {
 	const token = ++loadToken
 	const currentPath = resolveCurrentPath()

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -30,7 +30,7 @@ async function handleRouteChange() {
 	const currentPath = resolveCurrentPath()
 	if (currentPath && currentPath === loadedPath && page.value) {
 		// param-only navigation (/articles/a -> /articles/b): everything stays mounted —
-		// resources with route-dependent inputs re-evaluate and reload themselves (codeStore live bindings)
+		// codeStore's resource watchers re-evaluate route-dependent filters/params and reload themselves
 		return
 	}
 	await loadPage()

--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -29,12 +29,11 @@ let loadedPath: string | null = null
 async function handleRouteChange() {
 	const currentPath = resolveCurrentPath()
 	if (currentPath && currentPath === loadedPath && page.value) {
-		// param-only navigation (/articles/a -> /articles/b): same page, new params.
-		// Keep the block tree mounted; just re-evaluate page data against the new route.
-		await setPageData()
-	} else {
-		await loadPage()
+		// param-only navigation (/articles/a -> /articles/b): everything stays mounted —
+		// resources with route-dependent inputs re-evaluate and reload themselves (codeStore live bindings)
+		return
 	}
+	await loadPage()
 }
 
 async function loadPage() {
@@ -46,7 +45,8 @@ async function loadPage() {
 
 	page.value = await findPageWithRoute(window.app_name, currentPath)
 	if (!page.value) return
-	await setPageData()
+	await store.setPageData(page.value)
+	await codeStore.setPageScript(page.value, Boolean(page.value.is_standard))
 
 	const blocks = window.is_preview
 		? JSON.parse(page.value?.draft_blocks || page.value?.blocks)
@@ -55,11 +55,6 @@ async function loadPage() {
 		rootBlock.value = getBlockInstance(blocks[0])
 	}
 	loadedPath = currentPath
-}
-
-async function setPageData() {
-	await store.setPageData(page.value!)
-	await codeStore.setPageScript(page.value!, Boolean(page.value!.is_standard))
 }
 
 function resolveCurrentPath(): string | undefined {

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -255,6 +255,9 @@ async function loadPage(appID: string, pageID: string) {
 	try {
 		await store.setApp(appID)
 		await store.setPage(pageID)
+	} catch (error) {
+		console.error(`Failed to load page ${pageID}`, error)
+		toast.error("Failed to load the page")
 	} finally {
 		loadingPageID = null
 	}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -16,6 +16,8 @@ const useAppStore = defineStore("appStore", () => {
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page
+		// stop the old page's resource input watchers before the variables reset, else they fire spurious reloads
+		codeStore.disposeResourceInputs()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page)
 	}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -16,7 +16,6 @@ const useAppStore = defineStore("appStore", () => {
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page
-		// stop the old page's resource watchers before the variables reset, else they fire spurious reloads
 		codeStore.stopResourceWatchers()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page)

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -16,8 +16,8 @@ const useAppStore = defineStore("appStore", () => {
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page
-		// stop the old page's resource input watchers before the variables reset, else they fire spurious reloads
-		codeStore.disposeResourceInputs()
+		// stop the old page's resource watchers before the variables reset, else they fire spurious reloads
+		codeStore.stopResourceWatchers()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page)
 	}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -16,7 +16,6 @@ const useAppStore = defineStore("appStore", () => {
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page
-		codeStore.stopResourceWatchers()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page)
 	}

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -110,7 +110,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		const params: any = {
 			doctype: resource.document_type,
 			fields: fields.length ? fields : "*",
-			filters: evaluateAndWatch(
+			filters: useDynamicParams(
 				() => getEvaluatedFilters(resource.filters),
 				(filters) => {
 					listResource.update({ filters })
@@ -135,7 +135,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		const apiResource = createResource({
 			url: resource.url,
 			method: resource.method,
-			params: evaluateAndWatch(
+			params: useDynamicParams(
 				() => getAPIParams(resource.params),
 				(params) => {
 					apiResource.update({ params })
@@ -150,18 +150,16 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	const addDocumentResource = async (resource: DocumentResource, pageResources: Record<string, any>) => {
-		const createDoc = (docname?: string) =>
-			createDocumentResource({
-				doctype: resource.document_type,
-				name: docname,
-				auto: resource.auto,
-				...getTransforms(resource),
-				...getSuccessErrorHandlers(resource),
-				...getWhitelistedMethods(resource),
-			})
+		const params = {
+			doctype: resource.document_type,
+			auto: resource.auto,
+			...getTransforms(resource),
+			...getSuccessErrorHandlers(resource),
+			...getWhitelistedMethods(resource),
+		}
 
 		if (!resource.fetch_document_using_filters || !resource.filters) {
-			pageResources[resource.resource_name] = createDoc(resource.document_name)
+			pageResources[resource.resource_name] = createDocumentResource({ ...params, name: resource.document_name })
 			return
 		}
 
@@ -177,7 +175,7 @@ const useCodeStore = defineStore("codeStore", () => {
 				pageResources[resource.resource_name] = undefined
 				return
 			}
-			const doc = createDoc(docname) as any
+			const doc = createDocumentResource({ ...params, name: docname })
 			// carry over the editor's config stamps (see setResourceConfig in setPageResources)
 			const oldDoc = pageResources[resource.resource_name]
 			if (oldDoc?.resource_id) {
@@ -187,20 +185,20 @@ const useCodeStore = defineStore("codeStore", () => {
 			pageResources[resource.resource_name] = doc
 		}
 
-		const filters = evaluateAndWatch(() => getEvaluatedFilters(resource.filters) || {}, loadDoc)
+		const filters = useDynamicParams(() => getEvaluatedFilters(resource.filters) || {}, loadDoc)
 		await loadDoc(filters)
 	}
 
-	// Evaluate a resource's dynamic input ({{ }} filters/params) now, and call onChange whenever a
-	// route/variable change alters the result. Watching the serialized value keeps context churn
-	// that evaluates to the same input from refetching the resource.
-	function evaluateAndWatch<T>(evaluate: () => T, onChange: (value: T) => void): T {
+	// Evaluate a resource's dynamic input ({{ }} filters/params) and return the initial value,
+	// then call onChange whenever a route/variable change alters the result
+	function useDynamicParams<T>(evaluate: () => T, onChange: (value: T) => void): T {
+		const evaluated = computed(evaluate)
 		const stop = watch(
-			() => JSON.stringify(evaluate()),
-			() => onChange(evaluate()),
+			() => JSON.stringify(evaluated.value),
+			() => onChange(evaluated.value),
 		)
 		resourceWatchers.push(stop)
-		return evaluate()
+		return evaluated.value
 	}
 
 	const getEvaluatedFilters = (filters: Filters | null = null) => {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -596,7 +596,11 @@ const useCodeStore = defineStore("codeStore", () => {
 		async function loadDoc(currentFilters: Filters) {
 			const request = ++latestRequest
 			const docname = await resolveDocnameFromFilters(resource, currentFilters)
-			if (request !== latestRequest || !docname) return
+			if (request !== latestRequest) return
+			if (!docname) {
+				pageResources[resource.resource_name] = undefined
+				return
+			}
 			const doc = createDoc(docname) as any
 			// carry over the editor's config stamps (see setResourceConfig in setPageResources)
 			const oldDoc = pageResources[resource.resource_name]

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -51,6 +51,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	const currentPageName = ref<string | null>(null)
 	let pageScriptScope: EffectScope | null = null
 	let resourceWatchers: WatchStopHandle[] = []
+	let pendingResources: Record<string, any> | null = null
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
@@ -62,31 +63,27 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
 		stopResourceWatchers()
+		// Each load uses its own map, so old async updates cannot change the current page resources.
+		const pageResources = reactive({}) as Record<string, any>
+		pendingResources = pageResources
+
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
 
-		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
-			const newResource = await getNewResource(resource)
-			return {
-				resource_name: resource.resource_name,
-				value: newResource,
-				resource_id: resource.resource_id,
-				resource_type: resource.resource_type,
-			}
-		})
+		await Promise.all(
+			studioPageResources.data.map(async (resource: Resource) => {
+				await addPageResource(resource, pageResources)
+				const newResource = pageResources[resource.resource_name]
+				if (setResourceConfig && newResource) {
+					newResource.resource_id = resource.resource_id
+					newResource.resource_type = resource.resource_type
+				}
+			}),
+		)
 
-		const resolvedResources = await Promise.all(resourcePromises)
-
-		const newResources: Record<string, any> = {}
-		resolvedResources.forEach((item) => {
-			newResources[item.resource_name] = item.value
-			if (setResourceConfig) {
-				if (!item.value) return
-				newResources[item.resource_name].resource_id = item.resource_id
-				newResources[item.resource_name].resource_type = item.resource_type
-			}
-		})
-		resources.value = newResources
+		if (pendingResources === pageResources) {
+			resources.value = pageResources
+		}
 	}
 
 	async function setPageVariables(page: StudioPage) {
@@ -482,14 +479,16 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	}
 
-	function getNewResource(resource: Resource) {
+	async function addPageResource(resource: Resource, pageResources: Record<string, any>) {
 		switch (resource.resource_type) {
 			case "Document":
-				return getDocumentResource(resource)
+				return addDocumentResource(resource, pageResources)
 			case "Document List":
-				return getListResource(resource)
+				pageResources[resource.resource_name] = getListResource(resource)
+				break
 			case "API Resource":
-				return getAPIResource(resource)
+				pageResources[resource.resource_name] = getAPIResource(resource)
+				break
 		}
 	}
 
@@ -574,7 +573,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		return evaluated
 	}
 
-	const getDocumentResource = async (resource: DocumentResource) => {
+	const addDocumentResource = async (resource: DocumentResource, pageResources: Record<string, any>) => {
 		const createDoc = (docname?: string) =>
 			createDocumentResource({
 				doctype: resource.document_type,
@@ -586,40 +585,30 @@ const useCodeStore = defineStore("codeStore", () => {
 			})
 
 		if (!resource.fetch_document_using_filters || !resource.filters) {
-			return createDoc(resource.document_name)
+			pageResources[resource.resource_name] = createDoc(resource.document_name)
+			return
 		}
 
-		// the docname can't change on an existing document resource (frappe-ui caches them by
-		// doctype+name), so a filter change means re-resolving the docname and replacing the resource
+		// The docname can't change on an existing document resource (frappe-ui caches them by
+		// doctype+name), so a filter change means re-resolving the docname and replacing the entry.
+		// loadDoc is the entry's only writer; latestRequest keeps only the newest lookup's result.
 		let latestRequest = 0
-		const filters = evaluateAndWatch(
-			() => getEvaluatedFilters(resource.filters) || {},
-			async (newFilters) => {
-				const request = ++latestRequest
-				const docname = await resolveDocnameFromFilters(resource, newFilters)
-				const outdated = request !== latestRequest
-				if (outdated || !docname) return
-				replaceDocumentResource(resource.resource_name, createDoc(docname))
-			},
-		)
-
-		// If the filters changed while this initial lookup was pending, re-resolve
-		let docname = await resolveDocnameFromFilters(resource, filters)
-		if (latestRequest > 0) {
-			docname = await resolveDocnameFromFilters(resource, getEvaluatedFilters(resource.filters) || {})
+		async function loadDoc(currentFilters: Filters) {
+			const request = ++latestRequest
+			const docname = await resolveDocnameFromFilters(resource, currentFilters)
+			if (request !== latestRequest || !docname) return
+			const doc = createDoc(docname) as any
+			// carry over the editor's config stamps (see setResourceConfig in setPageResources)
+			const oldDoc = pageResources[resource.resource_name]
+			if (oldDoc?.resource_id) {
+				doc.resource_id = oldDoc.resource_id
+				doc.resource_type = oldDoc.resource_type
+			}
+			pageResources[resource.resource_name] = doc
 		}
-		return createDoc(docname)
-	}
 
-	function replaceDocumentResource(resourceName: string, newResource: any) {
-		if (!newResource) return
-		// carry over the editor's config stamps (see setResourceConfig in setPageResources)
-		const oldResource = resources.value[resourceName] as any
-		if (oldResource?.resource_id) {
-			newResource.resource_id = oldResource.resource_id
-			newResource.resource_type = oldResource.resource_type
-		}
-		resources.value[resourceName] = newResource
+		const filters = evaluateAndWatch(() => getEvaluatedFilters(resource.filters) || {}, loadDoc)
+		await loadDoc(filters)
 	}
 
 	const resolveDocnameFromFilters = async (resource: DocumentResource, filters: Filters) => {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia"
 import {
 	ref, computed, watch, watchEffect, reactive, toRef, toRefs, unref,
 	isRef, isReactive, shallowRef, readonly, markRaw, nextTick, effectScope,
-	type ComputedRef, type EffectScope, h,
+	type ComputedRef, type EffectScope, type WatchStopHandle, h,
 } from "vue"
 import { watchDebounced } from "@vueuse/core"
 import { createDocumentResource, createListResource, createResource, call } from "frappe-ui"
@@ -50,7 +50,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	const pageScriptError = ref<string | null>(null)
 	const currentPageName = ref<string | null>(null)
 	let pageScriptScope: EffectScope | null = null
-	let resourceInputsScope: EffectScope | null = null
+	let resourceWatchers: WatchStopHandle[] = []
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
@@ -61,10 +61,9 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
-		disposeResourceInputs()
+		stopResourceWatchers()
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
-		resourceInputsScope = effectScope(true)
 
 		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
 			const newResource = await getNewResource(resource)
@@ -247,52 +246,48 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	})
 
-	// Base context for every script scope — event/success/error handlers, function-value props, and page-script setup.
-	// Resources and route go in as live handles: page-script setup destructures its context once and
-	// keeps running across navigations, but a docname change swaps the document resource object and
-	// vue-router makes a new route object per navigation — a plain spread would freeze the captures.
 	const scriptContext = computed(() => {
 		const variablesRefs = toRefs(variables.value)
+		// Resources and currentRoute are proxies so scripts can destructure them once and still see the current values
 		return {
 			...variablesRefs,
-			...getResourceHandles(),
+			...currentResourceProxies(),
 			...pageScriptBindings.value,
 			...globalUtils,
-			route: liveRoute,
+			route: currentRoute,
 			router: routerObject.value,
 		}
 	})
 
-	const resourceHandles: Record<string, any> = {}
+	const resourceProxies: Record<string, any> = {}
 
-	function getResourceHandles() {
-		const handles: Record<string, any> = {}
+	function currentResourceProxies() {
+		const proxies: Record<string, any> = {}
 		for (const name in resources.value) {
-			resourceHandles[name] ??= createLiveHandle(() => resources.value[name])
-			handles[name] = resourceHandles[name]
+			resourceProxies[name] ??= proxyToCurrent(() => resources.value[name])
+			proxies[name] = resourceProxies[name]
 		}
-		return handles
+		return proxies
 	}
 
-	const liveRoute = createLiveHandle(() => unref(routeObject.value))
+	const currentRoute = proxyToCurrent(() => unref(routeObject.value))
 
-	// A stable object that forwards every access to the current target, so script closures created
-	// at setup stay live. Targets are frappe-ui resources / route objects whose methods are
-	// closures, not `this`-bound — values are returned as-is.
-	function createLiveHandle(getTarget: () => any) {
+	// An object that reads/writes every property on whatever getCurrent() returns right now.
+	// Methods come back as-is: frappe-ui resources and route objects use closures, not `this`.
+	function proxyToCurrent(getCurrent: () => any) {
 		return new Proxy(
 			{},
 			{
-				get: (_, key) => getTarget()?.[key],
-				has: (_, key) => key in (getTarget() || {}),
+				get: (_, key) => getCurrent()?.[key],
+				has: (_, key) => key in (getCurrent() || {}),
 				set: (_, key, value) => {
-					const target = getTarget()
+					const target = getCurrent()
 					if (target) target[key] = value
 					return true
 				},
-				ownKeys: () => Reflect.ownKeys(getTarget() || {}),
+				ownKeys: () => Reflect.ownKeys(getCurrent() || {}),
 				getOwnPropertyDescriptor: (_, key) => {
-					const target = getTarget()
+					const target = getCurrent()
 					if (target && key in target) return { enumerable: true, configurable: true, value: target[key] }
 				},
 			},
@@ -497,28 +492,21 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	}
 
-	function disposeResourceInputs() {
-		resourceInputsScope?.stop()
-		resourceInputsScope = null
+	function stopResourceWatchers() {
+		resourceWatchers.forEach((stop) => stop())
+		resourceWatchers = []
 	}
 
-	// Live binding for a dynamic resource input: the computed evaluates {{ }} expressions against the
-	// live context (route/variables/other resources), the watch pushes value changes into the created
-	// resource — createResource-style utilities take plain values, not getters, so we bridge ourselves.
-	// Returns the initial value for resource creation.
-	function bindResourceInput<T>(evaluate: () => T, apply: (value: T) => void): T {
-		const setup = () => {
-			const input = computed(evaluate)
-			let lastValue = JSON.stringify(input.value)
-			watch(input, (value) => {
-				const serialized = JSON.stringify(value)
-				if (serialized === lastValue) return
-				lastValue = serialized
-				apply(value)
-			})
-			return input.value
-		}
-		return resourceInputsScope ? (resourceInputsScope.run(setup) as T) : setup()
+	// Evaluate a resource's dynamic input ({{ }} filters/params) now, and call onChange whenever a
+	// route/variable change alters the result. Watching the serialized value keeps context churn
+	// that evaluates to the same input from refetching the resource.
+	function evaluateAndWatch<T>(evaluate: () => T, onChange: (value: T) => void): T {
+		const stop = watch(
+			() => JSON.stringify(evaluate()),
+			() => onChange(evaluate()),
+		)
+		resourceWatchers.push(stop)
+		return evaluate()
 	}
 
 	function getListResource(resource: DocumentListResource) {
@@ -530,7 +518,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		const params: any = {
 			doctype: resource.document_type,
 			fields: fields.length ? fields : "*",
-			filters: bindResourceInput(
+			filters: evaluateAndWatch(
 				() => getEvaluatedFilters(resource.filters),
 				(filters) => {
 					listResource.update({ filters })
@@ -555,7 +543,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		const apiResource = createResource({
 			url: resource.url,
 			method: resource.method,
-			params: bindResourceInput(
+			params: evaluateAndWatch(
 				() => getAPIParams(resource.params),
 				(params) => {
 					apiResource.update({ params })
@@ -600,23 +588,25 @@ const useCodeStore = defineStore("codeStore", () => {
 			return createDoc(resource.document_name)
 		}
 
-		let resolveToken = 0
-		const filters = bindResourceInput(
+		// the docname can't change on an existing document resource (frappe-ui caches them by
+		// doctype+name), so a filter change means re-resolving the docname and replacing the resource
+		let latestRequest = 0
+		const filters = evaluateAndWatch(
 			() => getEvaluatedFilters(resource.filters) || {},
 			async (newFilters) => {
-				const token = ++resolveToken
+				const request = ++latestRequest
 				const docname = await resolveDocnameFromFilters(resource, newFilters)
-				if (token !== resolveToken || !docname) return
-				// createDocumentResource caches by doctype+name, so an unchanged docname swaps in the same instance
-				swapPageResource(resource.resource_name, createDoc(docname))
+				const outdated = request !== latestRequest
+				if (outdated || !docname) return
+				replaceDocumentResource(resource.resource_name, createDoc(docname))
 			},
 		)
 		return createDoc(await resolveDocnameFromFilters(resource, filters))
 	}
 
-	// a docname change means a new document resource; carry over the editor's config stamps
-	function swapPageResource(resourceName: string, newResource: any) {
+	function replaceDocumentResource(resourceName: string, newResource: any) {
 		if (!newResource) return
+		// carry over the editor's config stamps (see setResourceConfig in setPageResources)
 		const oldResource = resources.value[resourceName] as any
 		if (oldResource?.resource_id) {
 			newResource.resource_id = oldResource.resource_id
@@ -741,7 +731,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		// resources
 		resources,
 		setPageResources,
-		disposeResourceInputs,
+		stopResourceWatchers,
 		// variables
 		variables,
 		setPageVariables,

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -69,6 +69,8 @@ const useCodeStore = defineStore("codeStore", () => {
 
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
+		// a newer load claimed the slot during the await — don't arm watchers for a page that won't install
+		if (pendingResources !== pageResources) return
 
 		await Promise.all(
 			studioPageResources.data.map(async (resource: Resource) => {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -60,6 +60,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		routerObject.value = router
 	}
 
+	// RESOURCES
 	let pendingResources: Record<string, any> | null = null
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
 		stopResourceWatchers()
@@ -69,7 +70,6 @@ const useCodeStore = defineStore("codeStore", () => {
 
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
-		// a newer load claimed the slot during the await — don't arm watchers for a page that won't install
 		if (pendingResources !== pageResources) return
 
 		await Promise.all(
@@ -88,6 +88,235 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	}
 
+	async function addPageResource(resource: Resource, pageResources: Record<string, any>) {
+		switch (resource.resource_type) {
+			case "Document":
+				return addDocumentResource(resource, pageResources)
+			case "Document List":
+				pageResources[resource.resource_name] = getListResource(resource)
+				break
+			case "API Resource":
+				pageResources[resource.resource_name] = getAPIResource(resource)
+				break
+		}
+	}
+
+	function getListResource(resource: DocumentListResource) {
+		let fields = []
+		if ("fields" in resource && typeof resource.fields === "string") {
+			fields = JSON.parse(resource.fields)
+		}
+
+		const params: any = {
+			doctype: resource.document_type,
+			fields: fields.length ? fields : "*",
+			filters: evaluateAndWatch(
+				() => getEvaluatedFilters(resource.filters),
+				(filters) => {
+					listResource.update({ filters })
+					if (listResource.auto) listResource.reload()
+				},
+			),
+			pageLength: resource.limit,
+			auto: resource.auto,
+			...getTransforms(resource),
+			...getSuccessErrorHandlers(resource),
+		}
+		if (resource.sort_field) {
+			params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
+		}
+		const listResource = createListResource(params)
+		// initialize listResource.data to an empty array to avoid undefined errors in the UI, frappe-ui sets data to null by default
+		listResource.data = []
+		return listResource
+	}
+
+	function getAPIResource(resource: APIResource) {
+		const apiResource = createResource({
+			url: resource.url,
+			method: resource.method,
+			params: evaluateAndWatch(
+				() => getAPIParams(resource.params),
+				(params) => {
+					apiResource.update({ params })
+					if (apiResource.auto) apiResource.reload()
+				},
+			),
+			auto: resource.auto,
+			...getTransforms(resource),
+			...getSuccessErrorHandlers(resource),
+		})
+		return apiResource
+	}
+
+	const addDocumentResource = async (resource: DocumentResource, pageResources: Record<string, any>) => {
+		const createDoc = (docname?: string) =>
+			createDocumentResource({
+				doctype: resource.document_type,
+				name: docname,
+				auto: resource.auto,
+				...getTransforms(resource),
+				...getSuccessErrorHandlers(resource),
+				...getWhitelistedMethods(resource),
+			})
+
+		if (!resource.fetch_document_using_filters || !resource.filters) {
+			pageResources[resource.resource_name] = createDoc(resource.document_name)
+			return
+		}
+
+		// The docname can't change on an existing document resource (frappe-ui caches them by
+		// doctype+name), so a filter change means re-resolving the docname and replacing the entry.
+		// loadDoc is the entry's only writer; latestRequest keeps only the newest lookup's result.
+		let latestRequest = 0
+		async function loadDoc(currentFilters: Filters) {
+			const request = ++latestRequest
+			const docname = await resolveDocnameFromFilters(resource, currentFilters)
+			if (request !== latestRequest) return
+			if (!docname) {
+				pageResources[resource.resource_name] = undefined
+				return
+			}
+			const doc = createDoc(docname) as any
+			// carry over the editor's config stamps (see setResourceConfig in setPageResources)
+			const oldDoc = pageResources[resource.resource_name]
+			if (oldDoc?.resource_id) {
+				doc.resource_id = oldDoc.resource_id
+				doc.resource_type = oldDoc.resource_type
+			}
+			pageResources[resource.resource_name] = doc
+		}
+
+		const filters = evaluateAndWatch(() => getEvaluatedFilters(resource.filters) || {}, loadDoc)
+		await loadDoc(filters)
+	}
+
+	// Evaluate a resource's dynamic input ({{ }} filters/params) now, and call onChange whenever a
+	// route/variable change alters the result. Watching the serialized value keeps context churn
+	// that evaluates to the same input from refetching the resource.
+	function evaluateAndWatch<T>(evaluate: () => T, onChange: (value: T) => void): T {
+		const stop = watch(
+			() => JSON.stringify(evaluate()),
+			() => onChange(evaluate()),
+		)
+		resourceWatchers.push(stop)
+		return evaluate()
+	}
+
+	const getEvaluatedFilters = (filters: Filters | null = null) => {
+		if (!filters) return
+		if (typeof filters === "string") {
+			filters = JSON.parse(filters)
+		}
+
+		const evaluatedFilters: Filters = {}
+
+		for (const key in filters) {
+			let value = Array.isArray(filters[key]) ? filters[key][1] : filters[key]
+
+			if (isDynamicValue(value)) {
+				// null ?? undefined → undefined, so nullish filters get dropped on serialization
+				evaluatedFilters[key] = getDynamicValue(value, {}) ?? undefined
+			} else {
+				evaluatedFilters[key] = value
+			}
+		}
+
+		return evaluatedFilters
+	}
+
+	function getAPIParams(params: Record<string, any> | string | null = null) {
+		if (!params) return null
+		if (typeof params === "string") {
+			params = JSON.parse(params)
+		}
+		// evaluate on a copy: evaluation re-runs on every context change and must not bake values into the config
+		const evaluated: Record<string, any> = { ...(params as Record<string, any>) }
+		Object.entries(evaluated).forEach(([key, value]) => {
+			if (isDynamicValue(value)) {
+				// null ?? undefined → undefined, so nullish params get dropped on serialization
+				evaluated[key] = getDynamicValue(value, {}) ?? undefined
+			}
+		})
+		return evaluated
+	}
+
+	const resolveDocnameFromFilters = async (resource: DocumentResource, filters: Filters) => {
+		// the common `name = {{ route.params.id }}` case resolves to the docname itself — no server lookup needed
+		const keys = Object.keys(filters)
+		if (keys.length === 1 && keys[0] === "name") {
+			return filters.name
+		}
+		// other filters (e.g. category = tech) need a lookup for one matching doc's name
+		const doc = await call("frappe.client.get_value", {
+			doctype: resource.document_type,
+			fieldname: "name",
+			filters,
+		})
+		return doc?.name
+	}
+
+	const getTransforms = (resource: Resource) => {
+		if (!resource.transform) return {}
+		return {
+			transform: (data: any) => {
+				try {
+					const context = { ...scriptContext.value, data }
+					const transformFn = new Function(
+						"ctx",
+						`with(ctx) {
+							${resource.transform}
+							return transform(data);
+						}`,
+					)
+					return transformFn(context)
+				} catch (error) {
+					console.error(`Error executing transform: ${resource.transform}`, error)
+					return data
+				}
+			},
+		}
+	}
+
+	const getSuccessErrorHandlers = (resource: Resource) => {
+		const handlers: Record<string, Function> = {}
+		if (resource.on_success) {
+			handlers["onSuccess"] = (data: DataResult) => {
+				return handleSuccess(resource.on_success!, data)
+			}
+		}
+		if (resource.on_error) {
+			handlers["onError"] = (error: any) => {
+				return handleError(resource.on_error!, error)
+			}
+		}
+		return handlers
+	}
+
+	const getWhitelistedMethods = (resource: DocumentResource) => {
+		if (resource.whitelisted_methods) {
+			let whitelisted_methods = resource.whitelisted_methods
+			if (typeof resource.whitelisted_methods === "string") {
+				whitelisted_methods = JSON.parse(resource.whitelisted_methods)
+			}
+			const methods: Record<string, string> = {}
+			whitelisted_methods.forEach((method: string) => methods[method] = method)
+			return { whitelistedMethods: methods }
+		}
+		return {}
+	}
+
+	function stopResourceWatchers() {
+		resourceWatchers.forEach((stop) => stop())
+		resourceWatchers = []
+	}
+
+	function teardownPage() {
+		stopResourceWatchers()
+		disposePageScriptScope()
+	}
+
+	// VARIABLES
 	async function setPageVariables(page: StudioPage) {
 		studioVariables.filters = { parent: page.name }
 		await studioVariables.reload()
@@ -123,11 +352,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		setValueInObject(variables.value, variablePath, value)
 	}
 
-	function disposePageScriptScope() {
-		pageScriptScope?.stop()
-		pageScriptScope = null
-	}
-
+	// PAGE SCRIPT
 	async function setPageScript(page: StudioPage, isStandardPage: boolean = false) {
 		disposePageScriptScope()
 		pageScriptBindings.value = {}
@@ -144,6 +369,11 @@ const useCodeStore = defineStore("codeStore", () => {
 		if (!source.trim()) return
 		const bindingNames = getTopLevelBindings(source)
 		pageScriptBindings.value = compilePageScript(source, bindingNames)
+	}
+
+	function disposePageScriptScope() {
+		pageScriptScope?.stop()
+		pageScriptScope = null
 	}
 
 	async function loadCodePageScript(pageName: string): Promise<Record<string, any>> {
@@ -168,24 +398,6 @@ const useCodeStore = defineStore("codeStore", () => {
 			reportPageScriptError(error)
 			return {}
 		}
-	}
-
-	// HMR: the active page's script (or a composable/util it imports) was edited. Re-run its setup
-	// with the freshly hot-loaded module so new refs/computed and changed dependency code take
-	// effect without a reload. (Pinia stores keep their singleton state — they refresh their code
-	// only via their own acceptHMRUpdate.) Registered once here so both the editor and the preview
-	// (each with their own codeStore) hot-apply script edits to the page they're showing.
-	async function applyPageScriptHMR(setup: unknown) {
-		pageScriptError.value = null
-		pageScriptBindings.value = await runPageScriptSetup(setup)
-	}
-	setPageScriptHotUpdateHandler((pageName, setup) => {
-		if (currentPageName.value === pageName) applyPageScriptHMR(setup)
-	})
-
-	function reportPageScriptError(error: unknown) {
-		console.error("Error running page script", error)
-		pageScriptError.value = error instanceof Error ? error.message : String(error)
 	}
 
 	function runInPageScriptScope(run: () => any): any {
@@ -234,6 +446,25 @@ const useCodeStore = defineStore("codeStore", () => {
 		}) || {}
 	}
 
+	function reportPageScriptError(error: unknown) {
+		console.error("Error running page script", error)
+		pageScriptError.value = error instanceof Error ? error.message : String(error)
+	}
+
+	// HMR: the active page's script (or a composable/util it imports) was edited. Re-run its setup
+	// with the freshly hot-loaded module so new refs/computed and changed dependency code take
+	// effect without a reload. (Pinia stores keep their singleton state — they refresh their code
+	// only via their own acceptHMRUpdate.) Registered once here so both the editor and the preview
+	// (each with their own codeStore) hot-apply script edits to the page they're showing.
+	async function applyPageScriptHMR(setup: unknown) {
+		pageScriptError.value = null
+		pageScriptBindings.value = await runPageScriptSetup(setup)
+	}
+	setPageScriptHotUpdateHandler((pageName, setup) => {
+		if (currentPageName.value === pageName) applyPageScriptHMR(setup)
+	})
+
+	// SCRIPT CONTEXTS
 	const evalContext = computed(() => {
 		return {
 			...variables.value,
@@ -279,8 +510,6 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	const currentRoute = proxyToCurrent(() => unref(routeObject.value))
 
-	// A stable object that forwards every read/write to whatever getCurrent() returns right now.
-	// Doesn't rebind methods — fine for frappe-ui resources and routes, which never use `this`.
 	function proxyToCurrent(getCurrent: () => any) {
 		return new Proxy(
 			{},
@@ -301,6 +530,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		)
 	}
 
+	// EXPRESSION EVALUATION
 	function getDynamicValue(value: string, localContext: ExpressionEvaluationContext) {
 		let result = ""
 		let lastIndex = 0
@@ -398,6 +628,28 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	}
 
+	function stringToFunction(value: string, localContext: Record<string, any>): Function | string {
+		/**
+		 * Convert a function string to an actual function
+		 * Used for component props that have function values
+		 */
+		const registeredComponents = window.__APP_COMPONENTS__ || {}
+
+		try {
+			const fn = new Function(
+				"h",
+				...Object.keys(registeredComponents),
+				...Object.keys(scriptContext.value),
+				...Object.keys(localContext),
+				`return (${value})`
+			)
+			return fn(h, ...Object.values(registeredComponents), ...Object.values(scriptContext.value), ...Object.values(localContext))
+		} catch (e) {
+			return value
+		}
+	}
+
+	// EVENT SCRIPTS
 	function executeUserScript(
 		script: string,
 		slotScope?: Record<string, any>,
@@ -477,255 +729,6 @@ const useCodeStore = defineStore("codeStore", () => {
 			return errorFn(context)
 		} catch (err) {
 			console.error(`Error executing error script: ${script}`, err)
-		}
-	}
-
-	async function addPageResource(resource: Resource, pageResources: Record<string, any>) {
-		switch (resource.resource_type) {
-			case "Document":
-				return addDocumentResource(resource, pageResources)
-			case "Document List":
-				pageResources[resource.resource_name] = getListResource(resource)
-				break
-			case "API Resource":
-				pageResources[resource.resource_name] = getAPIResource(resource)
-				break
-		}
-	}
-
-	function stopResourceWatchers() {
-		resourceWatchers.forEach((stop) => stop())
-		resourceWatchers = []
-	}
-
-	function teardownPage() {
-		stopResourceWatchers()
-		disposePageScriptScope()
-	}
-
-	// Evaluate a resource's dynamic input ({{ }} filters/params) now, and call onChange whenever a
-	// route/variable change alters the result. Watching the serialized value keeps context churn
-	// that evaluates to the same input from refetching the resource.
-	function evaluateAndWatch<T>(evaluate: () => T, onChange: (value: T) => void): T {
-		const stop = watch(
-			() => JSON.stringify(evaluate()),
-			() => onChange(evaluate()),
-		)
-		resourceWatchers.push(stop)
-		return evaluate()
-	}
-
-	function getListResource(resource: DocumentListResource) {
-		let fields = []
-		if ("fields" in resource && typeof resource.fields === "string") {
-			fields = JSON.parse(resource.fields)
-		}
-
-		const params: any = {
-			doctype: resource.document_type,
-			fields: fields.length ? fields : "*",
-			filters: evaluateAndWatch(
-				() => getEvaluatedFilters(resource.filters),
-				(filters) => {
-					listResource.update({ filters })
-					if (listResource.auto) listResource.reload()
-				},
-			),
-			pageLength: resource.limit,
-			auto: resource.auto,
-			...getTransforms(resource),
-			...getSuccessErrorHandlers(resource),
-		}
-		if (resource.sort_field) {
-			params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
-		}
-		const listResource = createListResource(params)
-		// initialize listResource.data to an empty array to avoid undefined errors in the UI, frappe-ui sets data to null by default
-		listResource.data = []
-		return listResource
-	}
-
-	function getAPIResource(resource: APIResource) {
-		const apiResource = createResource({
-			url: resource.url,
-			method: resource.method,
-			params: evaluateAndWatch(
-				() => getAPIParams(resource.params),
-				(params) => {
-					apiResource.update({ params })
-					if (apiResource.auto) apiResource.reload()
-				},
-			),
-			auto: resource.auto,
-			...getTransforms(resource),
-			...getSuccessErrorHandlers(resource),
-		})
-		return apiResource
-	}
-
-	function getAPIParams(params: Record<string, any> | string | null = null) {
-		if (!params) return null
-		if (typeof params === "string") {
-			params = JSON.parse(params)
-		}
-		// evaluate on a copy: evaluation re-runs on every context change and must not bake values into the config
-		const evaluated: Record<string, any> = { ...(params as Record<string, any>) }
-		Object.entries(evaluated).forEach(([key, value]) => {
-			if (isDynamicValue(value)) {
-				// null ?? undefined → undefined, so nullish params get dropped on serialization
-				evaluated[key] = getDynamicValue(value, {}) ?? undefined
-			}
-		})
-		return evaluated
-	}
-
-	const addDocumentResource = async (resource: DocumentResource, pageResources: Record<string, any>) => {
-		const createDoc = (docname?: string) =>
-			createDocumentResource({
-				doctype: resource.document_type,
-				name: docname,
-				auto: resource.auto,
-				...getTransforms(resource),
-				...getSuccessErrorHandlers(resource),
-				...getWhitelistedMethods(resource),
-			})
-
-		if (!resource.fetch_document_using_filters || !resource.filters) {
-			pageResources[resource.resource_name] = createDoc(resource.document_name)
-			return
-		}
-
-		// The docname can't change on an existing document resource (frappe-ui caches them by
-		// doctype+name), so a filter change means re-resolving the docname and replacing the entry.
-		// loadDoc is the entry's only writer; latestRequest keeps only the newest lookup's result.
-		let latestRequest = 0
-		async function loadDoc(currentFilters: Filters) {
-			const request = ++latestRequest
-			const docname = await resolveDocnameFromFilters(resource, currentFilters)
-			if (request !== latestRequest) return
-			if (!docname) {
-				pageResources[resource.resource_name] = undefined
-				return
-			}
-			const doc = createDoc(docname) as any
-			// carry over the editor's config stamps (see setResourceConfig in setPageResources)
-			const oldDoc = pageResources[resource.resource_name]
-			if (oldDoc?.resource_id) {
-				doc.resource_id = oldDoc.resource_id
-				doc.resource_type = oldDoc.resource_type
-			}
-			pageResources[resource.resource_name] = doc
-		}
-
-		const filters = evaluateAndWatch(() => getEvaluatedFilters(resource.filters) || {}, loadDoc)
-		await loadDoc(filters)
-	}
-
-	const resolveDocnameFromFilters = async (resource: DocumentResource, filters: Filters) => {
-		// the common `name = {{ route.params.id }}` case resolves to the docname itself — no server lookup needed
-		const keys = Object.keys(filters)
-		if (keys.length === 1 && keys[0] === "name") {
-			return filters.name
-		}
-		// other filters (e.g. category = tech) need a lookup for one matching doc's name
-		const doc = await call("frappe.client.get_value", {
-			doctype: resource.document_type,
-			fieldname: "name",
-			filters,
-		})
-		return doc?.name
-	}
-
-	const getEvaluatedFilters = (filters: Filters | null = null) => {
-		if (!filters) return
-		if (typeof filters === "string") {
-			filters = JSON.parse(filters)
-		}
-
-		const evaluatedFilters: Filters = {}
-
-		for (const key in filters) {
-			let value = Array.isArray(filters[key]) ? filters[key][1] : filters[key]
-
-			if (isDynamicValue(value)) {
-				// null ?? undefined → undefined, so nullish filters get dropped on serialization
-				evaluatedFilters[key] = getDynamicValue(value, {}) ?? undefined
-			} else {
-				evaluatedFilters[key] = value
-			}
-		}
-
-		return evaluatedFilters
-	}
-
-	const getTransforms = (resource: Resource) => {
-		if (!resource.transform) return {}
-		return {
-			transform: (data: any) => {
-				try {
-					const context = { ...scriptContext.value, data }
-					const transformFn = new Function(
-						"ctx",
-						`with(ctx) {
-							${resource.transform}
-							return transform(data);
-						}`,
-					)
-					return transformFn(context)
-				} catch (error) {
-					console.error(`Error executing transform: ${resource.transform}`, error)
-					return data
-				}
-			},
-		}
-	}
-
-	const getSuccessErrorHandlers = (resource: Resource) => {
-		const handlers: Record<string, Function> = {}
-		if (resource.on_success) {
-			handlers["onSuccess"] = (data: DataResult) => {
-				return handleSuccess(resource.on_success!, data)
-			}
-		}
-		if (resource.on_error) {
-			handlers["onError"] = (error: any) => {
-				return handleError(resource.on_error!, error)
-			}
-		}
-		return handlers
-	}
-
-	const getWhitelistedMethods = (resource: DocumentResource) => {
-		if (resource.whitelisted_methods) {
-			let whitelisted_methods = resource.whitelisted_methods
-			if (typeof resource.whitelisted_methods === "string") {
-				whitelisted_methods = JSON.parse(resource.whitelisted_methods)
-			}
-			const methods: Record<string, string> = {}
-			whitelisted_methods.forEach((method: string) => methods[method] = method)
-			return { whitelistedMethods: methods }
-		}
-		return {}
-	}
-
-	function stringToFunction(value: string, localContext: Record<string, any>): Function | string {
-		/**
-		 * Convert a function string to an actual function
-		 * Used for component props that have function values
-		 */
-		const registeredComponents = window.__APP_COMPONENTS__ || {}
-
-		try {
-			const fn = new Function(
-				"h",
-				...Object.keys(registeredComponents),
-				...Object.keys(scriptContext.value),
-				...Object.keys(localContext),
-				`return (${value})`
-			)
-			return fn(h, ...Object.values(registeredComponents), ...Object.values(scriptContext.value), ...Object.values(localContext))
-		} catch (e) {
-			return value
 		}
 	}
 

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -246,6 +246,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	})
 
+	// Base context for every script scope — event/success/error handlers, function-value props, and page-script setup
 	const scriptContext = computed(() => {
 		const variablesRefs = toRefs(variables.value)
 		// Resources and currentRoute are proxies so scripts can destructure them once and still see the current values
@@ -601,7 +602,13 @@ const useCodeStore = defineStore("codeStore", () => {
 				replaceDocumentResource(resource.resource_name, createDoc(docname))
 			},
 		)
-		return createDoc(await resolveDocnameFromFilters(resource, filters))
+
+		// If the filters changed while this initial lookup was pending, re-resolve
+		let docname = await resolveDocnameFromFilters(resource, filters)
+		if (latestRequest > 0) {
+			docname = await resolveDocnameFromFilters(resource, getEvaluatedFilters(resource.filters) || {})
+		}
+		return createDoc(docname)
 	}
 
 	function replaceDocumentResource(resourceName: string, newResource: any) {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -51,7 +51,6 @@ const useCodeStore = defineStore("codeStore", () => {
 	const currentPageName = ref<string | null>(null)
 	let pageScriptScope: EffectScope | null = null
 	let resourceWatchers: WatchStopHandle[] = []
-	let pendingResources: Record<string, any> | null = null
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
@@ -61,6 +60,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		routerObject.value = router
 	}
 
+	let pendingResources: Record<string, any> | null = null
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
 		stopResourceWatchers()
 		// Each load uses its own map, so old async updates cannot change the current page resources.
@@ -257,8 +257,15 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	})
 
-	const resourceProxies: Record<string, any> = {}
+	// for non-standard pages: scriptContext + vueReactivityApis since it can't import them
+	const interpretedScriptContext = computed(() => {
+		return {
+			...vueReactivityApis,
+			...scriptContext.value,
+		}
+	})
 
+	const resourceProxies: Record<string, any> = {}
 	function currentResourceProxies() {
 		const proxies: Record<string, any> = {}
 		for (const name in resources.value) {
@@ -270,8 +277,8 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	const currentRoute = proxyToCurrent(() => unref(routeObject.value))
 
-	// An object that reads/writes every property on whatever getCurrent() returns right now.
-	// Methods come back as-is: frappe-ui resources and route objects use closures, not `this`.
+	// A stable object that forwards every read/write to whatever getCurrent() returns right now.
+	// Doesn't rebind methods — fine for frappe-ui resources and routes, which never use `this`.
 	function proxyToCurrent(getCurrent: () => any) {
 		return new Proxy(
 			{},
@@ -291,14 +298,6 @@ const useCodeStore = defineStore("codeStore", () => {
 			},
 		)
 	}
-
-	// for non-standard pages: scriptContext + vueReactivityApis since it can't import them
-	const interpretedScriptContext = computed(() => {
-		return {
-			...vueReactivityApis,
-			...scriptContext.value,
-		}
-	})
 
 	function getDynamicValue(value: string, localContext: ExpressionEvaluationContext) {
 		let result = ""

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -13,7 +13,14 @@ import * as globalUtils from "@/utils/globalUtils"
 import { getInitialVariableValue, getValueFromObject, setValueInObject } from "@/utils/helpers"
 import { isDynamicValue, normalizeDynamicValue } from "@/utils/code"
 import { isFunctionExpression, toOptionalChaining, getTopLevelBindings } from "@/utils/parseCode"
-import type { Filters, Resource, DocumentResource, DataResult } from "@/types/Studio/StudioResource"
+import type {
+	Filters,
+	Resource,
+	DocumentResource,
+	DocumentListResource,
+	APIResource,
+	DataResult,
+} from "@/types/Studio/StudioResource"
 import type { StudioPage } from "@/types/Studio/StudioPage"
 import type { Variable } from "@/types/Studio/StudioPageVariable"
 import type { ExpressionEvaluationContext } from "@/types"
@@ -43,6 +50,7 @@ const useCodeStore = defineStore("codeStore", () => {
 	const pageScriptError = ref<string | null>(null)
 	const currentPageName = ref<string | null>(null)
 	let pageScriptScope: EffectScope | null = null
+	let resourceInputsScope: EffectScope | null = null
 
 	function setRouteObject(route: ComputedRef) {
 		routeObject.value = route
@@ -53,15 +61,13 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
+		disposeResourceInputs()
 		studioPageResources.filters = { parent: page.name }
 		await studioPageResources.reload()
+		resourceInputsScope = effectScope(true)
 
 		const resourcePromises = studioPageResources.data.map(async (resource: Resource) => {
-			const newResource = await getNewResource(resource, {
-				...variables.value,
-				route: unref(routeObject.value),
-				router: routerObject.value,
-			})
+			const newResource = await getNewResource(resource)
 			return {
 				resource_name: resource.resource_name,
 				value: newResource,
@@ -242,17 +248,56 @@ const useCodeStore = defineStore("codeStore", () => {
 	})
 
 	// Base context for every script scope — event/success/error handlers, function-value props, and page-script setup.
+	// Resources and route go in as live handles: page-script setup destructures its context once and
+	// keeps running across navigations, but a docname change swaps the document resource object and
+	// vue-router makes a new route object per navigation — a plain spread would freeze the captures.
 	const scriptContext = computed(() => {
 		const variablesRefs = toRefs(variables.value)
 		return {
 			...variablesRefs,
-			...resources.value,
+			...getResourceHandles(),
 			...pageScriptBindings.value,
 			...globalUtils,
-			route: unref(routeObject.value),
+			route: liveRoute,
 			router: routerObject.value,
 		}
 	})
+
+	const resourceHandles: Record<string, any> = {}
+
+	function getResourceHandles() {
+		const handles: Record<string, any> = {}
+		for (const name in resources.value) {
+			resourceHandles[name] ??= createLiveHandle(() => resources.value[name])
+			handles[name] = resourceHandles[name]
+		}
+		return handles
+	}
+
+	const liveRoute = createLiveHandle(() => unref(routeObject.value))
+
+	// A stable object that forwards every access to the current target, so script closures created
+	// at setup stay live. Targets are frappe-ui resources / route objects whose methods are
+	// closures, not `this`-bound — values are returned as-is.
+	function createLiveHandle(getTarget: () => any) {
+		return new Proxy(
+			{},
+			{
+				get: (_, key) => getTarget()?.[key],
+				has: (_, key) => key in (getTarget() || {}),
+				set: (_, key, value) => {
+					const target = getTarget()
+					if (target) target[key] = value
+					return true
+				},
+				ownKeys: () => Reflect.ownKeys(getTarget() || {}),
+				getOwnPropertyDescriptor: (_, key) => {
+					const target = getTarget()
+					if (target && key in target) return { enumerable: true, configurable: true, value: target[key] }
+				},
+			},
+		)
+	}
 
 	// for non-standard pages: scriptContext + vueReactivityApis since it can't import them
 	const interpretedScriptContext = computed(() => {
@@ -441,78 +486,146 @@ const useCodeStore = defineStore("codeStore", () => {
 		}
 	}
 
-	function getNewResource(resource: Resource, context?: ExpressionEvaluationContext) {
-		let fields = []
-		if ('fields' in resource && typeof resource.fields === "string") {
-			fields = JSON.parse(resource.fields)
-		}
-
+	function getNewResource(resource: Resource) {
 		switch (resource.resource_type) {
 			case "Document":
-				return getDocumentResource(resource, context)
+				return getDocumentResource(resource)
 			case "Document List":
-				const params: any = {
-					doctype: resource.document_type,
-					fields: fields.length ? fields : "*",
-					filters: getEvaluatedFilters(resource.filters, context),
-					pageLength: resource.limit,
-					auto: resource.auto,
-					...getTransforms(resource),
-					...getSuccessErrorHandlers(resource),
-				}
-				if (resource.sort_field) {
-					params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
-				}
-				let listResource = createListResource(params)
-				// initialize listResource.data to an empty array to avoid undefined errors in the UI, frappe-ui sets data to null by default
-				listResource.data = []
-				return listResource
+				return getListResource(resource)
 			case "API Resource":
-				return createResource({
-					url: resource.url,
-					method: resource.method,
-					params: getAPIParams(resource.params, context),
-					auto: resource.auto,
-					...getTransforms(resource),
-					...getSuccessErrorHandlers(resource),
-				})
+				return getAPIResource(resource)
 		}
 	}
 
-	function getAPIParams(params: Record<string, any> | string | null = null, context: ExpressionEvaluationContext) {
+	function disposeResourceInputs() {
+		resourceInputsScope?.stop()
+		resourceInputsScope = null
+	}
+
+	// Live binding for a dynamic resource input: the computed evaluates {{ }} expressions against the
+	// live context (route/variables/other resources), the watch pushes value changes into the created
+	// resource — createResource-style utilities take plain values, not getters, so we bridge ourselves.
+	// Returns the initial value for resource creation.
+	function bindResourceInput<T>(evaluate: () => T, apply: (value: T) => void): T {
+		const setup = () => {
+			const input = computed(evaluate)
+			let lastValue = JSON.stringify(input.value)
+			watch(input, (value) => {
+				const serialized = JSON.stringify(value)
+				if (serialized === lastValue) return
+				lastValue = serialized
+				apply(value)
+			})
+			return input.value
+		}
+		return resourceInputsScope ? (resourceInputsScope.run(setup) as T) : setup()
+	}
+
+	function getListResource(resource: DocumentListResource) {
+		let fields = []
+		if ("fields" in resource && typeof resource.fields === "string") {
+			fields = JSON.parse(resource.fields)
+		}
+
+		const params: any = {
+			doctype: resource.document_type,
+			fields: fields.length ? fields : "*",
+			filters: bindResourceInput(
+				() => getEvaluatedFilters(resource.filters),
+				(filters) => {
+					listResource.update({ filters })
+					if (listResource.auto) listResource.reload()
+				},
+			),
+			pageLength: resource.limit,
+			auto: resource.auto,
+			...getTransforms(resource),
+			...getSuccessErrorHandlers(resource),
+		}
+		if (resource.sort_field) {
+			params["orderBy"] = `${resource.sort_field} ${resource.sort_order}`
+		}
+		const listResource = createListResource(params)
+		// initialize listResource.data to an empty array to avoid undefined errors in the UI, frappe-ui sets data to null by default
+		listResource.data = []
+		return listResource
+	}
+
+	function getAPIResource(resource: APIResource) {
+		const apiResource = createResource({
+			url: resource.url,
+			method: resource.method,
+			params: bindResourceInput(
+				() => getAPIParams(resource.params),
+				(params) => {
+					apiResource.update({ params })
+					if (apiResource.auto) apiResource.reload()
+				},
+			),
+			auto: resource.auto,
+			...getTransforms(resource),
+			...getSuccessErrorHandlers(resource),
+		})
+		return apiResource
+	}
+
+	function getAPIParams(params: Record<string, any> | string | null = null) {
 		if (!params) return null
 		if (typeof params === "string") {
 			params = JSON.parse(params)
 		}
-		if (params && typeof params === "object") {
-			Object.entries(params).forEach(([key, value]) => {
-				if (isDynamicValue(value)) {
-					// null ?? undefined → undefined, so nullish params get dropped on serialization
-					params[key] = getDynamicValue(value, context) ?? undefined
-				}
-			})
-		}
-		return params
-	}
-
-	const getDocumentResource = async (resource: DocumentResource, context: ExpressionEvaluationContext) => {
-		let docname = resource.document_name
-		if (resource.fetch_document_using_filters && resource.filters) {
-			docname = await resolveDocnameFromFilters(resource, context)
-		}
-
-		return createDocumentResource({
-			doctype: resource.document_type,
-			name: docname,
-			auto: resource.auto,
-			...getTransforms(resource),
-			...getSuccessErrorHandlers(resource),
-			...getWhitelistedMethods(resource),
+		// evaluate on a copy: evaluation re-runs on every context change and must not bake values into the config
+		const evaluated: Record<string, any> = { ...(params as Record<string, any>) }
+		Object.entries(evaluated).forEach(([key, value]) => {
+			if (isDynamicValue(value)) {
+				// null ?? undefined → undefined, so nullish params get dropped on serialization
+				evaluated[key] = getDynamicValue(value, {}) ?? undefined
+			}
 		})
+		return evaluated
 	}
 
-	const resolveDocnameFromFilters = async (resource: DocumentResource, context: ExpressionEvaluationContext) => {
-		const filters = getEvaluatedFilters(resource.filters, context) || {}
+	const getDocumentResource = async (resource: DocumentResource) => {
+		const createDoc = (docname?: string) =>
+			createDocumentResource({
+				doctype: resource.document_type,
+				name: docname,
+				auto: resource.auto,
+				...getTransforms(resource),
+				...getSuccessErrorHandlers(resource),
+				...getWhitelistedMethods(resource),
+			})
+
+		if (!resource.fetch_document_using_filters || !resource.filters) {
+			return createDoc(resource.document_name)
+		}
+
+		let resolveToken = 0
+		const filters = bindResourceInput(
+			() => getEvaluatedFilters(resource.filters) || {},
+			async (newFilters) => {
+				const token = ++resolveToken
+				const docname = await resolveDocnameFromFilters(resource, newFilters)
+				if (token !== resolveToken || !docname) return
+				// createDocumentResource caches by doctype+name, so an unchanged docname swaps in the same instance
+				swapPageResource(resource.resource_name, createDoc(docname))
+			},
+		)
+		return createDoc(await resolveDocnameFromFilters(resource, filters))
+	}
+
+	// a docname change means a new document resource; carry over the editor's config stamps
+	function swapPageResource(resourceName: string, newResource: any) {
+		if (!newResource) return
+		const oldResource = resources.value[resourceName] as any
+		if (oldResource?.resource_id) {
+			newResource.resource_id = oldResource.resource_id
+			newResource.resource_type = oldResource.resource_type
+		}
+		resources.value[resourceName] = newResource
+	}
+
+	const resolveDocnameFromFilters = async (resource: DocumentResource, filters: Filters) => {
 		// the common `name = {{ route.params.id }}` case resolves to the docname itself — no server lookup needed
 		const keys = Object.keys(filters)
 		if (keys.length === 1 && keys[0] === "name") {
@@ -527,7 +640,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		return doc?.name
 	}
 
-	const getEvaluatedFilters = (filters: Filters | null = null, context: ExpressionEvaluationContext) => {
+	const getEvaluatedFilters = (filters: Filters | null = null) => {
 		if (!filters) return
 		if (typeof filters === "string") {
 			filters = JSON.parse(filters)
@@ -540,7 +653,7 @@ const useCodeStore = defineStore("codeStore", () => {
 
 			if (isDynamicValue(value)) {
 				// null ?? undefined → undefined, so nullish filters get dropped on serialization
-				evaluatedFilters[key] = getDynamicValue(value, context) ?? undefined
+				evaluatedFilters[key] = getDynamicValue(value, {}) ?? undefined
 			} else {
 				evaluatedFilters[key] = value
 			}
@@ -628,6 +741,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		// resources
 		resources,
 		setPageResources,
+		disposeResourceInputs,
 		// variables
 		variables,
 		setPageVariables,

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -498,6 +498,11 @@ const useCodeStore = defineStore("codeStore", () => {
 		resourceWatchers = []
 	}
 
+	function teardownPage() {
+		stopResourceWatchers()
+		disposePageScriptScope()
+	}
+
 	// Evaluate a resource's dynamic input ({{ }} filters/params) now, and call onChange whenever a
 	// route/variable change alters the result. Watching the serialized value keeps context churn
 	// that evaluates to the same input from refetching the resource.
@@ -732,7 +737,7 @@ const useCodeStore = defineStore("codeStore", () => {
 		// resources
 		resources,
 		setPageResources,
-		stopResourceWatchers,
+		teardownPage,
 		// variables
 		variables,
 		setPageVariables,

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -596,8 +596,7 @@ const useStudioStore = defineStore("store", () => {
 	// value selectors and in completions — no reload. Non-active pages refresh lazily on navigation
 	// (studioPageScripts caches the latest setup).
 	async function setPageData(page: StudioPage) {
-		// stop the old page's resource input watchers before the variables reset, else they fire spurious reloads
-		codeStore.disposeResourceInputs()
+		codeStore.stopResourceWatchers()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page, true)
 	}

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -194,8 +194,9 @@ const useStudioStore = defineStore("store", () => {
 	async function setPage(pageName: string) {
 		settingPage.value = true
 		pageConflict.value = false
-		codeStore.teardownPage()
 		savingPage.value = false
+		codeStore.teardownPage()
+
 		const page = await fetchPage(pageName)
 		if (!page) {
 			settingPage.value = false

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -596,6 +596,8 @@ const useStudioStore = defineStore("store", () => {
 	// value selectors and in completions — no reload. Non-active pages refresh lazily on navigation
 	// (studioPageScripts caches the latest setup).
 	async function setPageData(page: StudioPage) {
+		// stop the old page's resource input watchers before the variables reset, else they fire spurious reloads
+		codeStore.disposeResourceInputs()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page, true)
 	}

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -536,7 +536,8 @@ const useStudioStore = defineStore("store", () => {
 	const routeObject = computed(() => {
 		if (!activePage.value) return ""
 
-		const newRoute = toRaw(router.currentRoute.value)
+		// copy — mutating the live route object would wipe the editor router's own params (appID/pageID)
+		const newRoute = { ...toRaw(router.currentRoute.value) }
 		// Seed each dynamic param with its design-time test value (empty string when unset),
 		// e.g. "/hr/:employee/:id" -> { employee, id } filled from routeVariables
 		const paramNames = getRouteVariables(activePage.value.route)

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -194,8 +194,7 @@ const useStudioStore = defineStore("store", () => {
 	async function setPage(pageName: string) {
 		settingPage.value = true
 		pageConflict.value = false
-		// leaving the current page: drop its in-flight-save flag so the new page isn't blocked
-		// waiting on a save it doesn't own (that save's own callback no longer clears this flag)
+		codeStore.teardownPage()
 		savingPage.value = false
 		const page = await fetchPage(pageName)
 		if (!page) {
@@ -597,7 +596,6 @@ const useStudioStore = defineStore("store", () => {
 	// value selectors and in completions — no reload. Non-active pages refresh lazily on navigation
 	// (studioPageScripts caches the latest setup).
 	async function setPageData(page: StudioPage) {
-		codeStore.stopResourceWatchers()
 		await codeStore.setPageVariables(page)
 		await codeStore.setPageResources(page, true)
 	}


### PR DESCRIPTION
## Before

Navigating between dynamic route params (`/articles/a` → `/articles/b`) rebuilt the entire page. All page blocks were fetched on every route param change, causing the entire page to flicker. Even components not dependent on route param data (like the sidebar) flickered on every route change.

https://github.com/user-attachments/assets/3769fdc7-359b-44fe-968d-8f82273ef6c1


## After

- `AppContainer` keeps the block tree, variables, and page script mounted; route-dependent resources reload themselves. Only actual page changes go through a full load.
- Page scripts destructure their context once (`const { article, route } = context`) and now keep working across navigations: resources and `route` are exposed as proxies that always forward to the current object, so computed values and watchers keep tracking through doc swaps and route changes.
- Navigation tears down the outgoing page's watchers and script scope synchronously *before*
  fetching the next page, and a navigation token discards superseded loads.

https://github.com/user-attachments/assets/c9a31813-0555-4a01-932d-37e20461a9a6


## ⚠️ Behavioral change: page script

Page scripts now run **once per page visit** instead of re-running on parameter-only navigation - same as a Vue component's `setup`. One-time reads like `const id = route.params.id` will be stale after param navigation:

- derive from `route.params` inside `computed(...)`
- use `watch(() => route.params.x, ...)` for per-param side effects
- resources with `{{ route.params.* }}` filters reload automatically - no script code needed, and manual "reload on param change" watchers should be removed (they now double-fetch)


### Other fixes
- `routeObject` was mutating the router's **live** route object (overwriting `appID`/`pageID` with design-time route variables) - it now works on a copy. This broke page switching from pages with dynamic routes once the always-on watchers started reading it constantly.
- Page-load failures in the editor now show up (console + toast) instead of failing silently.
- Data panel shows a warning indicator when a filter-based document resource matched no document.