### PR TITLE
perf: fix slower selection in a huge block tree

### DIFF
--- a/frontend/src/components/ComponentLayers.vue
+++ b/frontend/src/components/ComponentLayers.vue
@@ -502,7 +502,7 @@ const updateParent = (event) => {
 }
 
 watch(
-	() => canvasStore.activeCanvas?.selectedBlocks,
+	() => canvasStore.activeCanvas?.selectedBlockIds,
 	() => {
 		if (canvasStore.activeCanvas?.selectedBlocks.length) {
 			canvasStore.activeCanvas?.selectedBlocks.forEach((block: Block) => {

--- a/frontend/src/utils/trackTarget.ts
+++ b/frontend/src/utils/trackTarget.ts
@@ -1,17 +1,8 @@
-// Extracted from Builder - modified later
-import { useElementBounding, useMutationObserver } from "@vueuse/core";
-import { nextTick, reactive, watch, watchEffect } from "vue";
-import { numberToPx } from "./helpers";
-import type { CanvasProps } from "@/types/StudioCanvas";
-
-declare global {
-	interface Window {
-		observer: any;
-	}
-}
-
-window.observer = null;
-const updateList: (() => void)[] = [];
+// Ported from Builder - modified to support multiple targets per host (slot overlays)
+import { useElementBounding } from "@vueuse/core"
+import { effectScope, getCurrentScope, nextTick, onScopeDispose, reactive, watch, watchEffect } from "vue"
+import { numberToPx } from "./helpers"
+import type { CanvasProps } from "@/types/StudioCanvas"
 
 export interface Tracker {
 	update: () => void
@@ -20,57 +11,76 @@ export interface Tracker {
 
 type Target = HTMLElement | SVGElement
 
-function trackTarget(target: Target | Target[], host: HTMLElement, canvasProps: CanvasProps): Tracker {
-	const targets = Array.isArray(target) ? target : [target];
-	const boundsList = targets.map((el) => reactive(useElementBounding(el)));
-	const update = () => boundsList.forEach((bounds) => bounds.update());
-	const container = targets[0]?.closest(".canvas-container");
-	// TODO: too much? find a better way to track changes
-	updateList.push(update);
-	const stopWatch = watch(canvasProps, () => nextTick(update), { deep: true })
+// All tracked targets share one MutationObserver on the canvas container. It is
+// created when the first target registers and disconnected once the last one is
+// removed, so it survives individual ComponentEditor remounts (a component-scoped
+// observer would die with whichever editor happened to create it) without leaking
+// stale updaters across the session.
+const updateList = new Set<() => void>()
+let observer: MutationObserver | null = null
 
-	if (!window.observer) {
-		let callback = () => {
-			nextTick(() => {
-				updateList.forEach((fn) => {
-					fn();
-				});
-			});
-		};
-		window.observer = useMutationObserver(container as HTMLElement, callback, {
-			attributes: true,
-			childList: true,
-			subtree: true,
-			attributeFilter: ["style", "class"],
-			characterData: true,
-		});
+function trackTarget(target: Target | Target[], host: HTMLElement, canvasProps: CanvasProps): Tracker {
+	const targets = Array.isArray(target) ? target : [target]
+	// detached scope so trackers created outside component context (slot overlays
+	// built in nextTick) still dispose their watchers and listeners on cleanup
+	const scope = effectScope(true)
+	const boundsList = scope.run(() => targets.map((el) => reactive(useElementBounding(el))))!
+	const update = () => boundsList.forEach((bounds) => bounds.update())
+
+	updateList.add(update)
+	const container = targets[0]?.closest(".canvas-container") as HTMLElement | null
+	if (container && !observer) {
+		startObserver(container)
 	}
 
-	const stopEffect = watchEffect(() => {
-		// span the union bounding box so a slot with multiple top-level blocks is fully covered
-		const top = Math.min(...boundsList.map((bounds) => bounds.top))
-		const left = Math.min(...boundsList.map((bounds) => bounds.left))
-		const right = Math.max(...boundsList.map((bounds) => bounds.right))
-		const bottom = Math.max(...boundsList.map((bounds) => bounds.bottom))
-		host.style.width = numberToPx(right - left, false)
-		host.style.height = numberToPx(bottom - top, false)
-		host.style.top = numberToPx(top, false)
-		host.style.left = numberToPx(left, false)
-	});
+	scope.run(() => {
+		watch(canvasProps, () => nextTick(update), { deep: true })
+
+		watchEffect(() => {
+			// span the union bounding box so a slot with multiple top-level blocks is fully covered
+			const top = Math.min(...boundsList.map((bounds) => bounds.top))
+			const left = Math.min(...boundsList.map((bounds) => bounds.left))
+			const right = Math.max(...boundsList.map((bounds) => bounds.right))
+			const bottom = Math.max(...boundsList.map((bounds) => bounds.bottom))
+			host.style.width = numberToPx(right - left, false)
+			host.style.height = numberToPx(bottom - top, false)
+			host.style.top = numberToPx(top, false)
+			host.style.left = numberToPx(left, false)
+		})
+	})
 
 	const cleanup = () => {
-		const index = updateList.indexOf(update)
-		if (index > -1) {
-			updateList.splice(index, 1)
+		updateList.delete(update)
+		scope.stop()
+		if (updateList.size === 0 && observer) {
+			observer.disconnect()
+			observer = null
 		}
-		stopWatch()
-		stopEffect()
-	};
+	}
+
+	// auto-cleanup with the owning component; explicit cleanup() stays for
+	// trackers whose targets change while the component lives (slot overlays)
+	if (getCurrentScope()) {
+		onScopeDispose(cleanup)
+	}
 
 	return {
 		update,
 		cleanup,
 	}
+}
+
+function startObserver(container: HTMLElement) {
+	observer = new MutationObserver(() => {
+		nextTick(() => updateList.forEach((fn) => fn()))
+	})
+	observer.observe(container, {
+		attributes: true,
+		childList: true,
+		subtree: true,
+		attributeFilter: ["style", "class"],
+		characterData: true,
+	})
 }
 
 export default trackTarget


### PR DESCRIPTION
1. Watch selected block IDs instead of watching the whole block tree in the Layers panel
2. Auto-dispose overlay trackers and shared MutationObserver