### PR TITLE
fix(UX): show component editor only on first repeated instance & faint outlines on others

### DIFF
--- a/frontend/src/components/ComponentEditor.vue
+++ b/frontend/src/components/ComponentEditor.vue
@@ -9,7 +9,7 @@
 	>
 		<!-- Component name label -->
 		<span
-			v-if="!props.block.isRoot()"
+			v-if="!props.block.isRoot() && isPrimaryInstance"
 			class="absolute -top-3 left-0 inline-flex items-center gap-1 text-xs"
 			:class="componentLabelClasses"
 		>
@@ -105,6 +105,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	isPrimaryInstance: {
+		type: Boolean,
+		default: true,
+	},
 })
 
 const store = useStudioStore()
@@ -116,11 +120,18 @@ const tracker = ref<Tracker>()
 const canvasProps = inject("canvasProps") as CanvasProps
 
 const showMarginPaddingHandlers = computed(() => {
-	return isBlockSelected.value && !props.block.isRoot() && !resizing.value && !canvasStore.isDragging
+	return (
+		props.isPrimaryInstance &&
+		isBlockSelected.value &&
+		!props.block.isRoot() &&
+		!resizing.value &&
+		!canvasStore.isDragging
+	)
 })
 
 const showResizer = computed(() => {
 	return (
+		props.isPrimaryInstance &&
 		!props.block.isRoot() &&
 		isBlockSelected.value &&
 		!canvasStore.isDragging &&
@@ -144,6 +155,11 @@ const getStyleClasses = computed(() => {
 		classes.push("ring-outline-purple-4")
 	} else {
 		classes.push("ring-outline-blue-4")
+	}
+
+	if (!props.isPrimaryInstance) {
+		classes.push("opacity-40")
+		return classes
 	}
 
 	if (isBlockSelected.value && !props.block.isRoot() && !canvasStore.isDragging) {
@@ -231,7 +247,12 @@ watchEffect(() => {
 
 // Slot overlay tracking
 const showSlotOverlays = computed(() => {
-	return isBlockSelected.value && !props.block.isRoot() && Object.keys(props.block.componentSlots).length > 0
+	return (
+		props.isPrimaryInstance &&
+		isBlockSelected.value &&
+		!props.block.isRoot() &&
+		Object.keys(props.block.componentSlots).length > 0
+	)
 })
 
 const slotOverlays = ref<Record<string, HTMLElement>>({})

--- a/frontend/src/components/StudioComponent.vue
+++ b/frontend/src/components/StudioComponent.vue
@@ -93,6 +93,7 @@
 			:block="block.extendedFromComponent || block"
 			:breakpoint="breakpoint"
 			:isSelected="isSelected"
+			:isPrimaryInstance="isPrimaryInstance"
 			:target="(target as HTMLElement)"
 		/>
 	</teleport>
@@ -264,6 +265,13 @@ watch(
 	},
 	{ immediate: true },
 )
+
+// Show component editor only on the first instance; the rest render as faint outlines
+const isPrimaryInstance = computed(() => {
+	if (!props.block.isRepeated()) return true
+	const instanceIndex = slotScope?.value?.dataIndex
+	return instanceIndex === undefined || instanceIndex === 0
+})
 
 const target = computed<HTMLElement | null>(() => {
 	if (!componentRef.value) return null


### PR DESCRIPTION
**Before:**

Too much noise with editors, margins, and padding handlers showing up on each repeated block instance

<img width="1512" height="312" alt="image" src="https://github.com/user-attachments/assets/35ccd33d-36b1-4c5e-81b8-07d13408f114" />


**After:**

Show component editor only on the first repeated instance & faint outlines on others

<img width="1512" height="312" alt="image" src="https://github.com/user-attachments/assets/93a145de-5504-40cf-8a62-5b05f4b3b70a" />
