### PR TITLE
fix: scope shared-dep resolver to the frontend dir so the linked frappe-ui checkout can't pull its own @tiptap

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -77,7 +77,8 @@ export default defineConfig(async () => {
 			}),
 			...frameworkUIPlugins,
 			studioRootAlias(),
-			sharedDependencyResolver(path.resolve(__dirname, "..")),
+			// Root must be the frontend dir
+			sharedDependencyResolver(path.resolve(__dirname)),
 			studioFolderWatcher(appsDir),
 		],
 		resolve: {


### PR DESCRIPTION
With the resolver root at apps/studio, the local frappe-ui checkout counted as 'inside Studio', so its `@tiptap` imports resolved from frappe-ui/node_modules while studio's own resolved from frontend/node_modules. The dep optimizer then bundled two prosemirror graphs (view 1.41.8 + 1.42.2), and every TextEditor mixed an EditorView from one copy with extension decorations from the other — crashing intermittently on mount.