### PR TITLE
fix: skip applying block styles on proxy components

### DIFF
--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -146,7 +146,15 @@ const slotClasses = ["__studio_component_slot__", "outline-none", "select-none"]
 
 const canvasProps = inject("canvasProps") as CanvasProps
 
+const rendersProxy = computed(() => {
+	if (canvasStore.editingMode === "page" || props.block.isContainer()) return false
+	return Boolean(props.block.getProxyComponent())
+})
+
 const styles = computed(() => {
+	// Isolate proxies from block styles entirely since they never reach a teleported overlay at runtime,
+	// and falling through onto a proxy they'd clobber its placement.
+	if (rendersProxy.value) return {}
 	const _styles = { ...props.block.getStyles(props.breakpoint) }
 	Object.entries(_styles).forEach(([key, value]) => {
 		if (value) {
@@ -169,13 +177,7 @@ const isOverlayNode = computed(() => {
 const componentName = computed(() => {
 	if (props.block.isContainer()) return props.block.originalElement || "div"
 
-	let name
-	if (canvasStore.editingMode === "page") {
-		name = props.block.componentName
-	} else {
-		const proxyComponent = props.block.getProxyComponent()
-		name = proxyComponent ? proxyComponent : props.block.componentName
-	}
+	let name = rendersProxy.value ? props.block.getProxyComponent() : props.block.componentName
 
 	if (props.block.isCustomVueComponent) {
 		name = customVueComponentsRegistry.value[name]


### PR DESCRIPTION
**Before:**

Old dialogs might have `position: static` in their styles, and [this change](https://github.com/frappe/studio/pull/223/changes) made dialogs absolutely positioned on the fragment canvas. Absolute positioning was overwritten by static positioning. But margin: 0 auto and transform: translateY(-50%) still apply to static elements. So old dialogs appeared outside the canvas

<img width="1511" height="591" alt="image" src="https://github.com/user-attachments/assets/2256eea7-c5ba-4114-96a1-90a9b67b53f4" />


**After**:

Skip applying block styles on proxy components. They never reach the actual overlay anyway

<img width="1511" height="626" alt="image" src="https://github.com/user-attachments/assets/b13524ce-5963-4e03-87dd-3db7f422df24" />
