### PR TITLE
fix: drop empty strings/objects/arrays in JSON exports

### DIFF
--- a/studio/export.py
+++ b/studio/export.py
@@ -8,6 +8,8 @@ from frappe.modules.export_file import strip_default_fields
 
 from studio.sync_json import cache_synced_file_hash
 
+PRESERVED_EMPTY_PROPERTIES = frozenset({"componentProps", "componentSlots"})
+
 
 def write_document_file(doc, folder=None, exclude_fields=None):
 	doc_export = doc.as_dict(no_nulls=True)
@@ -77,6 +79,9 @@ def remove_null_fields(docdict):
 	"""remove null and empty fields"""
 	to_remove = []
 	for attr, value in docdict.items():
+		if attr in PRESERVED_EMPTY_PROPERTIES:
+			continue
+
 		if isinstance(value, list):
 			if not value:
 				to_remove.append(attr)

--- a/studio/export.py
+++ b/studio/export.py
@@ -76,32 +76,21 @@ def parse_json(field):
 
 
 def remove_empty_values(docdict):
-	"""Recursively remove null and empty fields"""
+	"""Remove empty fields from documents, child rows, and block children."""
 	to_remove = []
 	for attr, value in docdict.items():
 		if attr in PRESERVED_EMPTY_PROPERTIES:
 			continue
 
 		if isinstance(value, list):
+			for item in value:
+				if isinstance(item, dict):
+					remove_empty_values(item)
 			if not value:
 				to_remove.append(attr)
-			else:
-				for v in value:
-					if isinstance(v, dict):
-						remove_empty_values(v)
-
-				value[:] = [v for v in value if not (isinstance(v, dict) and not v)]
-
-				if not value:
-					to_remove.append(attr)
-
 		elif isinstance(value, dict):
 			if not value:
 				to_remove.append(attr)
-			else:
-				remove_empty_values(value)
-				if not value:
-					to_remove.append(attr)
 		elif value is None or value == "":
 			to_remove.append(attr)
 

--- a/studio/export.py
+++ b/studio/export.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+
 import frappe
 from frappe.modules import scrub
 from frappe.modules.export_file import strip_default_fields
@@ -16,7 +17,7 @@ def write_document_file(doc, folder=None, exclude_fields=None):
 	remove_null_fields(doc_export)
 	for field in exclude_fields or []:
 		doc_export.pop(field, None)
-		
+
 	fname = scrub(doc_export.name)
 	path = os.path.join(folder, f"{fname}.json")
 	if Path(path).resolve().is_relative_to(Path(frappe.get_site_path()).resolve()):
@@ -83,9 +84,9 @@ def remove_null_fields(docdict):
 				for v in value:
 					if isinstance(v, dict):
 						remove_null_fields(v)
-				
+
 				value[:] = [v for v in value if not (isinstance(v, dict) and not v)]
-				
+
 				if not value:
 					to_remove.append(attr)
 
@@ -96,10 +97,8 @@ def remove_null_fields(docdict):
 				remove_null_fields(value)
 				if not value:
 					to_remove.append(attr)
-		elif not value:
+		elif value is None or value == "":
 			to_remove.append(attr)
 
 	for attr in to_remove:
 		del docdict[attr]
-
-

--- a/studio/export.py
+++ b/studio/export.py
@@ -16,7 +16,7 @@ def write_document_file(doc, folder=None, exclude_fields=None):
 	doc.run_method("before_export", doc_export)
 	doc_export = strip_default_fields(doc, doc_export)
 	# Fields written to a companion file (e.g. a Code field exported as .js) are dropped from JSON.
-	remove_null_fields(doc_export)
+	remove_empty_values(doc_export)
 	for field in exclude_fields or []:
 		doc_export.pop(field, None)
 
@@ -75,8 +75,8 @@ def parse_json(field):
 	return
 
 
-def remove_null_fields(docdict):
-	"""remove null and empty fields"""
+def remove_empty_values(docdict):
+	"""Recursively remove null and empty fields"""
 	to_remove = []
 	for attr, value in docdict.items():
 		if attr in PRESERVED_EMPTY_PROPERTIES:
@@ -88,7 +88,7 @@ def remove_null_fields(docdict):
 			else:
 				for v in value:
 					if isinstance(v, dict):
-						remove_null_fields(v)
+						remove_empty_values(v)
 
 				value[:] = [v for v in value if not (isinstance(v, dict) and not v)]
 
@@ -99,7 +99,7 @@ def remove_null_fields(docdict):
 			if not value:
 				to_remove.append(attr)
 			else:
-				remove_null_fields(value)
+				remove_empty_values(value)
 				if not value:
 					to_remove.append(attr)
 		elif value is None or value == "":

--- a/studio/export.py
+++ b/studio/export.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from pathlib import Path
-
 import frappe
 from frappe.modules import scrub
 from frappe.modules.export_file import strip_default_fields
@@ -13,11 +12,11 @@ def write_document_file(doc, folder=None, exclude_fields=None):
 	doc_export = doc.as_dict(no_nulls=True)
 	doc.run_method("before_export", doc_export)
 	doc_export = strip_default_fields(doc, doc_export)
