### PR TITLE
fix: only render children/slots if they exist

### DIFF
--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -4,7 +4,7 @@
 		:studioComponent="block"
 		:evaluationContext="evaluationContext"
 	/>
-	<template v-else-if="block.canHaveChildren()">
+	<template v-else-if="block.hasChildren() || block.hasComponentSlots()">
 		<component
 			ref="componentRef"
 			v-if="showComponent"

--- a/frontend/src/components/AppComponent.vue
+++ b/frontend/src/components/AppComponent.vue
@@ -21,11 +21,12 @@
 				:key="slotName"
 				v-slot:[slotName]="slotProps"
 			>
-				<SlotScopeProvider :scope="slotProps">
+				<SlotScopeProvider :scope="slotProps" v-slot="forwardedAttrs">
 					<AppComponent
 						v-for="slotBlock in slot.slotContent"
 						:block="slotBlock"
 						:key="slotBlock.componentId"
+						v-bind="forwardedAttrs"
 					/>
 				</SlotScopeProvider>
 			</template>

--- a/frontend/src/components/SlotScopeProvider.vue
+++ b/frontend/src/components/SlotScopeProvider.vue
@@ -1,16 +1,21 @@
 <template>
-	<slot />
+	<slot v-bind="attrs" />
 </template>
 
 <script setup lang="ts">
-import { computed, inject, provide, type ComputedRef } from "vue"
+import { computed, inject, provide, useAttrs, type ComputedRef } from "vue"
 import type { SlotScope } from "@/types"
 
 // Renderless provider that pushes a scoped slot's props onto the scope stack
 // so that blocks rendered inside the slot can reference them in expressions.
+// Attrs are re-exposed as slot props because as-child triggers (Dropdown/Popover) merge their handlers onto this vnode as attrs
+defineOptions({ inheritAttrs: false })
+
 const props = defineProps<{
 	scope: SlotScope
 }>()
+
+const attrs = useAttrs()
 
 const parentScope = inject<ComputedRef<SlotScope> | null>("slotScope", null)
 const scope = computed(() => ({ ...parentScope?.value, ...props.scope }))

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -34,11 +34,12 @@
 				:key="slotName"
 				v-slot:[slotName]="slotProps"
 			>
-				<SlotScopeProvider v-if="slot.slotContent.length" :scope="slotProps">
+				<SlotScopeProvider v-if="slot.slotContent.length" :scope="slotProps" v-slot="forwardedAttrs">
 					<StudioComponent
 						v-for="slotBlock in slot.slotContent"
 						:key="slotBlock.componentId"
 						:block="slotBlock"
+						v-bind="forwardedAttrs"
 						:class="slotClasses"
 						:data-slot-id="slot.slotId"
 						:data-slot-name="slotName"

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -16,7 +16,7 @@
 		:breakpoint="breakpoint"
 	/>
 
-	<template v-else-if="block.canHaveChildren()">
+	<template v-else-if="block.hasChildren() || block.hasComponentSlots()">
 		<component
 			v-if="showComponent"
 			:is="componentName"

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -54,6 +54,7 @@
 					:data-slot-id="slot.slotId"
 					:data-slot-name="slotName"
 					:data-component-id="block.componentId"
+					:data-breakpoint="breakpoint"
 				/>
 			</template>
 


### PR DESCRIPTION
Don't always pass empty default slots; components don't load the default slot fallback (Avatar, Dropdown)

Closes https://github.com/frappe/studio/issues/218
Regressed in https://github.com/frappe/studio/pull/199

**Before:**
Avatar fallback (label's first letter) not showing up

<img width="1512" height="261" alt="image" src="https://github.com/user-attachments/assets/ab51e3fa-4750-4de8-8f39-144b24a4eb85" />

**After:**

<img width="1512" height="261" alt="image" src="https://github.com/user-attachments/assets/8b6a81a3-403f-4687-9450-e61bd97560b7" />

<hr>

Others:
1. **Pass forwarded attributes in SlotScopeProvider.**
	If we override the default slot of the dropdown, it wasn't opening because reka-ui's as-child trigger passes its toggle handlers as fallthrough attrs on the slot's child vnode - SlotScopeProvider
3. **Attach the breakpoint to the empty slot div else it doesn't render in the editor**
	Dropdown with an empty trigger slot is renderless, so the empty slot div was not visible in the editor