### PR TITLE
fix: serve component definitions to the renderer without Studio roles

### DIFF
--- a/frontend/src/stores/componentStore.ts
+++ b/frontend/src/stores/componentStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia"
 import { markRaw, reactive } from "vue"
-import { createDocumentResource } from "frappe-ui"
+import { createResource } from "frappe-ui"
 import Block from "@/utils/block"
 import type { StudioComponent } from "@/types/Studio/StudioComponent"
 import { isObjectEmpty } from "@/utils/helpers"
@@ -13,13 +13,13 @@ const useComponentStore = defineStore("componentStore", () => {
 	const fetchingComponent = reactive<Set<string>>(new Set())
 
 	async function fetchComponent(componentName: string) {
-		const componentDoc = await createDocumentResource({
-			doctype: "Studio Component",
-			name: componentName,
-			auto: true,
+		const componentDoc = createResource({
+			url: "studio.studio.doctype.studio_component.studio_component.get_component",
+			method: "GET",
+			params: { component_name: componentName },
 		})
-		await componentDoc.get.promise
-		return componentDoc.doc as StudioComponent
+		await componentDoc.fetch()
+		return componentDoc.data as StudioComponent
 	}
 
 	async function getComponent(componentName: string): Promise<Block | undefined> {

--- a/studio/studio/doctype/studio_component/studio_component.py
+++ b/studio/studio/doctype/studio_component/studio_component.py
@@ -53,3 +53,25 @@ class StudioComponent(Document):
 			component_path = os.path.join(app_path, f"{self.component_id}.json")
 			print("Deleting component file at:", component_path)
 			delete_file(component_path)
+
+
+COMPONENT_INPUT_FIELDS = ("input_name", "type", "description", "options", "required", "default")
+
+
+@frappe.whitelist(methods=["GET"])
+def get_component(component_name: str) -> dict:
+	"""Serve a component definition to the app renderer without a DocType permission
+	check — like page definitions (see get_page), a component is markup with no draft
+	state; the data it renders stays permission-checked by the endpoints serving it."""
+	component = frappe.get_cached_doc("Studio Component", component_name)
+	return {
+		"name": component.name,
+		"component_name": component.component_name,
+		"component_id": component.component_id,
+		"block": component.block,
+		"is_disabled": component.is_disabled,
+		"inputs": [
+			{"name": row.name, **{field: row.get(field) for field in COMPONENT_INPUT_FIELDS}}
+			for row in component.inputs
+		],
+	}


### PR DESCRIPTION
Follow-up fix with https://github.com/frappe/studio/pull/242

**Before**:

<img width="3024" height="1712" alt="image" src="https://github.com/user-attachments/assets/a707af58-93de-4db0-9cb3-507d385dc9a4" />
<img width="1512" height="856" alt="comp-perm-2" src="https://github.com/user-attachments/assets/4bae1187-9104-4ca3-bdd4-09ec99f6f774" />

**After**:

<img width="1512" height="856" alt="components" src="https://github.com/user-attachments/assets/8fa2e8cf-fecf-4bc8-af7b-4d2f316a3b4f" />
<img width="3024" height="1712" alt="image" src="https://github.com/user-attachments/assets/49f4f7c5-c131-401a-b4c8-3b285a088aac" />