-
 	# Fields written to a companion file (e.g. a Code field exported as .js) are dropped from JSON.
+	remove_null_fields(doc_export)
 	for field in exclude_fields or []:
 		doc_export.pop(field, None)
-
+		
 	fname = scrub(doc_export.name)
 	path = os.path.join(folder, f"{fname}.json")
 	if Path(path).resolve().is_relative_to(Path(frappe.get_site_path()).resolve()):
@@ -78,11 +77,29 @@ def remove_null_fields(docdict):
 	to_remove = []
 	for attr, value in docdict.items():
 		if isinstance(value, list):
-			for v in value:
-				if isinstance(v, dict):
-					remove_null_fields(v)
+			if not value:
+				to_remove.append(attr)
+			else:
+				for v in value:
+					if isinstance(v, dict):
+						remove_null_fields(v)
+				
+				value[:] = [v for v in value if not (isinstance(v, dict) and not v)]
+				
+				if not value:
+					to_remove.append(attr)
+
+		elif isinstance(value, dict):
+			if not value:
+				to_remove.append(attr)
+			else:
+				remove_null_fields(value)
+				if not value:
+					to_remove.append(attr)
 		elif not value:
 			to_remove.append(attr)
 
 	for attr in to_remove:
 		del docdict[attr]
+
+

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -9,7 +9,7 @@ from frappe.utils import get_files_path
 from frappe.website.page_renderers.document_page import DocumentPage
 from frappe.website.website_generator import WebsiteGenerator
 
-from studio.export import can_export, delete_folder, remove_null_fields, write_document_file
+from studio.export import can_export, delete_folder, write_document_file
 from studio.realtime import publish_doc_change
 
 
@@ -132,9 +132,6 @@ class StudioApp(WebsiteGenerator):
 		if not self.flags.in_insert and self.has_value_changed("is_standard") and not self.is_standard:
 			self.delete_app_folder()
 		publish_doc_change("Studio App", self.name, self.name)
-
-	def before_export(self, doc):
-		remove_null_fields(doc)
 
 	def on_trash(self):
 		for page in self.pages:

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -265,9 +265,6 @@ class StudioPage(Document):
 		doc.name = self.get_export_docname()
 		doc.blocks = parse_json(doc.blocks)
 		doc.draft_blocks = parse_json(doc.draft_blocks)
-
-		remove_null_fields(doc)
-
 	def before_import(self):
 		self.name = self.page_name
 

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -14,7 +14,6 @@ from studio.export import (
 	can_export,
 	delete_folder,
 	parse_json,
-	remove_null_fields,
 	write_code_file,
 	write_document_file,
 )
@@ -265,6 +264,7 @@ class StudioPage(Document):
 		doc.name = self.get_export_docname()
 		doc.blocks = parse_json(doc.blocks)
 		doc.draft_blocks = parse_json(doc.draft_blocks)
+
 	def before_import(self):
 		self.name = self.page_name
 

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -3,6 +3,7 @@
 
 # import frappe
 from frappe.tests.utils import FrappeTestCase
+
 from studio.export import remove_null_fields
 
 
@@ -10,37 +11,21 @@ class TestStudioPage(FrappeTestCase):
 	def test_remove_null_fields(self):
 		test_dict = {
 			"keep_this": "value",
+			"keep_false": False,
+			"keep_zero": 0,
 			"remove_this_null": None,
 			"remove_this_empty_list": [],
-			"remove_this_empty_dict": {
-				"some_dict":{
-					"some_more_dict":{
-
-					}
+			"remove_this_empty_dict": {"some_dict": {"some_more_dict": {}}},
+			"nested_dict": {"keep_nested": 123, "remove_nested_null": None, "empty_nested_dict": {}},
+			"nested_list": [{"keep_list_dict": "", "remove_list_null": None}, {}],
+			"new_nested_list": [
+				{
+					"new_nested_list": [{"new_nested_list_again": []}],
 				}
-			},
-			"nested_dict": {
-				"keep_nested": 123,
-				"remove_nested_null": None,
-				"empty_nested_dict": {}
-			},
-			"nested_list": [
-				{"keep_list_dict": "", "remove_list_null": None},
-				{}
 			],
-			"new_nested_list":[
-				{"new_nested_list":[
-					{"new_nested_list_again":[]}
-
-				],
-				}
-			]
 		}
 		remove_null_fields(test_dict)
-		print(test_dict)
-		self.assertEqual(test_dict, {
-			"keep_this": "value",
-			"nested_dict": {
-				"keep_nested": 123
-			}
-		})
+		self.assertEqual(
+			test_dict,
+			{"keep_this": "value", "keep_false": False, "keep_zero": 0, "nested_dict": {"keep_nested": 123}},
+		)

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -3,7 +3,44 @@
 
 # import frappe
 from frappe.tests.utils import FrappeTestCase
+from studio.export import remove_null_fields
 
 
 class TestStudioPage(FrappeTestCase):
-	pass
+	def test_remove_null_fields(self):
+		test_dict = {
+			"keep_this": "value",
+			"remove_this_null": None,
+			"remove_this_empty_list": [],
+			"remove_this_empty_dict": {
+				"some_dict":{
+					"some_more_dict":{
+
+					}
+				}
+			},
+			"nested_dict": {
+				"keep_nested": 123,
+				"remove_nested_null": None,
+				"empty_nested_dict": {}
+			},
+			"nested_list": [
+				{"keep_list_dict": "", "remove_list_null": None},
+				{}
+			],
+			"new_nested_list":[
+				{"new_nested_list":[
+					{"new_nested_list_again":[]}
+
+				],
+				}
+			]
+		}
+		remove_null_fields(test_dict)
+		print(test_dict)
+		self.assertEqual(test_dict, {
+			"keep_this": "value",
+			"nested_dict": {
+				"keep_nested": 123
+			}
+		})

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -4,11 +4,11 @@
 # import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from studio.export import remove_null_fields
+from studio.export import remove_empty_values
 
 
 class TestStudioPage(FrappeTestCase):
-	def test_remove_null_fields(self):
+	def test_remove_empty_values(self):
 		test_dict = {
 			"keep_this": "value",
 			"keep_false": False,
@@ -28,7 +28,7 @@ class TestStudioPage(FrappeTestCase):
 				}
 			],
 		}
