### PR TITLE
feat: capture build failure error and show in a dialog

### DIFF
--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -425,7 +425,12 @@ const useStudioStore = defineStore("store", () => {
 					activePage.value = await fetchPage(selectedPage.value!)
 					setAppPages(activeApp.value!.name)
 					openPageInBrowser(activeApp.value!, activePage.value!)
-					toast.success(`App published successfully (${data?.message?.published_pages} pages)`)
+					const buildError = data?.message?.build_error
+					if (buildError) {
+						showBuildErrorToast(buildError, "App published, but the build failed")
+					} else {
+						toast.success(`App published successfully (${data?.message?.published_pages} pages)`)
+					}
 				},
 				onError(error: any) {
 					toast.error("Failed to publish the app", {
@@ -517,14 +522,29 @@ const useStudioStore = defineStore("store", () => {
 			name: activeApp.value.name,
 			method: "generate_app_build",
 		}, {
-			onSuccess() {
-				toast.success("App build generated")
+			onSuccess(data: any) {
+				const buildError = data?.message?.build_error
+				if (buildError) {
+					showBuildErrorToast(buildError)
+				} else {
+					toast.success("App build generated")
+				}
 			},
 			onError(error: any) {
 				toast.warning("Skipped app build due to errors", {
 					description: error?.messages?.join(", "),
 					duration: Infinity,
 				})
+			},
+		})
+	}
+
+	function showBuildErrorToast(buildError: { error_log: string }, title: string = "App build failed") {
+		toast.warning(title, {
+			duration: Infinity,
+			action: {
+				label: "View Error Log",
+				onClick: () => window.open(`/app/error-log/${buildError.error_log}`, "_blank"),
 			},
 		})
 	}

--- a/frontend/src/stores/studioStore.ts
+++ b/frontend/src/stores/studioStore.ts
@@ -347,9 +347,15 @@ const useStudioStore = defineStore("store", () => {
 				}
 			)
 			.then(async () => {
-				await generateAppBuild()
+				const buildError = await generateAppBuild()
 				activePage.value = await fetchPage(selectedPage.value!)
-				if (activeApp.value && activePage.value) {
+				if (!activeApp.value || !activePage.value) return
+				if (buildError) {
+					showBuildErrorDialog(
+						buildError,
+						"The page was published, but the app build failed - it may not reflect your latest changes.",
+					)
+				} else {
 					openPageInBrowser(activeApp.value, activePage.value)
 				}
 			})
@@ -424,11 +430,14 @@ const useStudioStore = defineStore("store", () => {
 				async onSuccess(data: any) {
 					activePage.value = await fetchPage(selectedPage.value!)
 					setAppPages(activeApp.value!.name)
-					openPageInBrowser(activeApp.value!, activePage.value!)
 					const buildError = data?.message?.build_error
 					if (buildError) {
-						showBuildErrorToast(buildError, "App published, but the build failed")
+						showBuildErrorDialog(
+							buildError,
+							"The app was published, but the build failed - published pages may not reflect your latest changes.",
+						)
 					} else {
+						openPageInBrowser(activeApp.value!, activePage.value!)
 						toast.success(`App published successfully (${data?.message?.published_pages} pages)`)
 					}
 				},
@@ -516,36 +525,50 @@ const useStudioStore = defineStore("store", () => {
 	}
 
 	// build
-	function generateAppBuild() {
-		if (!activeApp.value) return
-		return studioApps.runDocMethod.submit({
-			name: activeApp.value.name,
-			method: "generate_app_build",
-		}, {
-			onSuccess(data: any) {
-				const buildError = data?.message?.build_error
-				if (buildError) {
-					showBuildErrorToast(buildError)
-				} else {
-					toast.success("App build generated")
-				}
-			},
-			onError(error: any) {
-				toast.warning("Skipped app build due to errors", {
-					description: error?.messages?.join(", "),
-					duration: Infinity,
-				})
-			},
-		})
+	async function generateAppBuild(): Promise<{ error_log: string } | null> {
+		if (!activeApp.value) return null
+		try {
+			const data: any = await studioApps.runDocMethod.submit({
+				name: activeApp.value.name,
+				method: "generate_app_build",
+			})
+			const buildError = data?.message?.build_error
+			if (!buildError) {
+				toast.success("App build generated")
+			}
+			return buildError ?? null
+		} catch (error: any) {
+			toast.warning("Skipped app build due to errors", {
+				description: error?.messages?.join(", "),
+				duration: Infinity,
+			})
+			return null
+		}
 	}
 
-	function showBuildErrorToast(buildError: { error_log: string }, title: string = "App build failed") {
-		toast.warning(title, {
-			duration: Infinity,
-			action: {
-				label: "View Error Log",
-				onClick: () => window.open(`/app/error-log/${buildError.error_log}`, "_blank"),
-			},
+	function showBuildErrorDialog(buildError: { error_log: string }, message: string) {
+		dialog.confirm({
+			title: "App build failed",
+			message: `${message} Check the error log for the full build output.`,
+			theme: "yellow",
+			actions: [
+				{
+					label: "View Page",
+					variant: "outline",
+					onClick: () => {
+						if (activeApp.value && activePage.value) {
+							openPageInBrowser(activeApp.value, activePage.value)
+						}
+					},
+				},
+				{
+					label: "View Error Log",
+					variant: "solid",
+					onClick: () => {
+						window.open(`/app/error-log/${buildError.error_log}`, "_blank")
+					},
+				},
+			],
 		})
 	}
 

--- a/studio/ai/agent/tools/files.py
+++ b/studio/ai/agent/tools/files.py
@@ -89,7 +89,7 @@ def run_trigger_app_build(ctx, args: dict) -> str:
 	if isinstance(ref, str):
 		return ref
 	_, studio_app = ref
-	frappe.enqueue_doc("Studio App", studio_app, "generate_app_build", queue="long", timeout=1200)
+	frappe.enqueue_doc("Studio App", studio_app, "build_app_bundle", queue="long", timeout=1200)
 	return (
 		"Started an app rebuild. The file changes appear in the running app only after it finishes — "
 		"tell the user to wait for the build to complete."

--- a/studio/ai/agent/tools/scripts.py
+++ b/studio/ai/agent/tools/scripts.py
@@ -98,7 +98,7 @@ def _write_file_script(ctx, page, source: str) -> str:
 	folder = page.get_folder_path()
 	frappe.create_folder(folder)
 	write_code_file(page, folder, code_field="script", extension="ts", filename=page.get_export_docname())
-	frappe.enqueue_doc("Studio App", page.studio_app, "generate_app_build", queue="long", timeout=1200)
+	frappe.enqueue_doc("Studio App", page.studio_app, "build_app_bundle", queue="long", timeout=1200)
 	return (
 		"Wrote the page script to its code file and started an app rebuild. The change appears on the "
 		"canvas only after the build finishes — tell the user to wait for the rebuild to complete."

--- a/studio/build.py
+++ b/studio/build.py
@@ -3,15 +3,25 @@
 import json
 import os
 import re
+import subprocess
 import traceback
 
 import click
 import frappe
 from frappe.build import get_node_env
-from frappe.commands import popen
 from frappe.utils import get_files_path
 
 from studio.constants import DEFAULT_COMPONENTS, NON_VUE_COMPONENTS
+
+ANSI_ESCAPE_REGEX = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+class StudioAppBuildError(RuntimeError):
+	"""Build failure carrying the full build output on `output`."""
+
+	def __init__(self, message: str, output: str):
+		super().__init__(message)
+		self.output = output
 
 
 class StudioAppBuilder:
@@ -104,7 +114,23 @@ class StudioAppBuilder:
 			command += f" --page-scripts '{page_scripts_json}'"
 
 		studio_app_path = frappe.get_app_source_path("studio")
-		popen(command, cwd=studio_app_path, env=get_node_env(), raise_err=True)
+		result = subprocess.run(
+			command,
+			cwd=studio_app_path,
+			env={**os.environ, **get_node_env()},
+			shell=True,
+			capture_output=True,
+			text=True,
+		)
+		if result.stdout:
+			click.echo(result.stdout)
+		if result.stderr:
+			click.echo(result.stderr, err=True)
+		if result.returncode:
+			output = ANSI_ESCAPE_REGEX.sub("", f"{result.stdout or ''}\n{result.stderr or ''}")
+			raise StudioAppBuildError(
+				f"build failed for app '{self.app_name}' (exit status {result.returncode})", output
+			)
 
 	def get_app_components(self) -> set[str]:
 		pages = frappe.get_all(

--- a/studio/commands/__init__.py
+++ b/studio/commands/__init__.py
@@ -17,7 +17,13 @@ def build_studio_app(context, app_name: str, site: str | None = None):
 	frappe.init(site)
 	frappe.connect()
 	app = frappe.get_doc("Studio App", app_name)
-	app.generate_app_build()
+	result = app.generate_app_build()
+	if build_error := result.get("build_error"):
+		click.secho(
+			f"Build failed for '{app_name}' — see the output above (Error Log: {build_error['error_log']})",
+			fg="red",
+		)
+		raise SystemExit(1)
 	print(f"Studio App '{app_name}' built successfully.")
 
 

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -164,7 +164,9 @@ class StudioApp(WebsiteGenerator):
 		delete_folder(old_path)
 
 	@frappe.whitelist()
-	def generate_app_build(self):
+	def generate_app_build(self) -> dict:
+		"""Build the app bundle. Failures are logged to an Error Log and returned as
+		`build_error` instead of raised, so callers can surface them in the UI."""
 		if not frappe.has_permission("Studio App", ptype="write"):
 			frappe.throw(_("You do not have permission to generate the app build"), frappe.PermissionError)
 
@@ -174,8 +176,16 @@ class StudioApp(WebsiteGenerator):
 			StudioAppBuilder(
 				studio_app=self.name, is_standard=self.is_standard, frappe_app=self.frappe_app
 			).build()
+			return {"build_error": None}
 		except Exception as e:
-			raise Exception(f"Build process failed: {str(e)}")
+			return {"build_error": self._log_build_failure(e)}
+
+	def _log_build_failure(self, exception: Exception) -> dict:
+		error_log = frappe.log_error(
+			title=f"Studio app build failed: {self.name}",
+			message=getattr(exception, "output", None) or frappe.get_traceback(),
+		)
+		return {"error_log": error_log.name}
 
 	@frappe.whitelist()
 	def publish_app(self):
@@ -184,12 +194,7 @@ class StudioApp(WebsiteGenerator):
 			page_doc = frappe.get_doc("Studio Page", page)
 			page_doc.publish()
 
-		try:
-			self.generate_app_build()
-		except Exception:
-			pass
-
-		return {"published_pages": len(pages)}
+		return {"published_pages": len(pages), **self.generate_app_build()}
 
 	@frappe.whitelist()
 	def unpublish_app(self):

--- a/studio/studio/doctype/studio_app/studio_app.py
+++ b/studio/studio/doctype/studio_app/studio_app.py
@@ -170,15 +170,20 @@ class StudioApp(WebsiteGenerator):
 		if not frappe.has_permission("Studio App", ptype="write"):
 			frappe.throw(_("You do not have permission to generate the app build"), frappe.PermissionError)
 
-		from studio.build import StudioAppBuilder
-
 		try:
-			StudioAppBuilder(
-				studio_app=self.name, is_standard=self.is_standard, frappe_app=self.frappe_app
-			).build()
+			self.build_app_bundle()
 			return {"build_error": None}
 		except Exception as e:
 			return {"build_error": self._log_build_failure(e)}
+
+	def build_app_bundle(self):
+		"""Build the app bundle, raising on failure — background jobs enqueue this
+		so a failed build marks the job as failed instead of looking successful."""
+		from studio.build import StudioAppBuilder
+
+		StudioAppBuilder(
+			studio_app=self.name, is_standard=self.is_standard, frappe_app=self.frappe_app
+		).build()
 
 	def _log_build_failure(self, exception: Exception) -> dict:
 		error_log = frappe.log_error(


### PR DESCRIPTION
So that such errors don't go unnoticed: https://github.com/frappe/studio/pull/251

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/0eb67895-c8d2-4372-a0ba-f2685e877169" />

<img width="2484" height="1708" alt="image" src="https://github.com/user-attachments/assets/8004c018-4d95-43ab-bdd5-fec61de6673e" />
