### PR TITLE
fix(UX): name setting panel layers by tabname

### DIFF
--- a/frontend/src/components/PropEditors/SettingsTabsEditor.vue
+++ b/frontend/src/components/PropEditors/SettingsTabsEditor.vue
@@ -108,7 +108,18 @@ function removeTab(tab: TabEntry) {
 
 function updateLabel(tab: TabEntry, value: string) {
 	syncBlockNames(tab, value)
+	syncPanelTitle(tab, value)
 	tab.labelBlock?.setProp("text", value)
+}
+
+// only while the title still mirrors the label — a hand-edited title stays
+function syncPanelTitle(tab: TabEntry, label: string) {
+	const header = tab.panel
+		?.getChildrenAndSlotContent()
+		.find((child) => child.componentName === "SettingsHeader")
+	if (!header) return
+	const title = String(header.getProp("title") ?? "")
+	if (!title || title === tab.label) header.setProp("title", label)
 }
 
 // layer names like "ProfileNavItem"/"ProfilePanel" follow the label,

--- a/frontend/src/components/PropEditors/SettingsTabsEditor.vue
+++ b/frontend/src/components/PropEditors/SettingsTabsEditor.vue
@@ -112,14 +112,12 @@ function updateLabel(tab: TabEntry, value: string) {
 	tab.labelBlock?.setProp("text", value)
 }
 
-// only while the title still mirrors the label — a hand-edited title stays
+// only while the title still mirrors the label — a hand-edited (or cleared) title stays
 function syncPanelTitle(tab: TabEntry, label: string) {
 	const header = tab.panel
 		?.getChildrenAndSlotContent()
 		.find((child) => child.componentName === "SettingsHeader")
-	if (!header) return
-	const title = String(header.getProp("title") ?? "")
-	if (!title || title === tab.label) header.setProp("title", label)
+	if (header?.getProp("title") === tab.label) header.setProp("title", label)
 }
 
 // layer names like "ProfileNavItem"/"ProfilePanel" follow the label,

--- a/frontend/src/components/PropEditors/SettingsTabsEditor.vue
+++ b/frontend/src/components/PropEditors/SettingsTabsEditor.vue
@@ -109,7 +109,6 @@ function removeTab(tab: TabEntry) {
 function updateLabel(tab: TabEntry, value: string) {
 	syncBlockNames(tab, value)
 	tab.labelBlock?.setProp("text", value)
-	panelHeader(tab)?.setProp("title", value)
 }
 
 // layer names like "ProfileNavItem"/"ProfilePanel" follow the label,
@@ -123,12 +122,6 @@ function renameBlock(block: Block | null, oldLabel: string, newLabel: string, su
 	if (!block) return
 	const isAutoNamed = !block.blockName || block.blockName === tabBlockName(oldLabel, suffix)
 	if (isAutoNamed) block.blockName = tabBlockName(newLabel, suffix)
-}
-
-function panelHeader(tab: TabEntry) {
-	return (
-		tab.panel?.getChildrenAndSlotContent().find((child) => child.componentName === "SettingsHeader") || null
-	)
 }
 
 function renameValue(tab: TabEntry, next: string) {

--- a/frontend/src/components/PropEditors/SettingsTabsEditor.vue
+++ b/frontend/src/components/PropEditors/SettingsTabsEditor.vue
@@ -57,7 +57,7 @@ import { Button, toast } from "frappe-ui"
 import Input from "@/components/Input.vue"
 import InputLabel from "@/components/InputLabel.vue"
 import Block from "@/utils/block"
-import { navItem, settingsPanel } from "@/utils/blockTemplate/familyTemplates"
+import { navItem, settingsPanel, tabBlockName } from "@/utils/blockTemplate/familyTemplates"
 
 const props = defineProps<{ block: Block; label?: string }>()
 
@@ -107,7 +107,28 @@ function removeTab(tab: TabEntry) {
 }
 
 function updateLabel(tab: TabEntry, value: string) {
+	syncBlockNames(tab, value)
 	tab.labelBlock?.setProp("text", value)
+	panelHeader(tab)?.setProp("title", value)
+}
+
+// layer names like "ProfileNavItem"/"ProfilePanel" follow the label,
+// unless the block was renamed by hand in the layers panel
+function syncBlockNames(tab: TabEntry, label: string) {
+	renameBlock(tab.navItem, tab.label, label, "NavItem")
+	renameBlock(tab.panel, tab.label, label, "Panel")
+}
+
+function renameBlock(block: Block | null, oldLabel: string, newLabel: string, suffix: "NavItem" | "Panel") {
+	if (!block) return
+	const isAutoNamed = !block.blockName || block.blockName === tabBlockName(oldLabel, suffix)
+	if (isAutoNamed) block.blockName = tabBlockName(newLabel, suffix)
+}
+
+function panelHeader(tab: TabEntry) {
+	return (
+		tab.panel?.getChildrenAndSlotContent().find((child) => child.componentName === "SettingsHeader") || null
+	)
 }
 
 function renameValue(tab: TabEntry, next: string) {
@@ -118,6 +139,7 @@ function renameValue(tab: TabEntry, next: string) {
 		return
 	}
 	const wasActive = isActive(tab)
+	if (!tab.labelBlock) syncBlockNames(tab, next) // label falls back to value
 	tab.navItem.setProp("value", next)
 	tab.panel?.setProp("value", next)
 	if (wasActive) {

--- a/frontend/src/utils/blockTemplate/familyTemplates.ts
+++ b/frontend/src/utils/blockTemplate/familyTemplates.ts
@@ -282,9 +282,20 @@ export function navItem(value: string, label: string): BlockOptions {
 	// `value` pairs a nav item with the SettingsPanel that shares it.
 	return {
 		componentName: "SettingsNavItem",
+		blockName: tabBlockName(label, "NavItem"),
 		componentProps: { value },
 		children: [textBlock(label)],
 	};
+}
+
+// "User settings" -> "UserSettingsNavItem" — friendly layer names for tab pairs
+export function tabBlockName(label: string, suffix: "NavItem" | "Panel") {
+	const pascal = label
+		.split(/[^a-zA-Z0-9]+/)
+		.filter(Boolean)
+		.map((word) => word[0].toUpperCase() + word.slice(1))
+		.join("");
+	return pascal ? pascal + suffix : suffix;
 }
 
 export function settingsPanel(
@@ -295,6 +306,7 @@ export function settingsPanel(
 ): BlockOptions {
 	return {
 		componentName: "SettingsPanel",
+		blockName: tabBlockName(title, "Panel"),
 		componentProps: { value },
 		children: [
 			{


### PR DESCRIPTION
Adding a Settings tab adds a SettingsNavItem + SettingsPanel with Header + Body. It's hard to keep track of what got added. So, as you add/relabel tabs, the panels and navitem get relabelled along with the panel's header title prop


https://github.com/user-attachments/assets/d6eea521-eeef-4567-9b87-169ea1d9ef09