-		remove_null_fields(test_dict)
+		remove_empty_values(test_dict)
 		self.assertEqual(
 			test_dict,
 			{

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -17,6 +17,10 @@ class TestStudioPage(FrappeTestCase):
 			"remove_this_empty_list": [],
 			"remove_this_empty_dict": {"some_dict": {"some_more_dict": {}}},
 			"nested_dict": {"keep_nested": 123, "remove_nested_null": None, "empty_nested_dict": {}},
+			"block": {
+				"componentProps": {"empty_value": "", "false_value": False},
+				"componentSlots": {},
+			},
 			"nested_list": [{"keep_list_dict": "", "remove_list_null": None}, {}],
 			"new_nested_list": [
 				{
@@ -27,5 +31,14 @@ class TestStudioPage(FrappeTestCase):
 		remove_null_fields(test_dict)
 		self.assertEqual(
 			test_dict,
-			{"keep_this": "value", "keep_false": False, "keep_zero": 0, "nested_dict": {"keep_nested": 123}},
+			{
+				"keep_this": "value",
+				"keep_false": False,
+				"keep_zero": 0,
+				"nested_dict": {"keep_nested": 123},
+				"block": {
+					"componentProps": {"empty_value": "", "false_value": False},
+					"componentSlots": {},
+				},
+			},
 		)

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -15,16 +15,19 @@ class TestStudioPage(FrappeTestCase):
 			"keep_zero": 0,
 			"remove_this_null": None,
 			"remove_this_empty_list": [],
-			"remove_this_empty_dict": {"some_dict": {"some_more_dict": {}}},
-			"nested_dict": {"keep_nested": 123, "remove_nested_null": None, "empty_nested_dict": {}},
-			"block": {
-				"componentProps": {"empty_value": "", "false_value": False},
-				"componentSlots": {},
-			},
-			"nested_list": [{"keep_list_dict": "", "remove_list_null": None}, {}],
-			"new_nested_list": [
+			"remove_this_empty_dict": {},
+			"nested_config": {"empty_value": "", "empty_dict": {}},
+			"blocks": [
 				{
-					"new_nested_list": [{"new_nested_list_again": []}],
+					"componentName": "Button",
+					"remove_empty_string": "",
+					"remove_empty_list": [],
+					"remove_empty_dict": {},
+					"componentProps": {"empty_value": "", "false_value": False},
+					"componentSlots": {},
+					"children": [
+						{"componentName": "TextBlock", "remove_empty_string": ""},
+					],
 				}
 			],
 		}
@@ -35,10 +38,14 @@ class TestStudioPage(FrappeTestCase):
 				"keep_this": "value",
 				"keep_false": False,
 				"keep_zero": 0,
-				"nested_dict": {"keep_nested": 123},
-				"block": {
-					"componentProps": {"empty_value": "", "false_value": False},
-					"componentSlots": {},
-				},
+				"nested_config": {"empty_value": "", "empty_dict": {}},
+				"blocks": [
+					{
+						"componentName": "Button",
+						"componentProps": {"empty_value": "", "false_value": False},
+						"componentSlots": {},
+						"children": [{"componentName": "TextBlock"}],
+					}
+				],
 			},
 		)


### PR DESCRIPTION
 I have added few recursive checks for the json file and then removing them recusively through remove_null_fields function. Below are the results.
 Before the changes:
<img width="1397" height="967" alt="before-bug-229" src="https://github.com/user-attachments/assets/cddc3e9c-45e9-4e5e-b018-9dbdd4efdcae" />

After the changes:
<img width="957" height="862" alt="after-bug-229" src="https://github.com/user-attachments/assets/15f2f174-eaa8-4141-b3ea-4af770625003" />

Have ran migration :
<img width="1135" height="665" alt="bug-#229-migrate" src="https://github.com/user-attachments/assets/48e1ca81-8ed5-49aa-a6cb-9ee2ae021c6e" />

