### PR TITLE
fix(vite): serve studio apps installed from outside apps/

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,6 +24,40 @@ const appSymlinkedSources = fs.readdirSync(appsDir).flatMap((entry) => {
 	}
 })
 
+// An app can also be installed from outside apps/ without a symlink — bench records the
+// checkout it resolves to as a .pth in the venv, and `frappe.get_app_source_path` hands the
+// editor component paths from there. Read the same registry so fs.allow stays in step with
+// the paths the API advertises.
+const appPthSources = readPthAppSources().flatMap((source) => {
+	const studioDir = path.join(source, "studio")
+	return fs.existsSync(studioDir) ? [studioDir] : []
+})
+
+function readPthAppSources() {
+	const libDir = path.resolve(appsDir, "..", "env", "lib")
+	if (!fs.existsSync(libDir)) return []
+	return fs.readdirSync(libDir).flatMap((pythonDir) => {
+		const sitePackages = path.join(libDir, pythonDir, "site-packages")
+		if (!fs.existsSync(sitePackages)) return []
+		return fs
+			.readdirSync(sitePackages)
+			.filter((entry) => entry.endsWith(".pth"))
+			.flatMap((entry) => readPthLines(path.join(sitePackages, entry)))
+	})
+}
+
+function readPthLines(pthFile) {
+	try {
+		return fs
+			.readFileSync(pthFile, "utf8")
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => path.isAbsolute(line))
+	} catch {
+		return []
+	}
+}
+
 // @framework/ui (apps/frappe/ui) only exists on newer frappe (develop). On older
 // frappe it's absent, so its vite plugin, aliases, and component imports must be
 // skipped or the studio build breaks. This flag gates all of them.
@@ -60,7 +94,7 @@ export default defineConfig(async () => {
 			fs: {
 				// Allow serving custom Vue components and page scripts from any app, including ones
 				// symlinked from outside apps/
-				allow: [appsDir, ...appSymlinkedSources],
+				allow: [appsDir, ...appSymlinkedSources, ...appPthSources],
 			},
 			watch: {
 				// unplugin-vue-components generates this file which causes HMR while building other studio apps


### PR DESCRIPTION
Fixes #240

### Problem

An app whose source lives outside `apps/` can be installed two ways: symlinked into `apps/`, or installed from its checkout with bench recording the location in `env/lib/python*/site-packages/<app>.pth` while `apps/<app>` stays a real directory.

`fs.allow` only handles the first. `studio.api.get_custom_vue_components` resolves through `frappe.get_app_source_path`, which follows the `.pth` — so for the second the API advertises component paths the dev server then answers with **403**, and the editor renders the page with every custom component missing and nothing on screen to explain it.

### Fix

Read the same registry the API resolves through, and allow only each app's `studio/` folder — the same narrow scope `a4b6c57` established.

```js
allow: [appsDir, ...appSymlinkedSources, ...appPthSources],
```

### Verification

On a bench where `helpdesk.pth` points at a worktree and `apps/helpdesk` is a real directory holding a different branch:

| | component fetch (`.vue?raw`) | editor canvas |
|---|---|---|
| develop `58de51d` | `403` | renders without any custom component |
| with this change | `200` | renders the thread, details sidebar and composer |

Both measured against the same running dev server, with the fix as the only variable. The 403 is what distinguishes this from a URL-form problem — `/@fs/`-prefixing the path returns 403 too, so prefixing is not the issue.

### Scope

Additive: `appSymlinkedSources` is untouched, so benches that symlink apps into `apps/` behave exactly as before. `readPthAppSources` returns `[]` when the venv or a `.pth` is unreadable, so a bench laid out differently just gets the previous allow-list. Dev-server only — no effect on `build_standard_apps` or production output.

I have verified the `.pth` case on my bench; I have not had a symlinked-app bench to re-verify that path, though this change does not touch it.
