### PR TITLE
feat: serve page definitions to the renderer without Studio roles

### DIFF
--- a/frontend/src/pages/AppContainer.vue
+++ b/frontend/src/pages/AppContainer.vue
@@ -45,15 +45,13 @@ async function loadPage() {
 	}
 	codeStore.teardownPage()
 
-	page.value = await findPageWithRoute(window.app_name, currentPath)
+	page.value = await findPageWithRoute(window.app_name, currentPath, Boolean(window.is_preview))
 	if (token !== loadToken || !page.value) return
 	await store.setPageData(page.value)
 	await codeStore.setPageScript(page.value, Boolean(page.value.is_standard))
 	if (token !== loadToken) return
 
-	const blocks = window.is_preview
-		? JSON.parse(page.value?.draft_blocks || page.value?.blocks)
-		: JSON.parse(page.value?.blocks)
+	const blocks = JSON.parse(page.value?.blocks)
 	if (blocks) {
 		rootBlock.value = getBlockInstance(blocks[0])
 	}

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -16,8 +16,8 @@ const useAppStore = defineStore("appStore", () => {
 
 	async function setPageData(page: StudioPage) {
 		activePage.value = page
-		await codeStore.setPageVariables(page)
-		await codeStore.setPageResources(page)
+		await codeStore.setPageVariables(page, page.variables)
+		await codeStore.setPageResources(page, false, page.resources)
 	}
 
 	return {

--- a/frontend/src/stores/codeStore.ts
+++ b/frontend/src/stores/codeStore.ts
@@ -62,18 +62,26 @@ const useCodeStore = defineStore("codeStore", () => {
 
 	// RESOURCES
 	let pendingResources: Record<string, any> | null = null
-	async function setPageResources(page: StudioPage, setResourceConfig: boolean = false) {
+	async function setPageResources(
+		page: StudioPage,
+		setResourceConfig: boolean = false,
+		preloadedResources?: Resource[],
+	) {
 		stopResourceWatchers()
 		// Each load uses its own map, so old async updates cannot change the current page resources.
 		const pageResources = reactive({}) as Record<string, any>
 		pendingResources = pageResources
 
-		studioPageResources.filters = { parent: page.name }
-		await studioPageResources.reload()
-		if (pendingResources !== pageResources) return
+		let resourceRows = preloadedResources
+		if (!resourceRows) {
+			studioPageResources.filters = { parent: page.name }
+			await studioPageResources.reload()
+			if (pendingResources !== pageResources) return
+			resourceRows = studioPageResources.data
+		}
 
 		await Promise.all(
-			studioPageResources.data.map(async (resource: Resource) => {
+			resourceRows.map(async (resource: Resource) => {
 				await addPageResource(resource, pageResources)
 				const newResource = pageResources[resource.resource_name]
 				if (setResourceConfig && newResource) {
@@ -315,12 +323,16 @@ const useCodeStore = defineStore("codeStore", () => {
 	}
 
 	// VARIABLES
-	async function setPageVariables(page: StudioPage) {
-		studioVariables.filters = { parent: page.name }
-		await studioVariables.reload()
+	async function setPageVariables(page: StudioPage, preloadedVariables?: Variable[]) {
+		let variableRows = preloadedVariables
+		if (!variableRows) {
+			studioVariables.filters = { parent: page.name }
+			await studioVariables.reload()
+			variableRows = studioVariables.data
+		}
 		variables.value = {}
 
-		studioVariables.data.map((variable: Variable) => {
+		variableRows.map((variable: Variable) => {
 			variables.value[variable.variable_name] = getInitialVariableValue(variable)
 		})
 	}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -286,15 +286,20 @@ async function fetchPage(pageName: string) {
 	return pageResource.doc
 }
 
-async function findPageWithRoute(appName: string, pageRoute: string) {
-	let pageName = createResource({
-		url: "studio.studio.doctype.studio_page.studio_page.find_page_with_route",
+// Fetches the page definition (blocks + resources + variables) in one unprivileged call.
+// Data the page renders stays permission-checked by the endpoints its resources call.
+async function findPageWithRoute(appName: string, pageRoute: string, preview: boolean = false) {
+	const page = createResource({
+		url: "studio.studio.doctype.studio_page.studio_page.get_page",
 		method: "GET",
-		params: { app_name: appName, page_route: pageRoute },
+		params: { app_name: appName, page_route: pageRoute, preview },
 	})
-	await pageName.fetch()
-	pageName = pageName.data
-	return fetchPage(pageName)
+	try {
+		await page.fetch()
+	} catch (error) {
+		return null
+	}
+	return page.data
 }
 
 // extract dynamic route variables from a vue-router route, e.g. "/articles/:category" -> ["category"]

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 import json
 import os
+from urllib.parse import quote
 
 import frappe
 from frappe import _
@@ -14,6 +15,13 @@ from studio.realtime import publish_doc_change
 
 
 class StudioAppRenderer(DocumentPage):
+	def render(self):
+		# redirect guests to login instead of serving a dead page.
+		if frappe.session.user == "Guest":
+			frappe.flags.redirect_location = f"/login?redirect-to=/{quote(self.path)}"
+			raise frappe.Redirect(http_status_code=302)
+		return super().render()
+
 	def can_render(self):
 		if app := self.find_app_for_path():
 			self.doctype = "Studio App"

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -377,6 +377,59 @@ def find_page_with_route(app_name: str, page_route: str) -> str | None:
 		pass
 
 
+PAGE_RESOURCE_FIELDS = (
+	"resource_type",
+	"resource_name",
+	"auto",
+	"fields",
+	"filters",
+	"limit",
+	"sort_field",
+	"sort_order",
+	"document_type",
+	"document_name",
+	"fetch_document_using_filters",
+	"url",
+	"method",
+	"params",
+	"whitelisted_methods",
+	"transform",
+	"on_success",
+	"on_error",
+)
+
+PAGE_VARIABLE_FIELDS = ("variable_name", "variable_type", "initial_value")
+
+
+@frappe.whitelist(methods=["GET"])
+def get_page(app_name: str, page_route: str, preview: bool = False) -> dict:
+	"""Serve a page definition to the app renderer in a single call, without DocType
+	permission checks — a page definition is markup; the data it fetches stays
+	permission-checked by the endpoints its resources call."""
+	page_name = find_page_with_route(app_name, page_route)
+	if not page_name:
+		frappe.throw(_("Page not found"), frappe.DoesNotExistError)
+
+	page = frappe.get_cached_doc("Studio Page", page_name)
+	return {
+		"name": page.name,
+		"page_title": page.page_title,
+		"route": page.route,
+		"studio_app": page.studio_app,
+		"is_standard": page.is_standard,
+		"script": page.script,
+		"blocks": (page.draft_blocks or page.blocks) if preview else page.blocks,
+		"resources": [
+			{"resource_id": row.name, **{field: row.get(field) for field in PAGE_RESOURCE_FIELDS}}
+			for row in page.resources
+		],
+		"variables": [
+			{"name": row.name, **{field: row.get(field) for field in PAGE_VARIABLE_FIELDS}}
+			for row in page.variables
+		],
+	}
+
+
 @frappe.whitelist()
 def duplicate_page(page_name: str, app_name: str | None):
 	if not frappe.has_permission("Studio Page", ptype="write"):

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -403,14 +403,26 @@ PAGE_VARIABLE_FIELDS = ("variable_name", "variable_type", "initial_value")
 
 @frappe.whitelist(methods=["GET"])
 def get_page(app_name: str, page_route: str, preview: bool = False) -> dict:
-	"""Serve a page definition to the app renderer in a single call, without DocType
-	permission checks — a page definition is markup; the data it fetches stays
-	permission-checked by the endpoints its resources call."""
+	"""Serve a page definition to the app renderer in a single call.
+
+	Published pages need no role — a published definition is markup; the data it
+	fetches stays permission-checked by the endpoints its resources call. Drafts
+	and unpublished pages are only served in preview, which requires read access
+	on Studio Page."""
 	page_name = find_page_with_route(app_name, page_route)
 	if not page_name:
 		frappe.throw(_("Page not found"), frappe.DoesNotExistError)
 
 	page = frappe.get_cached_doc("Studio Page", page_name)
+	if preview:
+		frappe.has_permission("Studio Page", ptype="read", throw=True)
+		blocks = page.draft_blocks or page.blocks
+	else:
+		# unpublished routes 404 like nonexistent ones, so the endpoint doesn't confirm they exist
+		if not page.published:
+			frappe.throw(_("Page not found"), frappe.DoesNotExistError)
+		blocks = page.blocks
+
 	return {
 		"name": page.name,
 		"page_title": page.page_title,
@@ -418,7 +430,7 @@ def get_page(app_name: str, page_route: str, preview: bool = False) -> dict:
 		"studio_app": page.studio_app,
 		"is_standard": page.is_standard,
 		"script": page.script,
-		"blocks": (page.draft_blocks or page.blocks) if preview else page.blocks,
+		"blocks": blocks,
 		"resources": [
 			{"resource_id": row.name, **{field: row.get(field) for field in PAGE_RESOURCE_FIELDS}}
 			for row in page.resources


### PR DESCRIPTION
- Every navigation fetched a Studio Page doc, so non-studio users couldn't view rendered pages
- The renderer now makes 1 request per navigation instead of 4 to a custom endpoint. The editor keeps its existing permission-checked fetch paths.