### PR TITLE
fix: saving a Studio Component breaks

### DIFF
--- a/studio/studio/doctype/studio_component/studio_component.py
+++ b/studio/studio/doctype/studio_component/studio_component.py
@@ -39,7 +39,7 @@ class StudioComponent(Document):
 	def before_export(self, doc):
 		doc.block = parse_json(doc.block)
 
-	def validate(self):
+	def before_validate(self):
 		if isinstance(self.block, dict):
 			self.block = frappe.as_json(self.block, indent=None)
 

--- a/studio/studio/doctype/studio_component/studio_component.py
+++ b/studio/studio/doctype/studio_component/studio_component.py
@@ -39,6 +39,10 @@ class StudioComponent(Document):
 	def before_export(self, doc):
 		doc.block = parse_json(doc.block)
 
+	def validate(self):
+		if isinstance(self.block, dict):
+			self.block = frappe.as_json(self.block, indent=None)
+
 	def on_update(self):
 		publish_doc_change("Studio Component", self.name)
 

--- a/studio/studio/doctype/studio_component/test_studio_component.py
+++ b/studio/studio/doctype/studio_component/test_studio_component.py
@@ -1,20 +1,18 @@
 # Copyright (c) 2025, Frappe Technologies Pvt Ltd and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
-
-class IntegrationTestStudioComponent(IntegrationTestCase):
-	"""
-	Integration tests for StudioComponent.
-	Use this class for testing interactions between multiple components.
-	"""
-
-	pass
+class TestStudioComponent(IntegrationTestCase):
+	def test_block_round_trip(self):
+		block = {"componentName": "div", "children": [{"componentName": "span"}]}
+		component = frappe.get_doc(
+			doctype="Studio Component",
+			component_name="Round trip " + frappe.generate_hash(length=10),
+			block=block,
+		).insert()
+		component.reload()
+		self.assertEqual(component.block, frappe.as_json(block, indent=None))
+		self.assertEqual(frappe.parse_json(component.block), block)

--- a/studio/studio/doctype/studio_page/studio_page.py
+++ b/studio/studio/doctype/studio_page/studio_page.py
@@ -59,10 +59,6 @@ class StudioPage(Document):
 			self.name = f"page-{frappe.generate_hash(length=8)}"
 
 	def before_insert(self):
-		if isinstance(self.blocks, list):
-			self.blocks = frappe.as_json(self.blocks, indent=None)
-		if isinstance(self.draft_blocks, list):
-			self.draft_blocks = frappe.as_json(self.draft_blocks, indent=None)
 		if not self.blocks:
 			self.blocks = "[]"
 		if not self.page_title:
@@ -84,6 +80,10 @@ class StudioPage(Document):
 			frappe.db.set_value("Studio App", self.studio_app, "app_home", self.name)
 
 	def before_validate(self):
+		if isinstance(self.blocks, list):
+			self.blocks = frappe.as_json(self.blocks, indent=None)
+		if isinstance(self.draft_blocks, list):
+			self.draft_blocks = frappe.as_json(self.draft_blocks, indent=None)
 		# vue router needs a leading slash
 		if not self.route.startswith("/"):
 			self.route = f"/{self.route}"

--- a/studio/studio/doctype/studio_page/test_studio_page.py
+++ b/studio/studio/doctype/studio_page/test_studio_page.py
@@ -23,6 +23,19 @@ def component_ref(component) -> dict:
 	return {"componentName": component.name, "isStudioComponent": True, "children": []}
 
 
+class TestStudioPage(IntegrationTestCase):
+	def test_block_lists_round_trip(self):
+		app = make_studio_app(app_name="serialization-" + frappe.generate_hash(length=10))
+		blocks = [{"componentName": "div", "children": [{"componentName": "span"}]}]
+		page = frappe.get_doc(
+			doctype="Studio Page", studio_app=app.name, blocks=blocks, draft_blocks=blocks
+		).insert()
+		page.reload()
+		self.assertEqual(page.blocks, frappe.as_json(blocks, indent=None))
+		self.assertEqual(frappe.parse_json(page.blocks), blocks)
+		self.assertEqual(frappe.parse_json(page.draft_blocks), blocks)
+
+
 class TestGuestRendering(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):


### PR DESCRIPTION
Serialize block field in Studio Component before saving
Regression after https://github.com/frappe/studio/commit/01be9a03109987f4827e980820a5363d88d8fa0d

Closes: https://github.com/frappe/studio/issues/259, https://github.com/frappe/studio/issues/258