### PR TITLE
fix: resolve @tiptap/core from studio for exported apps

### DIFF
--- a/frontend/vite/sharedDependencyResolver.js
+++ b/frontend/vite/sharedDependencyResolver.js
@@ -5,14 +5,17 @@ import path from "path"
 // node_modules. So @framework/ui source must resolve it to Studio's single copy —
 // unlike the app's real deps (dompurify/vuedraggable/leaflet) which are installed
 // under apps/frappe/ui and resolve by realpath.
-const STUDIO_SHARED_DEPS = ["vue", "vue-router", "pinia", "frappe-ui", "reka-ui"]
+// @tiptap/core is here for the same reason: frappe-ui's TextEditor takes `extensions`
+// built from it, and an app has no copy of its own to build them with — nor should it,
+// since an extension made from a second copy never registers against the editor's schema.
+const STUDIO_SHARED_DEPS = ["vue", "vue-router", "pinia", "frappe-ui", "reka-ui", "@tiptap/core"]
 /**
  * Vite plugin to redirect shared dependency imports from files outside the Studio
  * project (custom Vue components and @framework/ui source) to Studio's own
  * installations.
  *
- * These are singleton deps (vue, vue-router, frappe-ui, reka-ui) that must resolve
- * from Studio to avoid duplicate instances. App-specific deps (including
+ * These are singleton deps (vue, vue-router, frappe-ui, reka-ui, @tiptap/core) that must
+ * resolve from Studio to avoid duplicate instances. App-specific deps (including
  * @framework/ui's own dompurify/vuedraggable/leaflet) resolve normally from the
  * app's own node_modules.
  */

--- a/frontend/vite/sharedDependencyResolver.js
+++ b/frontend/vite/sharedDependencyResolver.js
@@ -5,16 +5,17 @@ import path from "path"
 // node_modules. So @framework/ui source must resolve it to Studio's single copy —
 // unlike the app's real deps (dompurify/vuedraggable/leaflet) which are installed
 // under apps/frappe/ui and resolve by realpath.
-// @tiptap/core is here for the same reason: frappe-ui's TextEditor takes `extensions`
-// built from it, and an app has no copy of its own to build them with — nor should it,
-// since an extension made from a second copy never registers against the editor's schema.
-const STUDIO_SHARED_DEPS = ["vue", "vue-router", "pinia", "frappe-ui", "reka-ui", "@tiptap/core"]
+// The whole @tiptap scope is here for the same reason: frappe-ui's TextEditor takes
+// `extensions` built from @tiptap/core, @tiptap/pm, @tiptap/vue-3, @tiptap/extension-*
+// etc., and an app has no copies of its own to build them with — nor should it, since
+// an extension made from a second copy never registers against the editor's schema.
+const STUDIO_SHARED_DEPS = ["vue", "vue-router", "pinia", "frappe-ui", "reka-ui", "@tiptap"]
 /**
  * Vite plugin to redirect shared dependency imports from files outside the Studio
  * project (custom Vue components and @framework/ui source) to Studio's own
  * installations.
  *
- * These are singleton deps (vue, vue-router, frappe-ui, reka-ui, @tiptap/core) that must
+ * These are singleton deps (vue, vue-router, frappe-ui, reka-ui, @tiptap/*) that must
  * resolve from Studio to avoid duplicate instances. App-specific deps (including
  * @framework/ui's own dompurify/vuedraggable/leaflet) resolve normally from the
  * app's own node_modules.


### PR DESCRIPTION
Fixes #236.

Adds `@tiptap/core` to `STUDIO_SHARED_DEPS` so it resolves from Studio's tree, like the other singletons on that list.

A custom Vue component that builds a `TextEditor` extension has to import `Extension`/`Node`/`Mark` from `@tiptap/core`, but tiptap only reaches an exported app transitively through frappe-ui — the app's `studio/<studio_app>/` folder has no `node_modules` of its own. So the import went unresolved and the build failed:

```
Error: [vite]: Rolldown failed to resolve import "@tiptap/core" from
".../studio/helpdesk/components/KbArticleContent.vue?vue&type=script&setup=true&lang.ts"
```

Installing tiptap in the app would not be a fix: an extension built from a second copy of the class never registers against the editor's schema, so it would fail silently instead of loudly. Same reasoning as `reka-ui`, which is on the list already.

### Before

```
✗ Build failed in 19.43s
Build failed with 1 error:
Error: [vite]: Rolldown failed to resolve import "@tiptap/core" ...
✖ Build failed for helpdesk
```

### After

```
✓ built in 16.21s
Vite build completed for helpdesk
✔ Built helpdesk
```

Verified against an exported app whose article page renders through a read-only `TextEditor` with a custom extension: the build passes, and the extension registers against the same editor instance frappe-ui provides.

No UI changes.
